### PR TITLE
fix(security): contain external resource boundaries

### DIFF
--- a/src/agilab/agent_runtime/agent_run.py
+++ b/src/agilab/agent_runtime/agent_run.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -15,12 +13,17 @@ import subprocess
 import sys
 import tempfile
 import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 from uuid import uuid4
 
 from agilab.agent_runtime.agent_config import load_agent_config, resolve_agent_provider
-from agilab.agent_runtime.agent_tool_safety import evaluate_tool_permission, normalize_permission_level
+from agilab.agent_runtime.agent_tool_safety import (
+    evaluate_tool_permission,
+    normalize_permission_level,
+)
 from agilab.agent_runtime.agent_trace import (
     AgentTraceStore,
     load_trace_events,
@@ -28,7 +31,6 @@ from agilab.agent_runtime.agent_trace import (
     validate_event_sequence,
 )
 from agilab.security.secret_uri import redact_text
-
 
 TRACE_KIND = "agilab.agent_run.v1"
 MANIFEST_FILENAME = "agent_run_manifest.json"
@@ -1644,7 +1646,7 @@ def agent_handoff_payload(manifest_or_path: dict[str, object] | Path | str) -> d
     permission_map = permission if isinstance(permission, dict) else {}
     trace_events: list[dict[str, object]] = []
     if summary.trace_events_path:
-        for event in load_trace_events(summary.trace_events_path.parent):
+        for event in load_trace_events(summary.trace_events_path):
             trace_events.append(
                 {
                     "sequence": event.sequence,
@@ -1863,10 +1865,12 @@ def agent_context_payload(
     protocol_adapters: Sequence[str] = (),
     capabilities: Sequence[str] = (),
     limit: int = 20,
+    _summaries: Sequence[AgentRunSummary] | None = None,
+    _latest_manifest: dict[str, object] | Path | str | None = None,
 ) -> dict[str, object]:
     """Build a safe context pack from matching agent-run evidence."""
 
-    summaries = list_agent_runs(
+    summaries = list(_summaries) if _summaries is not None else list_agent_runs(
         root,
         agent=agent,
         status=status,
@@ -1883,9 +1887,10 @@ def agent_context_payload(
     latest_handoff: dict[str, object] | None = None
     latest_next_actions: dict[str, object] | None = None
     if summaries and str(summaries[0].manifest_path):
+        latest_source = _latest_manifest or summaries[0].manifest_path
         try:
-            latest_handoff = agent_handoff_payload(summaries[0].manifest_path)
-            latest_next_actions = agent_next_actions_payload(summaries[0].manifest_path)
+            latest_handoff = agent_handoff_payload(latest_source)
+            latest_next_actions = agent_next_actions_payload(latest_source)
         except (OSError, json.JSONDecodeError, ValueError):
             latest_handoff = None
             latest_next_actions = None
@@ -1959,10 +1964,11 @@ def agent_lineage_payload(
     root: Path | str | None = None,
     *,
     run_id: str,
+    _summaries: Sequence[AgentRunSummary] | None = None,
 ) -> dict[str, object]:
     """Build a follow-up lineage graph from agent-run metadata."""
 
-    summaries = list_agent_runs(root, limit=None)
+    summaries = list(_summaries) if _summaries is not None else list_agent_runs(root, limit=None)
     by_run_id = {summary.run_id: summary for summary in summaries if summary.run_id}
     children_by_parent: dict[str, list[AgentRunSummary]] = {}
     parent_by_child: dict[str, str] = {}
@@ -2086,7 +2092,7 @@ def _trace_event_count(summary: AgentRunSummary) -> int:
     if not summary.trace_events_path:
         return 0
     try:
-        return len(load_trace_events(summary.trace_events_path.parent))
+        return len(load_trace_events(summary.trace_events_path))
     except OSError:
         return 0
 
@@ -2292,7 +2298,7 @@ def validate_agent_run(manifest_or_path: dict[str, object] | Path | str) -> dict
     if summary.trace_events_path:
         if summary.trace_events_path.exists():
             try:
-                trace_events = load_trace_events(summary.trace_events_path.parent)
+                trace_events = load_trace_events(summary.trace_events_path)
             except (OSError, TypeError, ValueError) as exc:
                 if not terminal_trace_unavailable:
                     fail("trace_events_invalid", str(exc))

--- a/src/agilab/bridge_cli.py
+++ b/src/agilab/bridge_cli.py
@@ -7,7 +7,6 @@ import csv
 import hashlib
 import json
 import platform
-from pathlib import Path
 import re
 import shlex
 import shutil
@@ -15,6 +14,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 from agilab import run_manifest
@@ -493,6 +493,31 @@ def export_quarto_report(
     which: Callable[[str], str | None] = shutil.which,
 ) -> dict[str, Any]:
     manifest, manifest_payload, resolved_manifest = _load_run_manifest(manifest_path)
+    return _export_quarto_report_loaded(
+        manifest,
+        manifest_payload,
+        resolved_manifest,
+        output_path,
+        render=render,
+        quarto_bin=quarto_bin,
+        runner=runner,
+        which=which,
+    )
+
+
+def _export_quarto_report_loaded(
+    manifest: run_manifest.RunManifest,
+    manifest_payload: Mapping[str, Any],
+    resolved_manifest: Path,
+    output_path: Path,
+    *,
+    render: bool = False,
+    quarto_bin: str = "quarto",
+    runner: Runner = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> dict[str, Any]:
+    """Export an already validated manifest without reopening its source path."""
+
     output = output_path.expanduser().resolve(strict=False)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(

--- a/src/agilab/ci/ci_provider_artifacts.py
+++ b/src/agilab/ci/ci_provider_artifacts.py
@@ -9,13 +9,12 @@ import hashlib
 import ipaddress
 import json
 import os
-from collections.abc import Callable, Mapping, Sequence
-from pathlib import Path
 import re
 import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
 from typing import Any
-from urllib import parse
-from urllib import request
+from urllib import parse, request
 from zipfile import ZipFile
 
 from agilab.ci.ci_artifact_harvest import (
@@ -23,7 +22,6 @@ from agilab.ci.ci_artifact_harvest import (
     REQUIRED_ARTIFACT_KINDS,
     sample_ci_artifacts,
 )
-
 
 SCHEMA = "agilab.ci_provider_artifact_index.v1"
 PROVIDER = "github_actions"
@@ -268,11 +266,17 @@ def _github_artifact_download_request(url: str, token: str | None) -> request.Re
     return req
 
 
-def _gitlab_headers(token: str | None) -> dict[str, str]:
-    headers = {"User-Agent": DEFAULT_USER_AGENT}
+def _gitlab_headers() -> dict[str, str]:
+    return {"User-Agent": DEFAULT_USER_AGENT}
+
+
+def _gitlab_request(url: str, token: str | None) -> request.Request:
+    """Authenticate the initial GitLab request without forwarding auth on redirects."""
+
+    req = request.Request(url, headers=_gitlab_headers())
     if token:
-        headers["PRIVATE-TOKEN"] = token
-    return headers
+        req.add_unredirected_header("PRIVATE-TOKEN", token)
+    return req
 
 
 def _normalize_gitlab_host(value: str) -> str:
@@ -368,7 +372,7 @@ def _read_json_url(url: str, *, token: str | None, urlopen: UrlOpen) -> dict[str
 
 
 def _read_gitlab_json_url(url: str, *, token: str | None, urlopen: UrlOpen) -> list[Any]:
-    req = request.Request(url, headers=_gitlab_headers(token))
+    req = _gitlab_request(url, token)
     with urlopen(req) as response:
         payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, list):
@@ -504,7 +508,7 @@ def download_gitlab_ci_artifacts(
         name = _safe_id(str(artifact.get("name", "") or "job"))
         target = destination / f"{name}-{job_id}-{_safe_id(filename)}.zip"
         url = f"{base_url}/api/v4/projects/{encoded_project}/jobs/{job_id}/artifacts"
-        req = request.Request(url, headers=_gitlab_headers(token))
+        req = _gitlab_request(url, token)
         with urlopen(req) as response:
             target.write_bytes(response.read())
         paths.append(target)

--- a/src/agilab/install_apps.ps1
+++ b/src/agilab/install_apps.ps1
@@ -53,6 +53,15 @@ function Set-UvLinkMode {
 
 Set-UvLinkMode
 
+function Invoke-AppsRepositoryPolicy {
+    param([Parameter(Mandatory=$true)][string]$Repository)
+    $policyScript = Join-Path $PSScriptRoot "security/apps_repository_policy.py"
+    & uv --preview-features extra-build-dependencies run --no-project --no-config python -I $policyScript --repository $Repository
+    if ($LASTEXITCODE -ne 0) {
+        throw "APPS_REPOSITORY trust validation failed."
+    }
+}
+
 function Import-DotEnv {
     param([string]$Path)
     if (-not (Test-Path -LiteralPath $Path)) { return }
@@ -490,6 +499,7 @@ $AGILAB_REPOSITORY    = Fix-WindowsDrivePath $AGILAB_REPOSITORY
 $APPS_REPOSITORY  = Fix-WindowsDrivePath $APPS_REPOSITORY
 
 if (-not [string]::IsNullOrEmpty($APPS_REPOSITORY)) {
+  Invoke-AppsRepositoryPolicy -Repository $APPS_REPOSITORY
   $RepoRoot = Resolve-PhysicalPath $APPS_REPOSITORY
   if (-not $RepoRoot) { $RepoRoot = $APPS_REPOSITORY }
   Write-Color BLUE ("Using repository root: {0}" -f $RepoRoot)

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -2,6 +2,9 @@
 set -e
 set -o pipefail
 
+readonly AGILAB_INSTALL_APPS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly AGILAB_APPS_REPOSITORY_POLICY_SCRIPT="${AGILAB_INSTALL_APPS_SCRIPT_DIR}/security/apps_repository_policy.py"
+
 # --- Ensure arrays exist (avoids 'unbound variable' with set -u) -------------
 # We declare them empty up front; later code can append or overwrite freely.
 # This prevents errors like: ${REPOSITORY_PAGES[@]}: unbound variable
@@ -403,94 +406,11 @@ set_install_apps_selection_from_cli() {
   esac
 }
 
-is_truthy() {
-  local raw
-  raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
-  case "$raw" in
-    1|true|yes|on|enabled) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-apps_repository_in_allowlist() {
-  local repo="$1"
-  local physical_repo="$2"
-  local raw_allowlist="${AGILAB_APPS_REPOSITORY_ALLOWLIST:-}"
-  local -a entries=()
-  local entry physical_entry
-
-  [[ -n "${raw_allowlist//[[:space:],;]/}" ]] || return 1
-  parse_list_to_array entries "$raw_allowlist"
-  for entry in "${entries[@]}"; do
-    [[ -z "$entry" ]] && continue
-    if [[ "$entry" == "$repo" || "$entry" == "$physical_repo" ]]; then
-      return 0
-    fi
-    if [[ -e "$entry" ]]; then
-      physical_entry="$(resolve_physical_dir "$entry" 2>/dev/null || true)"
-      if [[ -n "$physical_entry" && "$physical_entry" == "$physical_repo" ]]; then
-        return 0
-      fi
-    fi
-  done
-  return 1
-}
-
 validate_apps_repository_policy() {
   local repo="$1"
-  local physical_repo=""
-  local strict=0
-  local allow_floating=0
-  local head_ref=""
-  local tag_ref=""
 
   [[ -n "$repo" ]] || return 0
-  physical_repo="$(resolve_physical_dir "$repo" 2>/dev/null || printf '%s' "$repo")"
-  if is_truthy "${AGILAB_STRICT_APPS_REPOSITORY:-}" || is_truthy "${AGILAB_SHARED_MODE:-}"; then
-    strict=1
-  fi
-  if is_truthy "${AGILAB_ALLOW_FLOATING_APPS_REPOSITORY:-}" || is_truthy "${AGILAB_DEV_APPS_REPOSITORY:-}"; then
-    allow_floating=1
-  fi
-
-  if (( strict )); then
-    if [[ -z "${AGILAB_APPS_REPOSITORY_ALLOWLIST:-}" ]]; then
-      echo -e "${RED}Error:${NC} Strict APPS_REPOSITORY mode requires AGILAB_APPS_REPOSITORY_ALLOWLIST." >&2
-      exit 1
-    fi
-    if ! apps_repository_in_allowlist "$repo" "$physical_repo"; then
-      echo -e "${RED}Error:${NC} APPS_REPOSITORY is not in AGILAB_APPS_REPOSITORY_ALLOWLIST: $repo" >&2
-      exit 1
-    fi
-  elif [[ -n "${AGILAB_APPS_REPOSITORY_ALLOWLIST:-}" ]] && ! apps_repository_in_allowlist "$repo" "$physical_repo"; then
-    echo -e "${YELLOW}Warning:${NC} APPS_REPOSITORY is not in AGILAB_APPS_REPOSITORY_ALLOWLIST: $repo" >&2
-  fi
-
-  if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    if (( strict )); then
-      echo -e "${RED}Error:${NC} Strict APPS_REPOSITORY mode requires a Git checkout pinned to a commit SHA or immutable tag." >&2
-      exit 1
-    fi
-    echo -e "${YELLOW}Warning:${NC} APPS_REPOSITORY is not a Git checkout; review it before shared use." >&2
-    return 0
-  fi
-
-  head_ref="$(git -C "$repo" symbolic-ref -q --short HEAD 2>/dev/null || true)"
-  if [[ -n "$head_ref" ]]; then
-    if (( strict && ! allow_floating )); then
-      echo -e "${RED}Error:${NC} APPS_REPOSITORY is on floating branch '$head_ref'. Checkout a reviewed commit SHA or immutable tag, or set AGILAB_DEV_APPS_REPOSITORY=1 for an explicit dev install." >&2
-      exit 1
-    fi
-    echo -e "${YELLOW}Warning:${NC} APPS_REPOSITORY is on floating branch '$head_ref'; pin to a reviewed commit or immutable tag before shared use." >&2
-    return 0
-  fi
-
-  tag_ref="$(git -C "$repo" describe --exact-match --tags HEAD 2>/dev/null || true)"
-  if [[ -n "$tag_ref" ]]; then
-    echo -e "${BLUE}APPS_REPOSITORY pinned to tag:${NC} $tag_ref"
-  else
-    echo -e "${BLUE}APPS_REPOSITORY pinned to detached commit:${NC} $(git -C "$repo" rev-parse --short HEAD 2>/dev/null || true)"
-  fi
+  "${UV_PREVIEW[@]}" run --no-project --no-config python -I "$AGILAB_APPS_REPOSITORY_POLICY_SCRIPT" --repository "$repo"
 }
 
 # Detect whether an application's data directory is reachable. Returns:

--- a/src/agilab/security/apps_repository_policy.py
+++ b/src/agilab/security/apps_repository_policy.py
@@ -1,0 +1,410 @@
+"""Shared trust policy for executable external AGILAB app repositories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+APPS_ALLOWLIST_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST"
+APPS_ALLOWLIST_FILE_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST_FILE"
+HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class AppsRepositoryPolicyResult:
+    """One deterministic decision shared by installers and security checks."""
+
+    status: str
+    summary: str
+    remediation: str
+    details: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _resolve_path(raw_path: str | None, *, cwd: Path) -> Path | None:
+    value = str(raw_path or "").strip().strip("'\"")
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve(strict=False)
+
+
+def _resolve_git_dir(repo: Path) -> Path | None:
+    dot_git = repo / ".git"
+    if dot_git.is_dir():
+        return dot_git
+    if dot_git.is_file():
+        text = dot_git.read_text(encoding="utf-8", errors="ignore").strip()
+        if text.startswith("gitdir:"):
+            git_dir = Path(text.split(":", 1)[1].strip()).expanduser()
+            if not git_dir.is_absolute():
+                git_dir = dot_git.parent / git_dir
+            return git_dir.resolve(strict=False)
+    return None
+
+
+def _git_common_dir(git_dir: Path) -> Path:
+    common_file = git_dir / "commondir"
+    if not common_file.is_file():
+        return git_dir
+    raw = common_file.read_text(encoding="utf-8", errors="ignore").strip()
+    common = Path(raw).expanduser()
+    if not common.is_absolute():
+        common = git_dir / common
+    return common.resolve(strict=False)
+
+
+def _git_config_value(repo: Path, section: str, key: str) -> str | None:
+    """Read a simple Git config value, including linked-worktree configs."""
+
+    git_dir = _resolve_git_dir(repo)
+    if git_dir is None:
+        return None
+    config_path = _git_common_dir(git_dir) / "config"
+    if not config_path.is_file():
+        return None
+    current_section: str | None = None
+    for raw_line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current_section = line[1:-1].strip()
+            continue
+        if current_section != section or "=" not in line:
+            continue
+        raw_key, raw_value = line.split("=", 1)
+        if raw_key.strip() == key:
+            return raw_value.strip()
+    return None
+
+
+def _git_origin_url(repo: Path) -> str | None:
+    return _git_config_value(repo, 'remote "origin"', "url")
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+    git_env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    git_env.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    try:
+        return subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.untrackedCache=false",
+                "-C",
+                str(repo),
+                *args,
+            ],
+            check=False,
+            capture_output=True,
+            env=git_env,
+            text=True,
+        )
+    except OSError:
+        return None
+
+
+def _verified_git_state(repo: Path) -> tuple[dict[str, Any], str | None]:
+    probe = _run_git(repo, "rev-parse", "--is-inside-work-tree")
+    if probe is None or probe.returncode != 0 or probe.stdout.strip() != "true":
+        return {"is_git_checkout": False, "git_verified": False}, None
+    branch = _run_git(repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+    head = _run_git(repo, "rev-parse", "--verify", "HEAD^{commit}")
+    origin = _run_git(repo, "config", "--local", "--get", "remote.origin.url")
+    worktree = _run_git(
+        repo,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--ignored=matching",
+    )
+    origin_url = (
+        origin.stdout.strip()
+        if origin is not None and origin.returncode == 0 and origin.stdout.strip()
+        else None
+    )
+    worktree_clean = bool(
+        worktree is not None
+        and worktree.returncode == 0
+        and not worktree.stdout.strip()
+    )
+    if head is None or head.returncode != 0 or not HEX_SHA_RE.match(head.stdout.strip()):
+        return (
+            {
+                "is_git_checkout": True,
+                "git_verified": True,
+                "head_state": "unknown",
+                "worktree_clean": worktree_clean,
+            },
+            origin_url,
+        )
+    if branch is not None and branch.returncode == 0 and branch.stdout.strip():
+        return (
+            {
+                "is_git_checkout": True,
+                "git_verified": True,
+                "head_state": "branch",
+                "name": branch.stdout.strip(),
+                "worktree_clean": worktree_clean,
+            },
+            origin_url,
+        )
+    return (
+        {
+            "is_git_checkout": True,
+            "git_verified": True,
+            "head_state": "detached",
+            "commit": head.stdout.strip(),
+            "worktree_clean": worktree_clean,
+        },
+        origin_url,
+    )
+
+
+def _redact_url(value: str | None) -> str | None:
+    if not value:
+        return value
+    return re.sub(r"(https?://)[^/@:\s]+(:[^/@\s]+)?@", r"\1<redacted>@", value)
+
+
+def _split_allowlist(value: str) -> list[str]:
+    return [item.strip() for item in re.split(r"[\n,;]", value) if item.strip()]
+
+
+def apps_repository_allowlist(config: Mapping[str, str], *, cwd: Path) -> list[str]:
+    """Return exact reviewed origin URLs from the env and optional file."""
+
+    allowlist = _split_allowlist(str(config.get(APPS_ALLOWLIST_ENV) or ""))
+    file_path = _resolve_path(config.get(APPS_ALLOWLIST_FILE_ENV), cwd=cwd)
+    if file_path and file_path.is_file():
+        for raw_line in file_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = raw_line.strip()
+            if line and not line.startswith("#"):
+                allowlist.extend(_split_allowlist(line))
+    return sorted(set(allowlist))
+
+
+def _git_head_state(repo: Path) -> dict[str, Any]:
+    git_dir = _resolve_git_dir(repo)
+    if git_dir is None:
+        return {"is_git_checkout": False}
+    head_path = git_dir / "HEAD"
+    if not head_path.is_file():
+        return {"is_git_checkout": True, "head_state": "unknown"}
+    head = head_path.read_text(encoding="utf-8", errors="ignore").strip()
+    if head.startswith("ref:"):
+        ref = head.split(":", 1)[1].strip()
+        short = ref.removeprefix("refs/heads/").removeprefix("refs/tags/")
+        return {
+            "is_git_checkout": True,
+            "head_state": "branch" if ref.startswith("refs/heads/") else "ref",
+            "ref": ref,
+            "name": short,
+        }
+    if HEX_SHA_RE.match(head):
+        return {"is_git_checkout": True, "head_state": "detached", "commit": head}
+    return {"is_git_checkout": True, "head_state": "unknown", "head": head[:64]}
+
+
+def evaluate_apps_repository_policy(
+    config: Mapping[str, str],
+    *,
+    cwd: Path,
+    strict: bool | None = None,
+    allow_floating: bool | None = None,
+) -> AppsRepositoryPolicyResult:
+    """Evaluate one repository using the same policy on every installer surface."""
+
+    path = _resolve_path(config.get("APPS_REPOSITORY"), cwd=cwd)
+    if strict is None:
+        strict = _truthy(config.get("AGILAB_STRICT_APPS_REPOSITORY")) or _truthy(
+            config.get("AGILAB_SHARED_MODE")
+        )
+    if allow_floating is None:
+        allow_floating = _truthy(config.get("AGILAB_ALLOW_FLOATING_APPS_REPOSITORY")) or _truthy(
+            config.get("AGILAB_DEV_APPS_REPOSITORY")
+        )
+    allowlist = apps_repository_allowlist(config, cwd=cwd)
+    base_details: dict[str, Any] = {
+        "path": str(path) if path else None,
+        "strict": strict,
+        "allow_floating": allow_floating,
+        "allowlist_configured": bool(allowlist),
+        "allowlist_size": len(allowlist),
+    }
+    if path is None:
+        return AppsRepositoryPolicyResult(
+            "pass",
+            "APPS_REPOSITORY is not configured.",
+            "No action required unless you install external apps.",
+            base_details,
+        )
+    if not path.exists():
+        return AppsRepositoryPolicyResult(
+            "fail" if strict else "warn",
+            "APPS_REPOSITORY points to a missing path.",
+            "Point APPS_REPOSITORY to an allowlisted reviewed checkout pinned to an immutable revision.",
+            base_details,
+        )
+    if not path.is_dir():
+        return AppsRepositoryPolicyResult(
+            "fail" if strict else "warn",
+            "APPS_REPOSITORY is not a directory.",
+            "Use a reviewed Git checkout directory for external apps.",
+            base_details,
+        )
+
+    git_state, origin_url = _verified_git_state(path)
+    details = {**base_details, **git_state}
+    if not git_state.get("is_git_checkout"):
+        return AppsRepositoryPolicyResult(
+            "fail" if strict else "warn",
+            "APPS_REPOSITORY is not a Git checkout.",
+            "Use an allowlisted Git checkout pinned to a commit SHA or immutable tag before shared use.",
+            details,
+        )
+
+    details["origin_url"] = _redact_url(origin_url)
+    if strict and not origin_url:
+        return AppsRepositoryPolicyResult(
+            "fail",
+            "APPS_REPOSITORY is pinned but has no origin URL to match against an allowlist.",
+            "Configure a reviewed origin URL before installing external apps in a shared environment.",
+            details,
+        )
+    if strict and not allowlist:
+        return AppsRepositoryPolicyResult(
+            "fail",
+            "Strict APPS_REPOSITORY mode requires an origin allowlist.",
+            (
+                f"Set {APPS_ALLOWLIST_ENV} or {APPS_ALLOWLIST_FILE_ENV} to the exact "
+                "reviewed repository origin URL."
+            ),
+            details,
+        )
+    if strict and origin_url not in allowlist:
+        return AppsRepositoryPolicyResult(
+            "fail",
+            "APPS_REPOSITORY origin is not in the configured allowlist.",
+            (
+                f"Add the exact reviewed origin URL to {APPS_ALLOWLIST_ENV} or "
+                f"{APPS_ALLOWLIST_FILE_ENV}, then rerun the gate."
+            ),
+            details,
+        )
+
+    if git_state.get("head_state") == "unknown":
+        return AppsRepositoryPolicyResult(
+            "fail" if strict else "warn",
+            "APPS_REPOSITORY does not resolve to a committed Git revision.",
+            "Checkout a reviewed commit SHA or immutable tag before installing external apps.",
+            details,
+        )
+
+    if not git_state.get("worktree_clean"):
+        if strict and not allow_floating:
+            return AppsRepositoryPolicyResult(
+                "fail",
+                "APPS_REPOSITORY contains unreviewed working-tree content (modified, untracked, or ignored).",
+                (
+                    "Restore a clean reviewed checkout, or use AGILAB_DEV_APPS_REPOSITORY=1 "
+                    "only for an explicit development install."
+                ),
+                details,
+            )
+        return AppsRepositoryPolicyResult(
+            "warn",
+            "APPS_REPOSITORY contains unreviewed working-tree content (modified, untracked, or ignored).",
+            "Restore a clean reviewed checkout before shared use.",
+            details,
+        )
+
+    if git_state.get("head_state") == "branch":
+        branch = str(git_state.get("name") or "")
+        if strict and not allow_floating:
+            return AppsRepositoryPolicyResult(
+                "fail",
+                f"APPS_REPOSITORY is on floating branch '{branch}'.",
+                (
+                    "Checkout a reviewed commit SHA or immutable tag, or set "
+                    "AGILAB_DEV_APPS_REPOSITORY=1 only for an explicit development install."
+                ),
+                details,
+            )
+        return AppsRepositoryPolicyResult(
+            "warn",
+            f"APPS_REPOSITORY is on floating branch '{branch}'.",
+            "Pin the checkout to a reviewed commit or immutable tag before shared use.",
+            details,
+        )
+
+    if allowlist and origin_url and origin_url not in allowlist:
+        return AppsRepositoryPolicyResult(
+            "warn",
+            "APPS_REPOSITORY origin is not in the configured allowlist.",
+            f"Add the exact reviewed origin URL to {APPS_ALLOWLIST_ENV} before shared use.",
+            details,
+        )
+    return AppsRepositoryPolicyResult(
+        "pass",
+        (
+            "APPS_REPOSITORY is pinned and allowlisted."
+            if strict
+            else "APPS_REPOSITORY is a Git checkout and is not on a floating branch."
+        ),
+        "Keep the referenced commit reviewed and scanned.",
+        details,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate an external AGILAB apps repository.")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    config = dict(os.environ)
+    config["APPS_REPOSITORY"] = args.repository
+    result = evaluate_apps_repository_policy(config, cwd=Path.cwd())
+    if args.json:
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        stream = sys.stderr if result.status == "fail" else sys.stdout
+        marker = {"pass": "OK", "warn": "Warning", "fail": "Error"}[result.status]
+        print(f"{marker}: {result.summary}", file=stream)
+        if result.status != "pass":
+            print(result.remediation, file=stream)
+    return 1 if result.status == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agilab/security/security_check.py
+++ b/src/agilab/security/security_check.py
@@ -3,23 +3,43 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import importlib.util
 import json
 import os
-from pathlib import Path
 import re
 import tomllib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from agilab.environment.env_file_utils import read_mutable_env_text
 
 try:
+    from agilab.security import apps_repository_policy as _apps_repository_policy
+except ImportError:  # pragma: no cover - supports direct script execution.
+    import apps_repository_policy as _apps_repository_policy  # type: ignore[no-redef]
+
+evaluate_apps_repository_policy = (
+    _apps_repository_policy.evaluate_apps_repository_policy
+)
+APPS_ALLOWLIST_ENV = _apps_repository_policy.APPS_ALLOWLIST_ENV
+APPS_ALLOWLIST_FILE_ENV = _apps_repository_policy.APPS_ALLOWLIST_FILE_ENV
+_apps_repository_allowlist = _apps_repository_policy.apps_repository_allowlist
+_git_config_value = _apps_repository_policy._git_config_value
+_git_head_state = _apps_repository_policy._git_head_state
+_git_origin_url = _apps_repository_policy._git_origin_url
+_redact_url = _apps_repository_policy._redact_url
+_resolve_git_dir = _apps_repository_policy._resolve_git_dir
+_split_allowlist = _apps_repository_policy._split_allowlist
+
+try:
     from .untrusted_content_boundary import build_external_source_boundary
 except ImportError:  # pragma: no cover - supports direct script execution.
     try:
-        from untrusted_content_boundary import build_external_source_boundary  # type: ignore[no-redef]
+        from untrusted_content_boundary import (
+            build_external_source_boundary,  # type: ignore[no-redef]
+        )
     except ImportError:
         _boundary_path = Path(__file__).resolve().parent / "untrusted_content_boundary.py"
         _boundary_spec = importlib.util.spec_from_file_location(
@@ -38,13 +58,10 @@ SCHEMA_VERSION = 1
 DEFAULT_ARTIFACT_MAX_AGE_DAYS = 30
 PROFILES = ("local", "shared", "cluster", "public-ui")
 SECRET_KEY_RE = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)", re.IGNORECASE)
-HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 LOCAL_HOSTS = {"", "127.0.0.1", "localhost", "::1"}
 EXPOSED_HOSTS = {"0.0.0.0", "::"}
 PUBLIC_BIND_OK_ENV = "AGILAB_PUBLIC_BIND_OK"
 PUBLIC_BIND_EVIDENCE_ENV = "AGILAB_PUBLIC_BIND_EVIDENCE"
-APPS_ALLOWLIST_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST"
-APPS_ALLOWLIST_FILE_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST_FILE"
 PLACEHOLDER_SECRET_VALUES = {
     "empty",
     "none",
@@ -125,191 +142,33 @@ def _resolve_path(raw_path: str | None, *, cwd: Path) -> Path | None:
     return path
 
 
-def _resolve_git_dir(repo: Path) -> Path | None:
-    dot_git = repo / ".git"
-    if dot_git.is_dir():
-        return dot_git
-    if dot_git.is_file():
-        text = dot_git.read_text(encoding="utf-8", errors="ignore").strip()
-        if text.startswith("gitdir:"):
-            git_dir = Path(text.split(":", 1)[1].strip()).expanduser()
-            if not git_dir.is_absolute():
-                git_dir = dot_git.parent / git_dir
-            return git_dir
-    return None
-
-
-def _git_config_value(repo: Path, section: str, key: str) -> str | None:
-    git_dir = _resolve_git_dir(repo)
-    if git_dir is None:
-        return None
-    config_path = git_dir / "config"
-    if not config_path.is_file():
-        return None
-    current_section: str | None = None
-    for raw_line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith(("#", ";")):
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            current_section = line[1:-1].strip()
-            continue
-        if current_section != section or "=" not in line:
-            continue
-        raw_key, raw_value = line.split("=", 1)
-        if raw_key.strip() == key:
-            return raw_value.strip()
-    return None
-
-
-def _git_origin_url(repo: Path) -> str | None:
-    return _git_config_value(repo, 'remote "origin"', "url")
-
-
-def _redact_url(value: str | None) -> str | None:
-    if not value:
-        return value
-    return re.sub(r"(https?://)[^/@:\s]+(:[^/@\s]+)?@", r"\1<redacted>@", value)
-
-
-def _split_allowlist(value: str) -> list[str]:
-    return [item.strip() for item in re.split(r"[\n,;]", value) if item.strip()]
-
-
-def _apps_repository_allowlist(config: Mapping[str, str], *, cwd: Path) -> list[str]:
-    allowlist = _split_allowlist(str(config.get(APPS_ALLOWLIST_ENV) or ""))
-    file_path = _resolve_path(config.get(APPS_ALLOWLIST_FILE_ENV), cwd=cwd)
-    if file_path and file_path.is_file():
-        for raw_line in file_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            line = raw_line.strip()
-            if line and not line.startswith("#"):
-                allowlist.extend(_split_allowlist(line))
-    return sorted(set(allowlist))
-
-
-def _git_head_state(repo: Path) -> dict[str, Any]:
-    git_dir = _resolve_git_dir(repo)
-    if git_dir is None:
-        return {"is_git_checkout": False}
-    head_path = git_dir / "HEAD"
-    if not head_path.is_file():
-        return {"is_git_checkout": True, "head_state": "unknown"}
-    head = head_path.read_text(encoding="utf-8", errors="ignore").strip()
-    if head.startswith("ref:"):
-        ref = head.split(":", 1)[1].strip()
-        short = ref.removeprefix("refs/heads/").removeprefix("refs/tags/")
-        return {
-            "is_git_checkout": True,
-            "head_state": "branch" if ref.startswith("refs/heads/") else "ref",
-            "ref": ref,
-            "name": short,
-        }
-    if HEX_SHA_RE.match(head):
-        return {"is_git_checkout": True, "head_state": "detached", "commit": head}
-    return {"is_git_checkout": True, "head_state": "unknown", "head": head[:64]}
-
-
 def _check_apps_repository(config: Mapping[str, str], *, cwd: Path, profile: str = "local") -> Check:
-    path = _resolve_path(config.get("APPS_REPOSITORY"), cwd=cwd)
-    if path is None:
-        return Check(
-            "apps_repository_pin",
-            "External apps repository pinning",
-            "pass",
-            "APPS_REPOSITORY is not configured.",
-            "No action required unless you install external apps.",
-            {},
-        )
-    if not path.exists():
-        return Check(
-            "apps_repository_pin",
-            "External apps repository pinning",
-            _status_for_profile(profile=profile),
-            "APPS_REPOSITORY points to a missing path.",
-            "Point APPS_REPOSITORY to an allowlisted reviewed checkout, pinned commit, or immutable tag.",
-            {"path": str(path)},
-        )
-    if not path.is_dir():
-        return Check(
-            "apps_repository_pin",
-            "External apps repository pinning",
-            _status_for_profile(profile=profile),
-            "APPS_REPOSITORY is not a directory.",
-            "Use a reviewed Git checkout directory for external apps.",
-            {"path": str(path)},
-        )
-    git_state = _git_head_state(path)
-    if not git_state.get("is_git_checkout"):
-        return Check(
-            "apps_repository_pin",
-            "External apps repository pinning",
-            _status_for_profile(profile=profile),
-            "APPS_REPOSITORY is not a Git checkout.",
-            "Use an allowlisted Git checkout pinned to a commit SHA or immutable tag before shared use.",
-            {"path": str(path), **git_state},
-        )
-    if git_state.get("head_state") == "branch":
-        return Check(
-            "apps_repository_pin",
-            "External apps repository pinning",
-            _status_for_profile(profile=profile),
-            "APPS_REPOSITORY is on a floating branch.",
-            "Checkout a reviewed commit SHA or immutable tag before installing external apps in shared environments.",
-            {"path": str(path), **git_state},
-        )
-    origin_url = _git_origin_url(path)
-    allowlist = _apps_repository_allowlist(config, cwd=cwd)
-    details = {
-        "path": str(path),
-        **git_state,
-        "origin_url": _redact_url(origin_url),
-        "allowlist_configured": bool(allowlist),
-        "untrusted_content_boundary": build_external_source_boundary(
+    result = evaluate_apps_repository_policy(
+        config,
+        cwd=cwd,
+        strict=_is_hardening_profile(profile),
+        allow_floating=False,
+    )
+    details = dict(result.details)
+    raw_path = details.get("path")
+    if raw_path:
+        path = Path(str(raw_path))
+        details["untrusted_content_boundary"] = build_external_source_boundary(
             path,
             source_kind="external_app_repository",
             source_name="APPS_REPOSITORY",
             trust_status="untrusted",
             metadata={
-                "origin_url": _redact_url(origin_url),
-                "allowlist_configured": bool(allowlist),
+                "origin_url": details.get("origin_url"),
+                "allowlist_configured": details.get("allowlist_configured", False),
             },
-        ),
-    }
-    if _is_hardening_profile(profile):
-        if not origin_url:
-            return Check(
-                "apps_repository_pin",
-                "External apps repository pinning",
-                "fail",
-                "APPS_REPOSITORY is pinned but has no origin URL to match against an allowlist.",
-                (
-                    "Set a reviewed origin URL and configure "
-                    f"{APPS_ALLOWLIST_ENV} or {APPS_ALLOWLIST_FILE_ENV} before shared use."
-                ),
-                details,
-            )
-        if origin_url not in allowlist:
-            return Check(
-                "apps_repository_pin",
-                "External apps repository pinning",
-                "fail",
-                "APPS_REPOSITORY origin is not in the configured allowlist.",
-                (
-                    "Add the exact reviewed origin URL to "
-                    f"{APPS_ALLOWLIST_ENV} or {APPS_ALLOWLIST_FILE_ENV}, then rerun the gate."
-                ),
-                details | {"allowlist_size": len(allowlist)},
-            )
+        )
     return Check(
         "apps_repository_pin",
         "External apps repository pinning",
-        "pass",
-        (
-            "APPS_REPOSITORY is pinned and allowlisted."
-            if _is_hardening_profile(profile)
-            else "APPS_REPOSITORY is a Git checkout and is not on a floating branch."
-        ),
-        "Keep the referenced commit reviewed and scanned.",
+        result.status,
+        result.summary,
+        result.remediation,
         details,
     )
 

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from agilab import agent_run, bridge_cli, run_manifest
 from agilab.secret_uri import redact_mapping
-
 
 _ALLOWED_ROOTS_ENV = "AGILAB_MCP_ALLOWED_ROOTS"
 _ALLOW_CWD_ENV = "AGILAB_MCP_ALLOW_CWD"
@@ -22,6 +23,10 @@ _CONFIGURED_ROOT_ENV_NAMES = (
     "AGILAB_LOG_ROOT",
     "AGILAB_AGENT_LOG_ROOT",
 )
+
+
+class _MCPPathError(ValueError):
+    """A caller-controlled path crossed the configured MCP read boundary."""
 
 
 def _repo_root() -> Path | None:
@@ -79,17 +84,248 @@ def _mcp_read_path(path: str | Path, *, purpose: str) -> Path:
     if any(_is_under_root(resolved, root) for root in roots):
         return resolved
     allowed = ", ".join(str(root) for root in roots) or "<none>"
-    raise ValueError(
+    raise _MCPPathError(
         f"MCP path for {purpose} is outside configured read roots: "
         f"{resolved} (allowed roots: {allowed})"
     )
+
+
+def _mcp_resource_path(
+    path: str | Path,
+    *,
+    manifest_path: Path,
+    purpose: str,
+) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = manifest_path.parent / candidate
+    return _mcp_read_path(candidate, purpose=purpose)
+
+
+def _canonicalize_path_value(
+    value: object,
+    *,
+    manifest_path: Path,
+    purpose: str,
+) -> object:
+    if isinstance(value, str) and value:
+        return str(
+            _mcp_resource_path(
+                value,
+                manifest_path=manifest_path,
+                purpose=purpose,
+            )
+        )
+    if isinstance(value, Mapping):
+        raw_path = value.get("path")
+        if isinstance(raw_path, str) and raw_path:
+            updated = dict(value)
+            updated["path"] = str(
+                _mcp_resource_path(
+                    raw_path,
+                    manifest_path=manifest_path,
+                    purpose=purpose,
+                )
+            )
+            return updated
+    return value
+
+
+def _canonicalize_agent_manifest_resources(
+    manifest: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    """Validate and canonicalize every agent artifact path before reuse."""
+
+    safe_manifest = deepcopy(dict(manifest))
+    artifacts = safe_manifest.get("artifacts")
+    if not isinstance(artifacts, Mapping):
+        return safe_manifest
+    safe_artifacts = dict(artifacts)
+    for name, value in tuple(safe_artifacts.items()):
+        safe_artifacts[name] = _canonicalize_path_value(
+            value,
+            manifest_path=manifest_path,
+            purpose=f"agent run {name} artifact",
+        )
+    trace = safe_artifacts.get("agent_trace")
+    if isinstance(trace, Mapping):
+        safe_trace = dict(trace)
+        for name in ("meta", "events", "tool_output_dir"):
+            raw_path = safe_trace.get(name)
+            if isinstance(raw_path, str) and raw_path:
+                safe_trace[name] = str(
+                    _mcp_resource_path(
+                        raw_path,
+                        manifest_path=manifest_path,
+                        purpose=f"agent trace {name} resource",
+                    )
+                )
+        safe_artifacts["agent_trace"] = safe_trace
+    safe_manifest["artifacts"] = safe_artifacts
+    return safe_manifest
+
+
+def _agent_manifest_file(path: Path) -> Path:
+    candidate = path / agent_run.MANIFEST_FILENAME if path.is_dir() else path
+    return _mcp_read_path(candidate, purpose="agent run manifest file")
+
+
+def _load_mcp_agent_manifest(path: str | Path) -> tuple[dict[str, Any], Path]:
+    input_path = _mcp_read_path(path, purpose="agent run manifest")
+    manifest_path = _agent_manifest_file(input_path)
+    manifest = agent_run.load_agent_run_manifest(manifest_path)
+    return (
+        _canonicalize_agent_manifest_resources(
+            manifest,
+            manifest_path=manifest_path,
+        ),
+        manifest_path,
+    )
+
+
+def _default_agent_log_root() -> Path:
+    raw = os.environ.get("AGI_LOG_DIR") or os.environ.get("AGILAB_LOG_ABS")
+    return Path(raw if raw else str(Path.home() / "log")).expanduser() / "agents"
+
+
+def _agent_manifest_records(
+    root: Path | None,
+    *,
+    agent: str = "",
+    status: str = "",
+    tag: str = "",
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapter: str = "",
+    capability: str = "",
+    limit: int | None = None,
+) -> list[tuple[dict[str, Any], Path, agent_run.AgentRunSummary]]:
+    """Load filtered agent records without dereferencing unchecked manifest paths."""
+
+    search_root = _mcp_read_path(
+        root if root is not None else _default_agent_log_root(),
+        purpose="agent log root",
+    )
+    if limit == 0 or not search_root.is_dir():
+        return []
+    candidates: list[Path] = []
+    for candidate in search_root.rglob(agent_run.MANIFEST_FILENAME):
+        safe_candidate = _mcp_read_path(
+            candidate,
+            purpose="discovered agent run manifest",
+        )
+        if safe_candidate.is_file():
+            candidates.append(safe_candidate)
+    candidates.sort(key=lambda path: path.stat().st_mtime_ns, reverse=True)
+
+    required_tags = set(agent_run._normalize_tags((tag,) if tag else ()))
+    required_metadata = dict(metadata or {})
+    required_protocol_adapters = set(
+        agent_run._normalize_slug_values(
+            (protocol_adapter,) if protocol_adapter else ()
+        )
+    )
+    required_capabilities = set(
+        agent_run._normalize_slug_values((capability,) if capability else ())
+    )
+    records: list[tuple[dict[str, Any], Path, agent_run.AgentRunSummary]] = []
+    for candidate in candidates:
+        try:
+            manifest, manifest_path = _load_mcp_agent_manifest(candidate)
+            summary = agent_run.summarize_agent_run(manifest)
+        except _MCPPathError:
+            raise
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if agent and summary.agent != agent:
+            continue
+        if status and summary.status != status:
+            continue
+        if required_tags and not required_tags.issubset(summary.tags):
+            continue
+        if required_metadata and any(
+            str(summary.metadata.get(key, "")) != value
+            for key, value in required_metadata.items()
+        ):
+            continue
+        protocols = manifest.get("protocols")
+        protocol_map = protocols if isinstance(protocols, Mapping) else {}
+        adapters = protocol_map.get("adapters")
+        adapter_values = (
+            {str(value) for value in adapters} if isinstance(adapters, list) else set()
+        )
+        if required_protocol_adapters and not required_protocol_adapters.issubset(
+            adapter_values
+        ):
+            continue
+        capabilities = protocol_map.get("capabilities")
+        capability_values = (
+            {str(value) for value in capabilities}
+            if isinstance(capabilities, list)
+            else set()
+        )
+        if required_capabilities and not required_capabilities.issubset(
+            capability_values
+        ):
+            continue
+        records.append((manifest, manifest_path, summary))
+        if limit is not None and len(records) >= limit:
+            break
+    return records
+
+
+def _canonicalize_run_manifest_resources(
+    payload: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    safe_payload = deepcopy(dict(payload))
+    artifacts = safe_payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        return safe_payload
+    safe_artifacts: list[object] = []
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            safe_artifacts.append(artifact)
+            continue
+        safe_artifact = dict(artifact)
+        raw_path = safe_artifact.get("path")
+        if isinstance(raw_path, str) and raw_path:
+            safe_artifact["path"] = str(
+                _mcp_resource_path(
+                    raw_path,
+                    manifest_path=manifest_path,
+                    purpose=f"run artifact {index}",
+                )
+            )
+        safe_artifacts.append(safe_artifact)
+    safe_payload["artifacts"] = safe_artifacts
+    return safe_payload
+
+
+def _load_mcp_run_manifest(
+    path: str | Path,
+    *,
+    purpose: str,
+) -> tuple[run_manifest.RunManifest, dict[str, Any], Path]:
+    input_path = _mcp_read_path(path, purpose=purpose)
+    _manifest, payload, resolved = bridge_cli._load_run_manifest(input_path)
+    safe_payload = _canonicalize_run_manifest_resources(
+        payload,
+        manifest_path=resolved,
+    )
+    return run_manifest.RunManifest.from_dict(safe_payload), safe_payload, resolved
 
 
 def list_projects(apps_root: str | Path) -> dict[str, Any]:
     root = _mcp_read_path(apps_root, purpose="projects root")
     projects = (
         [
-            {"name": path.name, "path": str(path)}
+            {
+                "name": path.name,
+                "path": str(_mcp_read_path(path, purpose="project directory")),
+            }
             for path in sorted(root.iterdir())
             if path.is_dir() and path.name.endswith("_project")
         ]
@@ -107,7 +343,12 @@ def list_runs(log_root: str | Path) -> dict[str, Any]:
     root = _mcp_read_path(log_root, purpose="run log root")
     runs = (
         [
-            {"path": str(path), "parent": str(path.parent)}
+            {
+                "path": str(_mcp_read_path(path, purpose="discovered run manifest")),
+                "parent": str(
+                    _mcp_read_path(path, purpose="discovered run manifest").parent
+                ),
+            }
             for path in sorted(root.rglob(run_manifest.RUN_MANIFEST_FILENAME))
         ]
         if root.is_dir()
@@ -157,14 +398,14 @@ def list_agent_runs(
         if log_root not in (None, "")
         else None
     )
-    summaries = agent_run.list_agent_runs(
+    records = _agent_manifest_records(
         root,
-        agent=agent or None,
-        status=status or None,
-        tags=(tag,) if tag else (),
+        agent=agent,
+        status=status,
+        tag=tag,
         metadata=metadata,
-        protocol_adapters=(protocol_adapter,) if protocol_adapter else (),
-        capabilities=(capability,) if capability else (),
+        protocol_adapter=protocol_adapter,
+        capability=capability,
         limit=limit,
     )
     return {
@@ -176,13 +417,15 @@ def list_agent_runs(
         "metadata": dict(metadata or {}),
         "protocol_adapter": protocol_adapter or None,
         "capability": capability or None,
-        "runs": [_agent_run_summary_payload(summary) for summary in summaries],
+        "runs": [
+            _agent_run_summary_payload(summary)
+            for _manifest, _path, summary in records
+        ],
     }
 
 
 def read_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
-    manifest = agent_run.load_agent_run_manifest(path)
+    manifest, path = _load_mcp_agent_manifest(manifest_path)
     summary = agent_run.summarize_agent_run(manifest)
     resolved = summary.manifest_path if str(summary.manifest_path) else path
     return {
@@ -193,8 +436,8 @@ def read_agent_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
-    summary = agent_run.summarize_agent_run(path)
+    manifest, path = _load_mcp_agent_manifest(manifest_path)
+    summary = agent_run.summarize_agent_run(manifest)
     return {
         "schema": "agilab.mcp.summarize_agent_run.v1",
         "manifest_path": str(summary.manifest_path or path),
@@ -203,20 +446,20 @@ def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def agent_handoff(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
+    manifest, path = _load_mcp_agent_manifest(manifest_path)
     return {
         "schema": "agilab.mcp.agent_handoff.v1",
         "manifest_path": str(path),
-        "handoff": agent_run.agent_handoff_payload(path),
+        "handoff": agent_run.agent_handoff_payload(manifest),
     }
 
 
 def agent_next_actions(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
+    manifest, path = _load_mcp_agent_manifest(manifest_path)
     return {
         "schema": "agilab.mcp.agent_next_actions.v1",
         "manifest_path": str(path),
-        "next_actions": agent_run.agent_next_actions_payload(path),
+        "next_actions": agent_run.agent_next_actions_payload(manifest),
     }
 
 
@@ -238,6 +481,17 @@ def agent_context(
         if log_root not in (None, "")
         else None
     )
+    records = _agent_manifest_records(
+        root,
+        agent=agent,
+        status=status,
+        tag=tag,
+        metadata=metadata,
+        protocol_adapter=protocol_adapter,
+        capability=capability,
+        limit=limit,
+    )
+    summaries = [summary for _manifest, _path, summary in records]
     return {
         "schema": "agilab.mcp.agent_context.v1",
         "log_root": str(root) if root is not None else "~/log/agents",
@@ -250,6 +504,8 @@ def agent_context(
             protocol_adapters=(protocol_adapter,) if protocol_adapter else (),
             capabilities=(capability,) if capability else (),
             limit=limit,
+            _summaries=summaries,
+            _latest_manifest=records[0][0] if records else None,
         ),
     }
 
@@ -264,32 +520,38 @@ def agent_lineage(
         if log_root not in (None, "")
         else None
     )
+    records = _agent_manifest_records(root, limit=None)
+    summaries = [summary for _manifest, _path, summary in records]
     return {
         "schema": "agilab.mcp.agent_lineage.v1",
         "log_root": str(root) if root is not None else "~/log/agents",
-        "lineage": agent_run.agent_lineage_payload(root, run_id=run_id),
+        "lineage": agent_run.agent_lineage_payload(
+            root,
+            run_id=run_id,
+            _summaries=summaries,
+        ),
     }
 
 
 def compare_agent_runs(
     left_manifest: str | Path, right_manifest: str | Path
 ) -> dict[str, Any]:
-    left = _mcp_read_path(left_manifest, purpose="left agent run manifest")
-    right = _mcp_read_path(right_manifest, purpose="right agent run manifest")
+    left_payload, left = _load_mcp_agent_manifest(left_manifest)
+    right_payload, right = _load_mcp_agent_manifest(right_manifest)
     return {
         "schema": "agilab.mcp.compare_agent_runs.v1",
         "left_manifest": str(left),
         "right_manifest": str(right),
-        "comparison": agent_run.compare_agent_runs(left, right),
+        "comparison": agent_run.compare_agent_runs(left_payload, right_payload),
     }
 
 
 def validate_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
+    manifest, path = _load_mcp_agent_manifest(manifest_path)
     return {
         "schema": "agilab.mcp.validate_agent_run.v1",
         "manifest_path": str(path),
-        "validation": agent_run.validate_agent_run(path),
+        "validation": agent_run.validate_agent_run(manifest),
     }
 
 
@@ -298,6 +560,16 @@ def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
         raise ValueError(f"Manifest must be a JSON object: {path}")
+    if payload.get("kind") == agent_run.TRACE_KIND:
+        payload = _canonicalize_agent_manifest_resources(
+            payload,
+            manifest_path=path,
+        )
+    else:
+        payload = _canonicalize_run_manifest_resources(
+            payload,
+            manifest_path=path,
+        )
     return {
         "schema": "agilab.mcp.read_manifest.v1",
         "manifest_path": str(path),
@@ -306,8 +578,10 @@ def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def summarize_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="run manifest")
-    manifest, _, resolved = bridge_cli._load_run_manifest(path)
+    manifest, _, resolved = _load_mcp_run_manifest(
+        manifest_path,
+        purpose="run manifest",
+    )
     return {
         "schema": "agilab.mcp.summarize_run.v1",
         "manifest_path": str(resolved),
@@ -316,8 +590,10 @@ def summarize_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def list_artifacts(manifest_path: str | Path) -> dict[str, Any]:
-    path = _mcp_read_path(manifest_path, purpose="run manifest")
-    manifest, _, resolved = bridge_cli._load_run_manifest(path)
+    manifest, _, resolved = _load_mcp_run_manifest(
+        manifest_path,
+        purpose="run manifest",
+    )
     return {
         "schema": "agilab.mcp.list_artifacts.v1",
         "manifest_path": str(resolved),
@@ -328,10 +604,14 @@ def list_artifacts(manifest_path: str | Path) -> dict[str, Any]:
 def compare_runs(
     left_manifest: str | Path, right_manifest: str | Path
 ) -> dict[str, Any]:
-    left_input = _mcp_read_path(left_manifest, purpose="left run manifest")
-    right_input = _mcp_read_path(right_manifest, purpose="right run manifest")
-    left, _, left_path = bridge_cli._load_run_manifest(left_input)
-    right, _, right_path = bridge_cli._load_run_manifest(right_input)
+    left, _, left_path = _load_mcp_run_manifest(
+        left_manifest,
+        purpose="left run manifest",
+    )
+    right, _, right_path = _load_mcp_run_manifest(
+        right_manifest,
+        purpose="right run manifest",
+    )
     left_summary = run_manifest.manifest_summary(left)
     right_summary = run_manifest.manifest_summary(right)
     return {
@@ -351,10 +631,17 @@ def compare_runs(
 def export_quarto_report(
     manifest_path: str | Path, output_path: str | Path
 ) -> dict[str, Any]:
-    manifest = _mcp_read_path(manifest_path, purpose="run manifest")
+    manifest, payload, resolved = _load_mcp_run_manifest(
+        manifest_path,
+        purpose="run manifest",
+    )
     output = _mcp_read_path(output_path, purpose="report output")
-    return bridge_cli.export_quarto_report(
-        manifest, output, render=False
+    return bridge_cli._export_quarto_report_loaded(
+        manifest,
+        payload,
+        resolved,
+        output,
+        render=False,
     )
 
 
@@ -384,16 +671,20 @@ def _capabilities_manifest_path(explicit: str | Path | None = None) -> Path | No
             if candidate.is_file()
             else None
         )
-    candidates: list[Path] = []
+    candidates: list[tuple[Path, bool]] = []
     env_value = os.environ.get("AGILAB_CAPABILITIES_MANIFEST")
     if env_value:
-        candidates.append(Path(env_value).expanduser())
+        candidates.append((Path(env_value).expanduser(), True))
     for parent in Path(__file__).resolve().parents:
-        candidates.append(parent / _CAPABILITIES_FILENAME)
-    candidates.append(Path.cwd() / _CAPABILITIES_FILENAME)
-    for candidate in candidates:
+        candidates.append((parent / _CAPABILITIES_FILENAME, False))
+    candidates.append((Path.cwd() / _CAPABILITIES_FILENAME, False))
+    for candidate, configured in candidates:
         if candidate.is_file():
-            return candidate.resolve()
+            try:
+                return _mcp_read_path(candidate, purpose="capabilities manifest")
+            except ValueError:
+                if configured:
+                    raise
     return None
 
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import importlib
 import builtins
+import importlib
 import json
-from pathlib import Path
+import os
 import subprocess
 import sys
-from types import SimpleNamespace
-from types import ModuleType
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -15,9 +15,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from agilab import agent_run, bridge_cli, run_manifest  # noqa: E402
 import agilab_mcp  # noqa: E402
-from agilab_mcp import manifest_tools, server as mcp_server  # noqa: E402
+from agilab import agent_run, bridge_cli, run_manifest  # noqa: E402
+from agilab_mcp import manifest_tools  # noqa: E402
+from agilab_mcp import server as mcp_server
 
 
 def _write_manifest(
@@ -825,7 +826,7 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         output_dir=agent_dir,
         run_id="agent-codex",
         permission_level="standard",
-        tags=("review",),
+        tags=("quality-review",),
         metadata={"branch": "main"},
         protocol_adapters=("mcp",),
         capabilities=("evidence-review",),
@@ -839,13 +840,13 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     agent_runs = manifest_tools.list_agent_runs(
         agent_root,
         agent="codex",
-        tag="review",
+        tag="quality review",
         metadata={"branch": "main"},
-        protocol_adapter="mcp",
-        capability="evidence-review",
+        protocol_adapter="MCP",
+        capability="evidence review",
     )["runs"]
     assert agent_runs[0]["run_id"] == "agent-codex"
-    assert agent_runs[0]["tags"] == ["review"]
+    assert agent_runs[0]["tags"] == ["quality-review"]
     assert agent_runs[0]["metadata"] == {"branch": "main"}
     assert (
         manifest_tools.summarize_agent_run(agent_dir)["summary"]["status"]
@@ -864,10 +865,10 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     context_payload = manifest_tools.agent_context(
         agent_root,
         agent="codex",
-        tag="review",
+        tag="quality review",
         metadata={"branch": "main"},
-        protocol_adapter="mcp",
-        capability="evidence-review",
+        protocol_adapter="MCP",
+        capability="evidence review",
     )
     assert context_payload["context"]["match_count"] == 1
     assert context_payload["context"]["latest"]["handoff"]["run"]["run_id"] == "agent-codex"
@@ -924,7 +925,7 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
                 "arguments": {
                     "log_root": str(agent_root),
                     "agent": "codex",
-                    "tag": "review",
+                        "tag": "quality review",
                     "metadata": {"branch": "main"},
                 },
             },
@@ -1228,6 +1229,177 @@ def test_manifest_tools_reject_paths_outside_allowed_roots(
         manifest_tools.list_agent_runs(log_root=outside)
     with pytest.raises(ValueError, match="outside configured read roots"):
         manifest_tools.agent_quickstart(capabilities_path=outside_manifest)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda manifest, _root: manifest_tools.read_agent_run(manifest),
+        lambda manifest, _root: manifest_tools.summarize_agent_run(manifest),
+        lambda manifest, _root: manifest_tools.agent_handoff(manifest),
+        lambda manifest, _root: manifest_tools.agent_next_actions(manifest),
+        lambda manifest, _root: manifest_tools.compare_agent_runs(manifest, manifest),
+        lambda manifest, _root: manifest_tools.validate_agent_run(manifest),
+        lambda _manifest, root: manifest_tools.list_agent_runs(root),
+        lambda _manifest, root: manifest_tools.agent_context(root),
+        lambda _manifest, root: manifest_tools.agent_lineage(root, run_id="forged-run"),
+    ],
+)
+def test_manifest_tools_reject_transitive_agent_resource_paths_outside_allowed_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation,
+) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    run_dir = allowed / "agents" / "forged-run"
+    run_dir.mkdir(parents=True)
+    outside.mkdir()
+    outside_events = outside / "agent_events.ndjson"
+    outside_events.write_text(
+        json.dumps(
+            {
+                "schema": "agilab.agent_trace.v1",
+                "sequence": 1,
+                "timestamp": "2026-07-27T00:00:00Z",
+                "run_id": "forged-run",
+                "event": "run_started",
+                "status": "running",
+                "message": "outside secret",
+                "metadata": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_path = run_dir / agent_run.MANIFEST_FILENAME
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": agent_run.TRACE_KIND,
+                "run_id": "forged-run",
+                "agent": "codex",
+                "label": "forged",
+                "status": "pass",
+                "returncode": 0,
+                "command": {"argv_sha256": "hash", "argv": []},
+                "context": {"tags": [], "metadata": {}},
+                "protocols": {"adapters": [], "capabilities": []},
+                "permission": {},
+                "timing": {"duration_seconds": 0.0},
+                "artifacts": {
+                    "manifest": str(manifest_path),
+                    "agent_trace": {"events": str(outside_events)},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(allowed))
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        operation(manifest_path, allowed / "agents")
+
+
+def test_manifest_tools_handoff_reads_exact_contained_trace_resource(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_root = tmp_path / "manifests"
+    manifest_root.mkdir()
+    safe_events = tmp_path / "reviewed-events.ndjson"
+    default_events = tmp_path / "agent_events.ndjson"
+
+    def event(message: str) -> str:
+        return json.dumps(
+            {
+                "schema": "agilab.agent_trace.v1",
+                "sequence": 1,
+                "created_at": "2026-07-27T00:00:00Z",
+                "run_id": "derived-parent-run",
+                "event": "command_start",
+                "status": "running",
+                "message": message,
+                "metadata": {},
+            }
+        ) + "\n"
+
+    safe_events.write_text(event("reviewed trace"), encoding="utf-8")
+    default_events.write_text(event("OUTSIDE-SENTINEL"), encoding="utf-8")
+    manifest_path = manifest_root / agent_run.MANIFEST_FILENAME
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": agent_run.TRACE_KIND,
+                "run_id": "derived-parent-run",
+                "agent": "codex",
+                "status": "pass",
+                "command": {"argv_sha256": "hash", "argv": []},
+                "artifacts": {
+                    "manifest": str(manifest_path),
+                    "agent_trace": {"events": str(safe_events)},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "AGILAB_MCP_ALLOWED_ROOTS",
+        os.pathsep.join((str(manifest_root), str(safe_events))),
+    )
+
+    payload = manifest_tools.agent_handoff(manifest_path)["handoff"]
+
+    assert payload["trace"]["event_count"] == 1
+    assert payload["trace"]["events"][0]["message"] == "reviewed trace"
+    assert "OUTSIDE-SENTINEL" not in json.dumps(payload)
+
+
+def test_manifest_tools_reject_transitive_run_artifact_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    outside_artifact = outside / "secret.txt"
+    outside_artifact.write_text("outside secret\n", encoding="utf-8")
+    escaped_link = allowed / "artifact.txt"
+    escaped_link.symlink_to(outside_artifact)
+    manifest_path = _write_manifest(allowed)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["artifacts"][0]["path"] = str(escaped_link)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(allowed))
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.list_artifacts(manifest_path)
+
+
+def test_manifest_tools_quarto_export_does_not_reopen_validated_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+    real_loader = bridge_cli._load_run_manifest
+    loaded_paths: list[Path] = []
+
+    def load_once(path: Path):
+        loaded_paths.append(path)
+        if len(loaded_paths) > 1:
+            raise AssertionError("validated manifest was reopened")
+        return real_loader(path)
+
+    monkeypatch.setattr(bridge_cli, "_load_run_manifest", load_once)
+
+    payload = manifest_tools.export_quarto_report(
+        manifest_path,
+        tmp_path / "contained-report.qmd",
+    )
+
+    assert payload["status"] == "pass"
+    assert loaded_paths == [manifest_path.resolve()]
 
 
 def test_manifest_tools_do_not_allow_launch_cwd_by_default(

--- a/test/test_ci_provider_artifacts.py
+++ b/test/test_ci_provider_artifacts.py
@@ -5,6 +5,7 @@ import io
 import json
 import sys
 from pathlib import Path
+from urllib import request
 from zipfile import ZipFile
 
 import pytest
@@ -17,20 +18,19 @@ package_paths = getattr(package, "__path__", None)
 if package_paths is not None and str(SRC_ROOT / "agilab") not in list(package_paths):
     package_paths.append(str(SRC_ROOT / "agilab"))
 
+from agilab import ci_provider_artifacts as provider_artifacts
 from agilab.ci.ci_artifact_harvest import (
     build_ci_artifact_harvest,
     sample_ci_artifacts,
 )
-from agilab import ci_provider_artifacts as provider_artifacts
 from agilab.ci.ci_provider_artifacts import (
     build_artifact_index_from_archives,
-    build_gitlab_ci_artifact_index,
     build_github_actions_artifact_index,
+    build_gitlab_ci_artifact_index,
     write_sample_ci_provider_archive,
     write_sample_github_actions_archive,
     write_sample_github_actions_directory,
 )
-
 
 TOOL_PATH = Path("tools/github_actions_artifact_index.py").resolve()
 GENERIC_TOOL_PATH = Path("tools/ci_provider_artifact_index.py").resolve()
@@ -439,7 +439,13 @@ def test_live_gitlab_allows_explicit_enterprise_host(tmp_path: Path) -> None:
 
     def fake_urlopen(req: object) -> _Response:
         headers = getattr(req, "headers", {})
-        token_headers.append(headers.get("Private-token") or headers.get("PRIVATE-TOKEN"))
+        unredirected = getattr(req, "unredirected_hdrs", {})
+        token_headers.append(
+            headers.get("Private-token")
+            or headers.get("PRIVATE-TOKEN")
+            or unredirected.get("Private-token")
+            or unredirected.get("PRIVATE-TOKEN")
+        )
         url = str(getattr(req, "full_url"))
         requested_urls.append(url)
         if url.endswith("/pipelines/987654321/jobs?scope[]=success&per_page=100&page=1"):
@@ -472,6 +478,38 @@ def test_live_gitlab_allows_explicit_enterprise_host(tmp_path: Path) -> None:
     ]
     assert token_headers == ["secret-token", "secret-token"]
     assert index["provider"] == "gitlab_ci"
+
+
+@pytest.mark.parametrize(
+    "redirect_url",
+    [
+        "https://gitlab.com/users/sign_in",
+        "https://objects.example.invalid/artifacts/42.zip",
+    ],
+)
+def test_gitlab_private_token_is_never_forwarded_across_redirects(
+    redirect_url: str,
+) -> None:
+    initial = provider_artifacts._gitlab_request(
+        "https://gitlab.com/api/v4/projects/thales%2Fagilab/jobs/42/artifacts",
+        token="secret-token",
+    )
+
+    assert "Private-token" not in initial.headers
+    assert initial.unredirected_hdrs["Private-token"] == "secret-token"
+
+    redirected = request.HTTPRedirectHandler().redirect_request(
+        initial,
+        None,
+        302,
+        "Found",
+        {},
+        redirect_url,
+    )
+
+    assert redirected is not None
+    assert "Private-token" not in redirected.headers
+    assert "Private-token" not in redirected.unredirected_hdrs
 
 
 def test_provider_archive_edge_cases_cover_validation_and_duplicates(tmp_path: Path) -> None:
@@ -560,7 +598,7 @@ def test_provider_download_helpers_cover_skips_headers_and_default_filenames(tmp
     req = provider_artifacts._github_artifact_download_request("https://example.invalid/a.zip", token=None)
     assert "Authorization" not in req.headers
     assert "Authorization" not in req.unredirected_hdrs
-    assert "PRIVATE-TOKEN" not in provider_artifacts._gitlab_headers(None)
+    assert "PRIVATE-TOKEN" not in provider_artifacts._gitlab_headers()
 
     class _ZipResponse:
         def __enter__(self) -> "_ZipResponse":

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
-
 INSTALL_APPS_SH = Path(__file__).resolve().parents[1] / "src/agilab/install_apps.sh"
+REPO_ROOT = INSTALL_APPS_SH.parents[2]
 
 
 def _extract_function(script_text: str, function_name: str, next_function_name: str) -> str:
@@ -160,7 +161,10 @@ def _run_validate_apps_repository_policy(
     strict: bool,
     allowlist: str = "",
     allow_floating: bool = False,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    uv = shutil.which("uv")
+    assert uv is not None
     script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
     start = script_text.index("parse_list_to_array() {")
     end = script_text.index("\n# Detect whether", start)
@@ -171,6 +175,8 @@ RED=''
 YELLOW=''
 BLUE=''
 NC=''
+UV_PREVIEW=({uv!r} --preview-features extra-build-dependencies)
+AGILAB_APPS_REPOSITORY_POLICY_SCRIPT={str(REPO_ROOT / "src/agilab/security/apps_repository_policy.py")!r}
 {function_body}
 validate_apps_repository_policy "$1"
 """
@@ -186,6 +192,7 @@ validate_apps_repository_policy "$1"
         capture_output=True,
         text=True,
         env=env,
+        cwd=cwd,
     )
 
 
@@ -194,7 +201,7 @@ def _run_install_apps_selection_from_cli(raw: str) -> dict[str, str]:
     function_body = _extract_function(
         script_text,
         "set_install_apps_selection_from_cli",
-        "is_truthy",
+        "validate_apps_repository_policy",
     )
     bash_script = f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -480,11 +487,24 @@ def test_validate_apps_repository_policy_rejects_floating_branch_in_strict_mode(
     repo_root = tmp_path / "apps_repo"
     repo_root.mkdir()
     subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True)
+    (repo_root / "README.md").write_text("reviewed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "reviewed"], cwd=repo_root, check=True, capture_output=True, text=True)
+    origin = "https://example.invalid/reviewed-apps.git"
+    subprocess.run(
+        ["git", "remote", "add", "origin", origin],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
     result = _run_validate_apps_repository_policy(
         repo_root,
         strict=True,
-        allowlist=str(repo_root.resolve()),
+        allowlist=origin,
     )
 
     assert result.returncode == 1
@@ -494,11 +514,90 @@ def test_validate_apps_repository_policy_rejects_floating_branch_in_strict_mode(
 def test_validate_apps_repository_policy_requires_allowlist_in_strict_mode(tmp_path: Path) -> None:
     repo_root = tmp_path / "apps_repo"
     repo_root.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True)
+    (repo_root / "README.md").write_text("reviewed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "reviewed"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://example.invalid/reviewed-apps.git"],
+        cwd=repo_root,
+        check=True,
+    )
+    subprocess.run(["git", "checkout", "--detach"], cwd=repo_root, check=True, capture_output=True, text=True)
 
     result = _run_validate_apps_repository_policy(repo_root, strict=True)
 
     assert result.returncode == 1
     assert "AGILAB_APPS_REPOSITORY_ALLOWLIST" in result.stderr
+
+
+def test_validate_apps_repository_policy_accepts_allowlisted_detached_origin(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "apps_repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True)
+    (repo_root / "README.md").write_text("reviewed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "reviewed"], cwd=repo_root, check=True, capture_output=True, text=True)
+    origin = "https://example.invalid/reviewed-apps.git"
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=repo_root, check=True)
+    subprocess.run(["git", "checkout", "--detach"], cwd=repo_root, check=True, capture_output=True, text=True)
+
+    result = _run_validate_apps_repository_policy(
+        repo_root,
+        strict=True,
+        allowlist=origin,
+    )
+
+    assert result.returncode == 0
+    assert "pinned" in result.stdout.lower()
+
+
+def test_validate_apps_repository_policy_ignores_shadow_module_in_launch_cwd(
+    tmp_path: Path,
+) -> None:
+    launch_cwd = tmp_path / "untrusted-cwd"
+    shadow = launch_cwd / "agilab" / "security" / "apps_repository_policy.py"
+    shadow.parent.mkdir(parents=True)
+    (launch_cwd / "agilab" / "__init__.py").write_text("", encoding="utf-8")
+    (shadow.parent / "__init__.py").write_text("", encoding="utf-8")
+    shadow.write_text("print('SHADOW POLICY EXECUTED')\n", encoding="utf-8")
+    backend_sentinel = launch_cwd / "UNTRUSTED-BACKEND-EXECUTED"
+    (launch_cwd / "pyproject.toml").write_text(
+        """
+[project]
+name = "untrusted-launch-project"
+version = "0.0.0"
+
+[build-system]
+requires = []
+build-backend = "untrusted_backend"
+backend-path = ["."]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (launch_cwd / "untrusted_backend.py").write_text(
+        "from pathlib import Path\nPath('UNTRUSTED-BACKEND-EXECUTED').write_text('bad')\n",
+        encoding="utf-8",
+    )
+
+    result = _run_validate_apps_repository_policy(
+        tmp_path / "missing-apps-repository",
+        strict=True,
+        allowlist="https://example.invalid/reviewed-apps.git",
+        cwd=launch_cwd,
+    )
+
+    assert result.returncode == 1
+    assert "SHADOW POLICY EXECUTED" not in result.stdout
+    assert "missing path" in result.stderr
+    assert not backend_sentinel.exists()
 
 
 def test_install_apps_preserves_caller_apps_repository_over_env_file() -> None:

--- a/test/test_security_check.py
+++ b/test/test_security_check.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import importlib.util
 import json
+import os
 import runpy
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-
 
 ROOT = Path(__file__).resolve().parents[1]
 SECURITY_CHECK_PATH = ROOT / "src" / "agilab" / "security_check.py"
@@ -21,6 +22,41 @@ SPEC.loader.exec_module(security_check)
 
 def _touch_now(path: Path) -> None:
     path.write_text("{}", encoding="utf-8")
+
+
+def _init_apps_repository(
+    path: Path,
+    *,
+    origin: str | None = None,
+) -> None:
+    path.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("reviewed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "reviewed"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if origin:
+        subprocess.run(["git", "remote", "add", "origin", origin], cwd=path, check=True)
+    subprocess.run(
+        ["git", "checkout", "--detach"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_env_file_parser_path_resolution_and_secret_placeholders(tmp_path: Path):
@@ -126,9 +162,7 @@ def test_apps_repository_check_reports_missing_file_nongit_and_pinned_checkout(t
     assert nongit_check.status == "warn"
     assert "not a Git checkout" in nongit_check.summary
 
-    git_dir = app_dir / ".git"
-    git_dir.mkdir()
-    (git_dir / "HEAD").write_text("0123456789abcdef0123456789abcdef01234567\n", encoding="utf-8")
+    _init_apps_repository(app_dir)
     pinned_check = security_check._check_apps_repository(
         {"APPS_REPOSITORY": str(app_dir)},
         cwd=tmp_path,
@@ -143,14 +177,8 @@ def test_apps_repository_check_reports_missing_file_nongit_and_pinned_checkout(t
 
 def test_shared_profile_requires_apps_repository_origin_allowlist(tmp_path: Path):
     apps = tmp_path / "apps"
-    git_dir = apps / ".git"
-    git_dir.mkdir(parents=True)
     origin = "https://github.com/ThalesGroup/agilab-apps"
-    (git_dir / "HEAD").write_text("0123456789abcdef0123456789abcdef01234567\n", encoding="utf-8")
-    (git_dir / "config").write_text(
-        f'[remote "origin"]\n    url = {origin}\n',
-        encoding="utf-8",
-    )
+    _init_apps_repository(apps, origin=origin)
 
     missing_allowlist = security_check._check_apps_repository(
         {"APPS_REPOSITORY": str(apps)},
@@ -184,15 +212,203 @@ def test_shared_profile_requires_apps_repository_origin_allowlist(tmp_path: Path
     assert allowlisted_by_file.status == "pass"
 
 
-def test_shared_profile_requires_origin_url_for_pinned_apps_repository(tmp_path: Path):
-    apps = tmp_path / "apps"
+def test_apps_repository_policy_is_shared_by_security_gate_and_installers() -> None:
+    from agilab.security import apps_repository_policy
+
+    assert security_check.evaluate_apps_repository_policy is apps_repository_policy.evaluate_apps_repository_policy
+
+    bash = (Path("src/agilab/install_apps.sh")).read_text(encoding="utf-8")
+    powershell = (Path("src/agilab/install_apps.ps1")).read_text(encoding="utf-8")
+    policy_path = "security/apps_repository_policy.py"
+    assert policy_path in bash
+    assert policy_path in powershell
+    assert "BASH_SOURCE[0]" in bash
+    assert "$PSScriptRoot" in powershell
+    assert "run --no-project --no-config python -I" in bash
+    assert "run --no-project --no-config python -I" in powershell
+    assert "AGILAB_APPS_POLICY_PYTHON" not in bash
+    assert "AGILAB_APPS_POLICY_PYTHON" not in powershell
+
+
+def test_apps_repository_policy_rejects_forged_git_metadata(tmp_path: Path) -> None:
+    apps = tmp_path / "forged-apps"
     git_dir = apps / ".git"
     git_dir.mkdir(parents=True)
-    (git_dir / "HEAD").write_text("0123456789abcdef0123456789abcdef01234567\n", encoding="utf-8")
-    (git_dir / "config").write_text(
-        "\n# ignored\n[remote \"upstream\"]\n    fetch = +refs/heads/*:refs/remotes/upstream/*\n",
+    origin = "https://example.invalid/reviewed-apps.git"
+    (git_dir / "HEAD").write_text(
+        "0123456789abcdef0123456789abcdef01234567\n",
         encoding="utf-8",
     )
+    (git_dir / "config").write_text(
+        f'[remote "origin"]\n    url = {origin}\n',
+        encoding="utf-8",
+    )
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(apps),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "fail"
+    assert "not a Git checkout" in check.summary
+    assert check.details["git_verified"] is False
+
+
+def test_shared_apps_repository_policy_rejects_dirty_detached_checkout(
+    tmp_path: Path,
+) -> None:
+    apps = tmp_path / "apps"
+    origin = "https://example.invalid/reviewed-apps.git"
+    _init_apps_repository(apps, origin=origin)
+    (apps / "README.md").write_text("unreviewed change\n", encoding="utf-8")
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(apps),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "fail"
+    assert "unreviewed working-tree content" in check.summary
+    assert check.details["worktree_clean"] is False
+
+
+def test_shared_apps_repository_policy_rejects_ignored_executable_content(
+    tmp_path: Path,
+) -> None:
+    apps = tmp_path / "apps"
+    origin = "https://example.invalid/reviewed-apps.git"
+    _init_apps_repository(apps, origin=origin)
+    (apps / ".gitignore").write_text("apps-pages/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=apps, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "ignore local pages"],
+        cwd=apps,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    ignored_page = apps / "apps-pages" / "unreviewed_page"
+    ignored_page.mkdir(parents=True)
+    (ignored_page / "page.py").write_text("raise SystemExit('unreviewed')\n", encoding="utf-8")
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(apps),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "fail"
+    assert "unreviewed working-tree content" in check.summary
+    assert check.details["worktree_clean"] is False
+
+
+def test_apps_repository_policy_ignores_git_environment_repository_redirection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trusted = tmp_path / "trusted"
+    origin = "https://example.invalid/reviewed-apps.git"
+    _init_apps_repository(trusted, origin=origin)
+    untrusted = tmp_path / "not-a-repository"
+    untrusted.mkdir()
+    monkeypatch.setenv("GIT_DIR", str(trusted / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(trusted))
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(untrusted),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "fail"
+    assert "not a Git checkout" in check.summary
+    assert check.details["git_verified"] is False
+
+
+def test_apps_repository_policy_ignores_git_environment_origin_spoofing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    apps = tmp_path / "apps"
+    _init_apps_repository(apps)
+    spoofed_origin = "https://example.invalid/reviewed-apps.git"
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "remote.origin.url")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", spoofed_origin)
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(apps),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": spoofed_origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "fail"
+    assert "no origin URL" in check.summary
+    assert check.details["origin_url"] is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX fsmonitor hook fixture")
+def test_apps_repository_policy_does_not_execute_repository_fsmonitor_hook(
+    tmp_path: Path,
+) -> None:
+    apps = tmp_path / "apps"
+    origin = "https://example.invalid/reviewed-apps.git"
+    _init_apps_repository(apps, origin=origin)
+    sentinel = tmp_path / "FSMONITOR-EXECUTED"
+    hook = tmp_path / "fsmonitor-hook"
+    hook.write_text(
+        f"#!/bin/sh\nprintf executed > {str(sentinel)!r}\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    subprocess.run(
+        ["git", "config", "core.fsmonitor", str(hook)],
+        cwd=apps,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=apps,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert sentinel.is_file(), "fixture must prove ordinary git status executes the hook"
+    sentinel.unlink()
+
+    check = security_check._check_apps_repository(
+        {
+            "APPS_REPOSITORY": str(apps),
+            "AGILAB_APPS_REPOSITORY_ALLOWLIST": origin,
+        },
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert check.status == "pass"
+    assert not sentinel.exists()
+
+
+def test_shared_profile_requires_origin_url_for_pinned_apps_repository(tmp_path: Path):
+    apps = tmp_path / "apps"
+    _init_apps_repository(apps)
 
     check = security_check._check_apps_repository(
         {"APPS_REPOSITORY": str(apps)},


### PR DESCRIPTION
## Summary

- enforce canonical, fail-closed containment for MCP manifests and every transitive agent/run resource before downstream helpers can inspect it
- keep GitLab private tokens on the initial request only so redirects never receive authentication
- unify external apps-repository trust validation across Bash, PowerShell, and `agilab security-check`
- isolate policy execution from untrusted launch projects and Python paths, sanitize Git environment overrides, disable repository fsmonitor hooks, and reject modified, untracked, or ignored executable content

## Repro

1. Place an agent or run manifest under an allowed MCP root and point a nested artifact, trace resource, symlink, or derived trace parent outside that root. Several read-only MCP endpoints could reach the unchecked resource.
2. Build a GitLab request with `PRIVATE-TOKEN` as a normal header and follow an HTTP redirect. The redirect request inherited the credential.
3. Configure the same external apps checkout through the Bash installer, PowerShell installer, and security check. The three surfaces enforced different policies; PowerShell had no equivalent gate. A polluted launch directory or `GIT_*` environment could also shadow or spoof the policy boundary.

## Root Cause

Top-level MCP arguments were contained, but manifest-owned resource paths were trusted transitively and one export path reopened the unchecked manifest. GitLab authentication used redirect-copyable request headers. Apps-repository validation was duplicated or absent across entry points and executed without isolating the Python/uv and Git discovery environments.

## Regression Test

Coverage now includes:

- directly external, symlinked, and derived-parent MCP resources
- exact trace-file loading and no post-validation Quarto manifest reopen
- normalized agent tag/protocol/capability queries
- same-origin and cross-origin GitLab redirects
- forged Git metadata, `GIT_DIR`/worktree redirection, origin config spoofing, ignored executable content, and repository fsmonitor hooks
- polluted launch directories with a shadow Python package and executable in-tree build backend
- strict Bash acceptance/rejection cases plus shared Bash/PowerShell/security-check policy wiring

## Validation

- 166 focused tests passed across agent runtime, audience/MCP bridges, GitLab artifacts, installers, and security check; one existing `runpy` warning remains
- Bash installer syntax and PowerShell installer parser validation passed
- changed-file Ruff `E9,F,I`, staged impact, staged scope, diff, provenance, and pre-push guards passed
- no `src/agilab/core/agi-core/**` files changed
- all GitHub checks passed, including Linux/macOS/Windows installs, Python boundaries, Windows core tests, policy, and GitGuardian
- repo-wide `./dev lint` still reports 137 existing strict-rule findings; the changed-file lint slice is clean

## Review Evidence

- Implementer: Codex sub-agent `runtime_process_fix`, inherited GPT-5; edited the 12-file scope
- Independent reviewer: Codex sub-agent, inherited GPT-5; read-only review with no file edits
- Reviewer identified derived trace-parent containment, query-normalization, polluted-cwd policy execution, Git fsmonitor regressions, and one docs inconsistency; all findings were addressed
- Canonical docs PR jpmorard/thales_agilab#181 and public mirror PR ThalesGroup/agilab#874 are merged, satisfying the documented dependency
- Final reviewer verdict: no remaining code/security findings

## Agent Metadata

- Tokki: 1.0.34
- Agent/runtime: Codex CLI 0.145.0
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
