### PR TITLE
test: skip .venv-prefixed dirs in the import hygiene scan

### DIFF
--- a/test/test_import_deprecation_hygiene.py
+++ b/test/test_import_deprecation_hygiene.py
@@ -13,7 +13,6 @@ SCAN_ROOTS = (
 
 def _python_files() -> list[Path]:
     skipped_parts = {
-        ".venv",
         "__pycache__",
         "build",
         "dist",
@@ -24,6 +23,12 @@ def _python_files() -> list[Path]:
     for root in SCAN_ROOTS:
         for path in root.rglob("*.py"):
             if skipped_parts.intersection(path.parts):
+                continue
+            # Environments are not repo source. Match by prefix: alongside plain
+            # `.venv`, app and page bundles create siblings such as
+            # `.venv.agilab-linking`, whose third-party contents would otherwise
+            # be scanned as if they were ours.
+            if any(part.startswith(".venv") for part in path.parts):
                 continue
             files.append(path)
     return sorted(files)


### PR DESCRIPTION
Found while sweeping the 215 root `test/` modules that no CI workflow runs (see below).

## The bug

`test_import_deprecation_hygiene` excludes a path part **equal to** `.venv`:

```python
skipped_parts = {".venv", "__pycache__", ...}
if skipped_parts.intersection(path.parts):
```

App and page bundles create sibling environments named `.venv.agilab-linking`. That string never equals `.venv`, so 3701 third-party files — Cython, distutils shims, vendored libraries — were scanned as AGILAB source, yielding 296 `imports from distutils` and 88 `suppresses all warnings` violations that no repo change could ever fix.

## The fix

Match by prefix. Verified it narrows rather than silences:

| | Files scanned |
|---|---|
| before | 4913 |
| after | 1212 |
| excluded | 3701, **all** under `.venv.agilab-linking`, none repo source |

Both tests in the module pass.

## Why nobody noticed

`.venv*` is gitignored, so a clean CI checkout has nothing to trip over. The failure fires only for developers who have installed apps-pages locally — the normal working state. And this module is in the set CI never runs anyway.

## Context: a CI coverage gap

Sweeping the root `test/` suite turned up something structural. No workflow runs `test/` as a directory. `coverage.yml` and `windows-core-tests.yml` name component dirs (`src/agilab/core/*/test`, `src/agilab/lib/agi-web/test`), and `coverage.yml`'s dynamic shard plan (`tools/coverage_shard_plan.py`) enumerates root modules explicitly:

- **323** root `test/test_*.py` modules
- **108** referenced by the shard plan
- **215** run by no workflow at all

`coverage.yml` is also `push: branches: [main]` only — no `pull_request` trigger — so even the 108 do not gate PRs.

That is why `test_architecture_surface_contract`, `test_tools_surface_contract` and `test_package_split_contract` (fixed in #869 and #871) sat red for 4–12 days: none of the three is in the shard plan. Running the 215 ungated modules locally gives **2277 passed, 13 failed, 7 skipped**. This PR fixes 2 of the 13; the rest are being triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)