### PR TITLE
fix(ci): preserve cache pruning with setup-uv v9

### DIFF
--- a/.github/actions/setup-locked-python-tools/action.yml
+++ b/.github/actions/setup-locked-python-tools/action.yml
@@ -10,9 +10,10 @@ runs:
   using: composite
   steps:
     - name: Set up pinned uv
-      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         version: "0.10.7"
+        prune-cache: true
 
     - name: Install hash-locked Python tools
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Resolve Playwright version for browser cache key
         id: playwright-version
@@ -162,7 +163,8 @@ jobs:
           uv --preview-features extra-build-dependencies run --extra dev pytest -q -o addopts='' \
             test/test_package_split_contract.py \
             test/test_pypi_publish_workflow.py \
-            test/test_compat_shim_inventory.py
+            test/test_compat_shim_inventory.py \
+            test/test_github_actions_node_runtime.py
 
       - name: Validate app contract matrix
         run: |
@@ -254,6 +256,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Validate base CLI runtime
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -251,7 +251,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -118,7 +118,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -265,7 +265,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -368,7 +368,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -426,7 +426,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Define heartbeat helper
         shell: bash
@@ -121,6 +122,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Define heartbeat helper
         shell: bash
@@ -268,6 +270,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Prepare artifacts
         run: mkdir -p test-results
@@ -371,6 +374,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Run agi-web coverage
         run: |
@@ -429,6 +433,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Prepare artifacts
         run: mkdir -p test-results

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Setup uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -46,6 +46,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
           cache-dependency-glob: |
             uv.lock
             pyproject.toml

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
 
       - name: Verify managed docs/source mirror stamp
         env:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -71,6 +71,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Run strict AGILAB audit review
         env:
@@ -126,6 +127,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Resolve Playwright version for browser cache key
         id: playwright-version
@@ -194,6 +196,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Build sample external evidence payload
         run: |
@@ -270,6 +273,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Generate per-profile SBOM and vulnerability evidence
         run: |

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -68,7 +68,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -123,7 +123,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -191,7 +191,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -267,7 +267,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -78,7 +78,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 
@@ -315,7 +315,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -81,6 +81,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Resolve Playwright version for browser cache key
         id: playwright-version
@@ -318,6 +319,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Download UI robot shard artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
 

--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -47,6 +47,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.7"
+          prune-cache: true
 
       - name: Run Windows core test tracker command
         shell: pwsh

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -261,9 +261,16 @@ def test_windows_core_tests_workflow_matches_failure_tracker_command() -> None:
     assert "test-results/windows-core-tests.txt" in text
     assert "test-results/windows-core-tests.xml" in text
     assert "test-results/windows-core-warning-report.json" in text
-    assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in text
+    assert (
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        in text
+    )
     assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7" in text
-    assert "astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2" in text
+    assert (
+        "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0"
+        in text
+    )
+    assert "prune-cache: true" in text
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
 
 

--- a/test/test_ci_workflow_credential_boundaries.py
+++ b/test/test_ci_workflow_credential_boundaries.py
@@ -8,7 +8,7 @@ WORKFLOW_ROOT = Path(".github/workflows")
 LOCKED_TOOLS_ACTION = Path(".github/actions/setup-locked-python-tools/action.yml")
 LOCK_INTEGRITY_WORKFLOW = WORKFLOW_ROOT / "ci-tool-lock-integrity.yml"
 REQUIREMENTS_ROOT = Path(".github/requirements")
-SETUP_UV_SHA = "11f9893b081a58869d3b5fccaea48c9e9e46f990"
+SETUP_UV_SHA = "c771a70e6277c0a99b617c7a806ffedaca235ff9"
 
 LOCKED_TOOL_JOBS = {
     ("pypi-publish.yaml", "release-plan"): ".github/requirements/ci-publish.txt",
@@ -354,6 +354,7 @@ def test_locked_python_tools_action_uses_pinned_uv_and_hashed_installs() -> None
 
     assert steps[0]["uses"] == f"astral-sh/setup-uv@{SETUP_UV_SHA}"
     assert steps[0]["with"]["version"] == "0.10.7"
+    assert steps[0]["with"]["prune-cache"] is True
     install_step = steps[1]
     assert (
         'uv venv --python "$(command -v python)" "$environment_path"'

--- a/test/test_github_actions_node_runtime.py
+++ b/test/test_github_actions_node_runtime.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
 
-WORKFLOW_GLOBS = ("*.yml", "*.yaml")
-WORKFLOW_DIR = Path(".github/workflows")
+AUTOMATION_GLOBS = ("*.yml", "*.yaml")
+AUTOMATION_DIRS = (Path(".github/workflows"), Path(".github/actions"))
+SETUP_UV_SHA = "c771a70e6277c0a99b617c7a806ffedaca235ff9"
 
 NODE24_COMPATIBLE_ACTIONS = {
     "actions/cache/restore": {"v5"},
     "actions/cache/save": {"v5"},
-    "actions/checkout": {"v5", "v6"},
+    "actions/checkout": {"v5", "v6", "v7"},
     "actions/setup-python": {"v7"},
     "actions/upload-artifact": {"v6", "v7"},
     "actions/download-artifact": {"v7", "v8"},
@@ -18,16 +20,28 @@ NODE24_COMPATIBLE_ACTIONS = {
     "actions/upload-pages-artifact": {"v5"},
     "actions/deploy-pages": {"v5"},
     "actions/github-script": {"v8", "v9"},
-    "astral-sh/setup-uv": {"v7", "v8"},
+    "astral-sh/setup-uv": {"v7", "v8", "v9"},
     "codecov/codecov-action": {"v6"},
 }
 
 
-def _workflow_files() -> list[Path]:
+def _automation_files() -> list[Path]:
     files: list[Path] = []
-    for pattern in WORKFLOW_GLOBS:
-        files.extend(WORKFLOW_DIR.glob(pattern))
+    for directory in AUTOMATION_DIRS:
+        for pattern in AUTOMATION_GLOBS:
+            files.extend(directory.rglob(pattern))
     return sorted(files)
+
+
+def _step_mappings(value: object):
+    if isinstance(value, dict):
+        if "uses" in value:
+            yield value
+        for child in value.values():
+            yield from _step_mappings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _step_mappings(child)
 
 
 def test_github_actions_use_node24_compatible_major_versions() -> None:
@@ -35,8 +49,10 @@ def test_github_actions_use_node24_compatible_major_versions() -> None:
     uses_pattern = re.compile(r"uses:\s+([\w.-]+/[\w.-]+(?:/[\w.-]+)*)@([^\s#]+)")
     pinned_sha_pattern = re.compile(r"^[0-9a-f]{40}$")
 
-    for workflow in _workflow_files():
-        for line_no, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
+    for workflow in _automation_files():
+        for line_no, line in enumerate(
+            workflow.read_text(encoding="utf-8").splitlines(), start=1
+        ):
             match = uses_pattern.search(line)
             if not match:
                 continue
@@ -48,7 +64,9 @@ def test_github_actions_use_node24_compatible_major_versions() -> None:
             if pinned_sha_pattern.fullmatch(ref):
                 comment_match = re.search(r"#\s*(v\d+)\b", line)
                 if not comment_match:
-                    failures.append(f"{workflow}:{line_no}: {action}@{ref} should include a '# vN' major comment")
+                    failures.append(
+                        f"{workflow}:{line_no}: {action}@{ref} should include a '# vN' major comment"
+                    )
                     continue
                 effective_ref = comment_match.group(1)
             if effective_ref not in allowed_refs:
@@ -56,4 +74,29 @@ def test_github_actions_use_node24_compatible_major_versions() -> None:
                     f"{workflow}:{line_no}: {action}@{effective_ref} should use one of {sorted(allowed_refs)}"
                 )
 
+    assert failures == []
+
+
+def test_setup_uv_v9_preserves_cache_pruning() -> None:
+    failures: list[str] = []
+    setup_steps = 0
+    expected_use = f"astral-sh/setup-uv@{SETUP_UV_SHA}"
+
+    for automation_file in _automation_files():
+        document = yaml.safe_load(automation_file.read_text(encoding="utf-8"))
+        for step in _step_mappings(document):
+            uses = str(step["uses"])
+            if not uses.startswith("astral-sh/setup-uv@"):
+                continue
+            setup_steps += 1
+            if uses != expected_use:
+                failures.append(
+                    f"{automation_file}: expected {expected_use}, found {uses}"
+                )
+            if step.get("with", {}).get("prune-cache") is not True:
+                failures.append(
+                    f"{automation_file}: setup-uv must set prune-cache: true"
+                )
+
+    assert setup_steps > 0
     assert failures == []


### PR DESCRIPTION
## Summary

- upgrade every tracked `astral-sh/setup-uv` use to the pinned v9.0.0 commit
- preserve v8 cache behavior explicitly with `prune-cache: true` in all 17 workflow and composite-action steps
- make setup-uv pinning and cache-pruning coverage part of the always-running fast repository contracts

## Repro

The generated v9 upgrade omitted `prune-cache`. setup-uv v8 defaulted this input to `true`, while v9 defaults it to `false`, so accepting the generated patch as-is would stop post-job cache pruning and increase Actions cache usage. The generated patch also left the reusable composite action on v8.

Upstream evidence:
- [v8 action input default](https://github.com/astral-sh/setup-uv/blob/11f9893b081a58869d3b5fccaea48c9e9e46f990/action.yml)
- [v9 action input default](https://github.com/astral-sh/setup-uv/blob/c771a70e6277c0a99b617c7a806ffedaca235ff9/action.yml)
- [v9.0.0 release notes](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0)

## Root Cause

The action major changed the cache-pruning default. The dependency update replaced workflow `uses` lines without preserving that behavioral input, and the existing compatibility test scanned only `.github/workflows` while the fast CI contract did not run it.

## Regression Test

`test/test_github_actions_node_runtime.py` now recursively scans both workflows and composite actions, requires the exact v9 SHA, and requires `prune-cache: true` on every setup-uv step. It is included in the fast repository-contract job. The locked-tools composite action also has a focused assertion.

## Validation

- staged impact analysis: low risk
- focused workflow and automation contracts: 105 passed
- post-format focused rerun: 30 passed
- Ruff: passed
- diff/YAML contract checks: passed
- hosted checks: all required checks passed on Linux, macOS, and Windows
- public demo smoke: skipped by path policy
- full repository suite: not run locally; workflow-only scope is covered by the focused contracts and hosted matrix

## Review Evidence

- Reviewer: Codex sub-agent (exact model version unavailable)
- Role: read-only correctness and regression review
- Result: review-clean; no findings
- Findings addressed: not applicable
- Files edited by reviewer: none

## Agent Metadata

- Tokki version: 1.0.34
- Agent/runtime: codex-cli 0.145.0
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
