### PR TITLE
chore(badges): align coverage with CI

### DIFF
--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-core coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-core coverage: 91%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="59.0" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="59.0" y="14">agi-core coverage</text>
-  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="134.0" y="14">92%</text>
+  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">91%</text>
+  <text x="134.0" y="14">91%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-node coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-node coverage: 91%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="59.0" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="59.0" y="14">agi-node coverage</text>
-  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="134.0" y="14">92%</text>
+  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">91%</text>
+  <text x="134.0" y="14">91%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="134" height="20" role="img" aria-label="agilab coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="134" height="20" role="img" aria-label="agilab coverage: 94%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="51.0" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="51.0" y="14">agilab coverage</text>
-  <text x="118.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="118.0" y="14">95%</text>
+  <text x="118.0" y="15" fill="#010101" fill-opacity=".3">94%</text>
+  <text x="118.0" y="14">94%</text>
 </g>
 </svg>


### PR DESCRIPTION
Repairs the post-merge coverage badge drift reported by main workflow run [30266208534](https://github.com/ThalesGroup/agilab/actions/runs/30266208534).

## Summary

- Refresh `agi-node` from 92% to 91%.
- Refresh minimum-policy `agi-core` from 92% to 91%.
- Refresh weighted aggregate `agilab` from 95% to 94%.
- Leave the other four coverage badges unchanged.

## Repro

The `Verify committed badges are up to date` step regenerated badges from all five Ubuntu coverage XML artifacts, then failed `git diff --exit-code -- badges/` on exactly these three files.

## Root Cause

The committed SVG values no longer matched the current CI-canonical Cobertura results. Every coverage-producing job passed; only the stale generated badge check failed.

## Regression Test

- Downloaded all five XML artifacts from run `30266208534` and regenerated badges with the repository generator.
- Confirmed the staged patch matches the failed CI diff exactly.
- Confirmed independent generation yields `agi-node` 91.892% → 91%, `agi-core` minimum 91.892% → 91%, and `agilab` weighted 94.894% → 94%.

## Validation

- Coverage badge guard passed with `--changed-only --require-fresh-xml --allow-badge-only`.
- Badge generator and guard tests passed.
- Badge workflow parity profile passed after commit.
- Scope, provenance, and diff checks passed.
- Hosted checks: all required checks passed for head `c271eb5`; `root-tests` passed in 10m21s.

## Review Evidence

- GPT-5 Codex reviewer sub-agent, read-only: no merge blockers; verified the five downloaded XMLs, exact CI diff, aggregate policies, and unchanged badge set.

## Agent Metadata

- Tokki: 1.0.34
- Agent/runtime: codex-cli 0.145.0
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used