### PR TITLE
fix(tooling): fail closed on changed paths

### DIFF
--- a/src/agilab/reuse/reuse_catalog.py
+++ b/src/agilab/reuse/reuse_catalog.py
@@ -417,9 +417,9 @@ def _surface_path(repo_root: Path, kind: str, surface_id: str) -> Path:
 
 def git_changed_paths(repo_root: Path, *, base_ref: str = "HEAD") -> tuple[str, ...]:
     commands = (
-        ("git", "diff", "--name-only", "--diff-filter=ACMR", base_ref, "--"),
-        ("git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "--"),
-        ("git", "ls-files", "--others", "--exclude-standard"),
+        ("git", "diff", "--no-renames", "--name-only", "-z", base_ref, "--"),
+        ("git", "diff", "--no-renames", "--cached", "--name-only", "-z", "--"),
+        ("git", "ls-files", "--others", "--exclude-standard", "-z"),
     )
     paths: set[str] = set()
     for command in commands:
@@ -433,7 +433,7 @@ def git_changed_paths(repo_root: Path, *, base_ref: str = "HEAD") -> tuple[str, 
             )
         except (OSError, subprocess.CalledProcessError):
             continue
-        paths.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+        paths.update(path for path in result.stdout.split("\0") if path)
     return tuple(sorted(paths))
 
 

--- a/test/test_agent_skill_quality_guard.py
+++ b/test/test_agent_skill_quality_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -58,6 +59,64 @@ def test_scan_skill_reports_unreferenced_support_file_as_low(tmp_path: Path) -> 
 
     assert any(finding.rule == "unreferenced-support-file" for finding in findings)
     assert {finding.severity for finding in findings} == {"low"}
+
+
+def test_changed_skill_deleting_skill_md_blocks_quality_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    git("init", "--quiet")
+    git("config", "user.name", "AGILAB Test")
+    git("config", "user.email", "agilab-test@example.invalid")
+    skills_root = repo / ".codex/skills"
+    skill_dir = _write_skill(skills_root, "demo", "Use this workflow.")
+    references = skill_dir / "references"
+    references.mkdir()
+    (references / "guide.md").write_text("Supporting guidance.\n", encoding="utf-8")
+    git("add", ".codex/skills/demo")
+    git("commit", "--quiet", "-m", "add skill")
+    base = git("rev-parse", "HEAD")
+
+    (skill_dir / "SKILL.md").unlink()
+    git("add", "--all")
+    git("commit", "--quiet", "-m", "delete skill entrypoint")
+    monkeypatch.setattr(module, "REPO_ROOT", repo)
+
+    selected = module.changed_skill_dirs(base, [skills_root])
+    findings = module.scan(selected)
+
+    assert selected == [skill_dir.resolve()]
+    assert any(finding.rule == "missing-skill-md" for finding in findings)
+    assert (
+        module.main(
+            [
+                "--roots",
+                str(skills_root),
+                "--changed-only",
+                "--base-ref",
+                base,
+                "--external-validator",
+                "off",
+                "--fail-on",
+                "high",
+            ]
+        )
+        == 2
+    )
 
 
 def test_external_validator_can_be_required_or_skipped(monkeypatch) -> None:

--- a/test/test_agi_core_change_guard.py
+++ b/test/test_agi_core_change_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -13,6 +14,36 @@ assert spec is not None and spec.loader is not None
 guard = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = guard
 spec.loader.exec_module(guard)
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repo_with_protected_file(
+    tmp_path: Path,
+    *,
+    filename: str = "pyproject.toml",
+) -> tuple[Path, Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.name", "AGILAB Test")
+    _git(repo, "config", "user.email", "agilab-test@example.invalid")
+    _git(repo, "config", "core.quotePath", "true")
+    protected = repo / "src/agilab/core/agi-core" / filename
+    protected.parent.mkdir(parents=True)
+    protected.write_text("[project]\nname = 'agi-core'\n", encoding="utf-8")
+    _git(repo, "add", protected.relative_to(repo).as_posix())
+    _git(repo, "commit", "--quiet", "-m", "add protected file")
+    return repo, protected, _git(repo, "rev-parse", "HEAD")
 
 
 def test_protected_path_detection_is_limited_to_agi_core() -> None:
@@ -54,3 +85,50 @@ def test_other_actor_can_change_unprotected_paths() -> None:
     )
 
     assert result.passed
+
+
+def test_changed_files_between_includes_deleted_protected_path(tmp_path: Path) -> None:
+    repo, protected, base = _repo_with_protected_file(tmp_path)
+
+    protected.unlink()
+    _git(repo, "add", "--all")
+    _git(repo, "commit", "--quiet", "-m", "delete protected file")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    changed = guard.changed_files_between(base, head, repo_root=repo)
+    result = guard.evaluate(changed, actor="other-user")
+
+    assert changed == ("src/agilab/core/agi-core/pyproject.toml",)
+    assert not result.passed
+
+
+def test_changed_files_between_includes_protected_rename_source(tmp_path: Path) -> None:
+    repo, protected, base = _repo_with_protected_file(tmp_path)
+    moved = repo / "src/agilab/core/moved.py"
+    protected.rename(moved)
+    _git(repo, "add", "--all")
+    _git(repo, "commit", "--quiet", "-m", "move protected file")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    changed = guard.changed_files_between(base, head, repo_root=repo)
+    result = guard.evaluate(changed, actor="other-user")
+
+    assert changed == (
+        "src/agilab/core/agi-core/pyproject.toml",
+        "src/agilab/core/moved.py",
+    )
+    assert not result.passed
+
+
+def test_changed_files_between_preserves_unicode_protected_path(tmp_path: Path) -> None:
+    repo, protected, base = _repo_with_protected_file(tmp_path, filename="mód.py")
+    protected.write_text("VALUE = 2\n", encoding="utf-8")
+    _git(repo, "add", protected.relative_to(repo).as_posix())
+    _git(repo, "commit", "--quiet", "-m", "update unicode protected file")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    changed = guard.changed_files_between(base, head, repo_root=repo)
+    result = guard.evaluate(changed, actor="other-user")
+
+    assert changed == ("src/agilab/core/agi-core/mód.py",)
+    assert not result.passed

--- a/test/test_changed_file_detection.py
+++ b/test/test_changed_file_detection.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACKED_CHANGE_SELECTORS = (
+    "src/agilab/reuse/reuse_catalog.py",
+    "tools/agent_context_router.py",
+    "tools/agent_skill_quality_guard.py",
+    "tools/agi_core_change_guard.py",
+    "tools/coverage_badge_guard.py",
+    "tools/ga_regression_selector.py",
+    "tools/impact_validate.py",
+    "tools/maintenance_memory.py",
+    "tools/pypi_publish.py",
+    "tools/pre_push_changed_files.py",
+    "tools/release_plan.py",
+    "tools/skill_security_scan.py",
+    "tools/workflow_parity.py",
+    "tools/worktree_scope_guard.py",
+)
+SHELL_CHANGE_SELECTORS = ("tools/demo_agentic_agilab_workflow.sh",)
+
+
+@pytest.mark.parametrize("relative_path", TRACKED_CHANGE_SELECTORS)
+def test_tracked_change_selectors_do_not_filter_change_types(relative_path: str) -> None:
+    text = (ROOT / relative_path).read_text(encoding="utf-8")
+    diff_commands = [
+        command
+        for command in re.findall(
+            r'[\[(]\s*(?:"git",\s*)?"diff(?:-tree)?".*?[\])]',
+            text,
+            flags=re.DOTALL,
+        )
+        if '"--name-only"' in command
+    ]
+
+    assert diff_commands
+    assert "--diff-filter=" not in text
+    assert all('"--no-renames"' in command for command in diff_commands)
+    assert all('"-z"' in command for command in diff_commands)
+
+
+@pytest.mark.parametrize("relative_path", SHELL_CHANGE_SELECTORS)
+def test_shell_change_selectors_preserve_rename_sources(relative_path: str) -> None:
+    lines = (ROOT / relative_path).read_text(encoding="utf-8").splitlines()
+    diff_lines = [line for line in lines if "git diff" in line and "--name-only" in line]
+
+    assert diff_lines
+    assert all("--no-renames" in line for line in diff_lines)
+    assert all(" -z" in line for line in diff_lines)

--- a/test/test_ga_regression_selector.py
+++ b/test/test_ga_regression_selector.py
@@ -518,8 +518,8 @@ def test_collect_changed_files_uses_unstaged_and_untracked(monkeypatch) -> None:
 
     assert files == ["src/agilab/pipeline_ai.py", "test/test_new_selector.py"]
     assert calls == [
-        ["diff", "--name-only", "--diff-filter=ACMR", "HEAD~1"],
-        ["ls-files", "--others", "--exclude-standard"],
+        ["diff", "--no-renames", "--name-only", "-z", "HEAD~1"],
+        ["ls-files", "--others", "--exclude-standard", "-z"],
     ]
 
 
@@ -788,6 +788,7 @@ def test_discover_test_files_uses_git_and_caches_result(tmp_path: Path, monkeypa
             "--cached",
             "--others",
             "--exclude-standard",
+            "-z",
             "--",
             *module.DEFAULT_TEST_ROOTS,
         ]

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -184,7 +184,7 @@ def test_pre_push_records_use_default_branch_merge_base_for_topic_update():
         calls.append(list(args))
         if args[:2] == ["merge-base", "localsha"]:
             return "default-base-sha"
-        return "docs/source/getting-started.rst\nsrc/agilab/main_page.py"
+        return "docs/source/getting-started.rst\0src/agilab/main_page.py\0"
 
     stdin_text = "refs/heads/topic localsha refs/heads/topic remotesha\n"
     changed = pre_push_changed_files.changed_files_from_pre_push(stdin_text, git=fake_git)
@@ -194,8 +194,9 @@ def test_pre_push_records_use_default_branch_merge_base_for_topic_update():
         ["merge-base", "localsha", "origin/main"],
         [
             "diff",
+            "--no-renames",
             "--name-only",
-            "--diff-filter=ACMR",
+            "-z",
             "default-base-sha",
             "localsha",
         ],
@@ -207,7 +208,7 @@ def test_pre_push_records_keep_remote_sha_for_main_update():
 
     def fake_git(args):
         calls.append(list(args))
-        return "tools/release_plan.py"
+        return "tools/release_plan.py\0"
 
     stdin_text = "refs/heads/main localsha refs/heads/main remotesha\n"
     changed = pre_push_changed_files.changed_files_from_pre_push(
@@ -217,7 +218,7 @@ def test_pre_push_records_keep_remote_sha_for_main_update():
 
     assert changed == ("tools/release_plan.py",)
     assert calls == [
-        ["diff", "--name-only", "--diff-filter=ACMR", "remotesha", "localsha"]
+        ["diff", "--no-renames", "--name-only", "-z", "remotesha", "localsha"]
     ]
 
 

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -2349,7 +2349,7 @@ def test_git_commit_version_blocks_dirty_release_metadata_after_commit(monkeypat
     ]
 
 
-def test_ensure_docs_repo_release_ready_ignores_unrelated_dirty_paths(tmp_path, monkeypatch, capsys) -> None:
+def test_ensure_docs_repo_release_ready_rejects_unrelated_dirty_paths(tmp_path, monkeypatch) -> None:
     module = _load_pypi_publish()
 
     docs_repo = tmp_path / "thales_agilab"
@@ -2357,8 +2357,43 @@ def test_ensure_docs_repo_release_ready_ignores_unrelated_dirty_paths(tmp_path, 
 
     monkeypatch.setattr(module, "_git_status_paths", lambda _repo: ["docs/source/quick-start.rst", "apps/templates"])
 
-    assert module.ensure_docs_repo_release_ready(docs_repo) == ["docs/source/quick-start.rst"]
-    assert "ignoring them for docs release: apps/templates" in capsys.readouterr().out
+    with pytest.raises(SystemExit, match="mixed-scope release commit") as exc_info:
+        module.ensure_docs_repo_release_ready(docs_repo)
+
+    assert "apps/templates" in str(exc_info.value)
+
+
+def test_git_status_paths_preserves_cross_boundary_rename_source(tmp_path) -> None:
+    module = _load_pypi_publish()
+    docs_repo = tmp_path / "thales_agilab"
+    docs_repo.mkdir()
+
+    def git(*args: str) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=docs_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    git("init", "--quiet")
+    git("config", "user.name", "AGILAB Test")
+    git("config", "user.email", "agilab-test@example.invalid")
+    outside = docs_repo / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    git("add", "outside.txt")
+    git("commit", "--quiet", "-m", "initial")
+    (docs_repo / "docs/source").mkdir(parents=True)
+    git("mv", "outside.txt", "docs/source/moved.txt")
+
+    assert module._git_status_paths(docs_repo) == [
+        "docs/source/moved.txt",
+        "outside.txt",
+    ]
+    with pytest.raises(SystemExit, match="outside.txt"):
+        module.ensure_docs_repo_release_ready(docs_repo)
 
 
 def test_generate_docs_in_docs_repository_runs_in_docs_repo(monkeypatch, tmp_path) -> None:
@@ -2418,9 +2453,66 @@ def test_git_commit_docs_repository_pushes_only_release_managed_docs_paths(monke
 
     assert calls == [
         (["git", "add", "-A", "--", "docs/source/demos.rst", "docs/source/quick-start.rst"], docs_repo),
-        (["git", "commit", "-m", "docs(release): sync docs for 2026.04.21"], docs_repo),
+        (
+            [
+                "git",
+                "commit",
+                "-m",
+                "docs(release): sync docs for 2026.04.21",
+                "--",
+                "docs/source/demos.rst",
+                "docs/source/quick-start.rst",
+            ],
+            docs_repo,
+        ),
         (["git", "push", "origin", "main"], docs_repo),
     ]
+
+
+def test_git_commit_docs_repository_leaves_unrelated_staged_change_outside_commit(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    module = _load_pypi_publish()
+    docs_repo = tmp_path / "thales_agilab"
+    docs_repo.mkdir()
+
+    def git(*args: str) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=docs_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    git("init", "--quiet")
+    git("config", "user.name", "AGILAB Test")
+    git("config", "user.email", "agilab-test@example.invalid")
+    docs_path = docs_repo / "docs/source/release.rst"
+    docs_path.parent.mkdir(parents=True)
+    docs_path.write_text("old docs\n", encoding="utf-8")
+    outside = docs_repo / "outside.txt"
+    outside.write_text("old outside\n", encoding="utf-8")
+    git("add", "docs/source/release.rst", "outside.txt")
+    git("commit", "--quiet", "-m", "initial")
+
+    docs_path.write_text("new docs\n", encoding="utf-8")
+    outside.write_text("new outside\n", encoding="utf-8")
+    git("add", "outside.txt")
+
+    monkeypatch.setattr(module, "find_docs_repository", lambda: (docs_repo, "test"))
+    monkeypatch.setattr(
+        module,
+        "ensure_docs_repo_release_ready",
+        lambda _repo: ["docs/source/release.rst"],
+    )
+
+    module.git_commit_docs_repository("2026.04.21")
+
+    assert git("show", "--format=", "--name-only", "HEAD") == "docs/source/release.rst"
+    assert git("diff", "--cached", "--name-only") == "outside.txt"
 
 
 def test_docs_repository_commit_required_for_release_link_updates() -> None:
@@ -2508,7 +2600,7 @@ def test_create_and_push_tag_includes_docs_repo_when_requested(monkeypatch, tmp_
 
     monkeypatch.setattr(module, "find_apps_repository", lambda: (None, None))
     monkeypatch.setattr(module, "find_docs_repository", lambda: (docs_repo, "default"))
-    monkeypatch.setattr(module, "_git_status_paths", lambda _repo: ["apps/templates"])
+    monkeypatch.setattr(module, "_git_status_paths", lambda _repo: [])
     monkeypatch.setattr(module, "_tag_exists", lambda _tag, repo=None: False)
     monkeypatch.setattr(
         module,
@@ -2532,14 +2624,13 @@ def test_create_and_push_tag_blocks_uncommitted_docs_release_paths(monkeypatch, 
 
     monkeypatch.setattr(module, "find_apps_repository", lambda: (None, None))
     monkeypatch.setattr(module, "find_docs_repository", lambda: (docs_repo, "default"))
-    monkeypatch.setattr(module, "_git_status_paths", lambda _repo: ["docs/source/quick-start.rst", "apps/templates"])
+    monkeypatch.setattr(module, "_git_status_paths", lambda _repo: ["docs/source/quick-start.rst"])
     monkeypatch.setattr(module, "_create_tag_in_repo", lambda *_args, **_kwargs: None)
 
     try:
         module.create_and_push_tag("2026.04.21", include_apps_repo=False, include_docs_repo=True)
     except SystemExit as exc:
         assert "docs/source/quick-start.rst" in str(exc)
-        assert "apps/templates" not in str(exc)
     else:
         raise AssertionError("create_and_push_tag() should reject uncommitted docs release paths")
 

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -1243,25 +1243,27 @@ def test_git_changed_files_collects_unique_paths(monkeypatch) -> None:
     def _fake_run(argv, **_kwargs):
         calls.append(list(argv))
         if argv[:2] == ["git", "diff"] and argv[-1] == "HEAD":
-            return SimpleNamespace(returncode=0, stdout="tools/a.py\nshared.py\n")
-        if argv == ["git", "diff", "--name-only", "origin/main...HEAD"]:
-            return SimpleNamespace(returncode=0, stdout="tools/a.py\nshared.py\n")
-        if argv[:3] == ["git", "diff", "--cached"]:
+            return SimpleNamespace(returncode=0, stdout="tools/a.py\0shared.py\0")
+        if argv == ["git", "diff", "--no-renames", "--name-only", "-z", "origin/main...HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="tools/a.py\0shared.py\0")
+        if argv[:4] == ["git", "diff", "--no-renames", "--cached"]:
             return SimpleNamespace(returncode=1, stdout="")
-        return SimpleNamespace(returncode=0, stdout="shared.py\nuntracked.py\n")
+        return SimpleNamespace(returncode=0, stdout="shared.py\0untracked.py\0")
 
     monkeypatch.setattr(module.subprocess, "run", _fake_run)
 
     assert module._git_changed_files() == ["tools/a.py", "shared.py", "untracked.py"]
     assert calls == [
-        ["git", "diff", "--name-only", "HEAD"],
-        ["git", "diff", "--cached", "--name-only"],
-        ["git", "ls-files", "--others", "--exclude-standard"],
+        ["git", "diff", "--no-renames", "--name-only", "-z", "HEAD"],
+        ["git", "diff", "--no-renames", "--cached", "--name-only", "-z"],
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
     ]
 
     calls.clear()
     assert module._git_changed_files("origin/main") == ["tools/a.py", "shared.py"]
-    assert calls == [["git", "diff", "--name-only", "origin/main...HEAD"]]
+    assert calls == [
+        ["git", "diff", "--no-renames", "--name-only", "-z", "origin/main...HEAD"]
+    ]
 
 
 def test_installer_profile_adds_contract_check_when_app_path_is_provided() -> None:

--- a/test/test_worktree_scope_guard.py
+++ b/test/test_worktree_scope_guard.py
@@ -106,10 +106,10 @@ def test_changed_files_uses_staged_or_full_diff():
     def fake_git(args):
         calls.append(tuple(args))
         if "--cached" in args:
-            return "staged.py\n"
+            return "staged.py\0"
         if "ls-files" in args:
-            return "new.py\n"
-        return "dirty.py\n"
+            return "new.py\0"
+        return "dirty.py\0"
 
     assert scope_guard.changed_files(git=fake_git) == ("dirty.py", "staged.py")
     assert scope_guard.changed_files(staged=True, git=fake_git) == ("staged.py",)
@@ -118,6 +118,9 @@ def test_changed_files_uses_staged_or_full_diff():
         "new.py",
         "staged.py",
     )
+    assert all(not any(part.startswith("--diff-filter=") for part in call) for call in calls)
+    assert all("--no-renames" in call for call in calls if call[0] == "diff")
+    assert all("-z" in call for call in calls)
 
 
 def test_main_includes_untracked_by_default(capsys, monkeypatch):

--- a/tools/agent_context_router.py
+++ b/tools/agent_context_router.py
@@ -107,7 +107,7 @@ def _matches_any(path: str, patterns: Iterable[str]) -> bool:
 def _git_changed_files(*, staged: bool, changed: bool) -> list[str]:
     if not staged and not changed:
         return []
-    args = ["git", "diff", "--name-only"]
+    args = ["git", "diff", "--no-renames", "--name-only", "-z"]
     if staged:
         args.append("--cached")
     elif changed:
@@ -123,7 +123,7 @@ def _git_changed_files(*, staged: bool, changed: bool) -> list[str]:
     )
     if completed.returncode != 0:
         raise RuntimeError(completed.stderr.strip() or "git diff failed")
-    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return [path for path in completed.stdout.split("\0") if path]
 
 
 def load_skill_index(capabilities_path: Path = DEFAULT_CAPABILITIES) -> dict[str, dict[str, str]]:

--- a/tools/agent_skill_quality_guard.py
+++ b/tools/agent_skill_quality_guard.py
@@ -109,7 +109,16 @@ def changed_skill_dirs(base_ref: str, roots: Iterable[Path]) -> list[Path]:
     if not root_args:
         return []
     result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", *root_args],
+        [
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base_ref}...HEAD",
+            "--",
+            *root_args,
+        ],
         cwd=REPO_ROOT,
         text=True,
         capture_output=True,
@@ -118,11 +127,11 @@ def changed_skill_dirs(base_ref: str, roots: Iterable[Path]) -> list[Path]:
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git diff failed")
     dirs: set[Path] = set()
-    for raw in result.stdout.splitlines():
+    for raw in result.stdout.split("\0"):
         rel = Path(raw)
         if len(rel.parts) >= 3 and rel.parts[1] == "skills":
             candidate = REPO_ROOT / rel.parts[0] / rel.parts[1] / rel.parts[2]
-            if (candidate / "SKILL.md").exists():
+            if candidate.is_dir():
                 dirs.add(candidate.resolve())
     return sorted(dirs)
 

--- a/tools/agi_core_change_guard.py
+++ b/tools/agi_core_change_guard.py
@@ -62,16 +62,16 @@ def _run_git(args: Sequence[str], *, repo_root: Path = REPO_ROOT) -> str:
         stderr=subprocess.PIPE,
         text=True,
     )
-    return completed.stdout.strip()
+    return completed.stdout if "-z" in args else completed.stdout.strip()
 
 
 def changed_files_between(base_ref: str, head_ref: str, *, repo_root: Path = REPO_ROOT) -> tuple[str, ...]:
     base = EMPTY_TREE_SHA if normalize_actor(base_ref) == ZERO_SHA else base_ref
     output = _run_git(
-        ["diff", "--name-only", "--diff-filter=ACMR", base, head_ref],
+        ["diff", "--no-renames", "--name-only", "-z", base, head_ref],
         repo_root=repo_root,
     )
-    return tuple(line.strip() for line in output.splitlines() if line.strip())
+    return tuple(path for path in output.split("\0") if path)
 
 
 def read_changed_files(path: Path) -> tuple[str, ...]:

--- a/tools/coverage_badge_guard.py
+++ b/tools/coverage_badge_guard.py
@@ -148,21 +148,49 @@ def _normalize_paths(paths: Iterable[str]) -> list[str]:
     return sorted(normalized)
 
 
+def _split_git_paths(value: str) -> list[str]:
+    return [path for path in value.split("\0") if path]
+
+
 def changed_files(base: str | None, *, include_untracked: bool = False) -> list[str]:
     resolved_base = base or _default_base()
     changed: list[str] = []
-    diff_base = _run_git(["diff", "--name-only", "--diff-filter=ACMR", f"{resolved_base}...HEAD"], check=False)
+    diff_base = _run_git(
+        ["diff", "--no-renames", "--name-only", "-z", f"{resolved_base}...HEAD"],
+        check=False,
+    )
     if diff_base.returncode == 0:
-        changed.extend(diff_base.stdout.splitlines())
+        changed.extend(_split_git_paths(diff_base.stdout))
     else:
-        diff_base = _run_git(["diff", "--name-only", "--diff-filter=ACMR", resolved_base], check=False)
+        diff_base = _run_git(
+            ["diff", "--no-renames", "--name-only", "-z", resolved_base],
+            check=False,
+        )
         if diff_base.returncode == 0:
-            changed.extend(diff_base.stdout.splitlines())
+            changed.extend(_split_git_paths(diff_base.stdout))
 
-    changed.extend(_run_git(["diff", "--name-only", "--diff-filter=ACMR"], check=False).stdout.splitlines())
-    changed.extend(_run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"], check=False).stdout.splitlines())
+    changed.extend(
+        _split_git_paths(
+            _run_git(["diff", "--no-renames", "--name-only", "-z"], check=False).stdout
+        )
+    )
+    changed.extend(
+        _split_git_paths(
+            _run_git(
+                ["diff", "--no-renames", "--cached", "--name-only", "-z"],
+                check=False,
+            ).stdout
+        )
+    )
     if include_untracked:
-        changed.extend(_run_git(["ls-files", "--others", "--exclude-standard"], check=False).stdout.splitlines())
+        changed.extend(
+            _split_git_paths(
+                _run_git(
+                    ["ls-files", "--others", "--exclude-standard", "-z"],
+                    check=False,
+                ).stdout
+            )
+        )
     return _normalize_paths(changed)
 
 

--- a/tools/demo_agentic_agilab_workflow.sh
+++ b/tools/demo_agentic_agilab_workflow.sh
@@ -68,16 +68,16 @@ PY=("${UV[@]}" python)
 AGILAB=("${UV[@]}" agilab)
 
 CHANGED_FILES=()
-while IFS= read -r path; do
+while IFS= read -r -d '' path; do
   if [[ -n "$path" ]]; then
     CHANGED_FILES+=("$path")
   fi
 done < <(
   {
-    git diff --name-only
-    git diff --cached --name-only
-    git ls-files --others --exclude-standard
-  } | sort -u
+    git diff --no-renames --name-only -z
+    git diff --no-renames --cached --name-only -z
+    git ls-files --others --exclude-standard -z
+  } | sort -zu
 )
 
 ROUTER_FILES=()

--- a/tools/ga_regression_selector.py
+++ b/tools/ga_regression_selector.py
@@ -166,7 +166,7 @@ def _git_lines(args: Sequence[str]) -> list[str]:
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return [path for path in proc.stdout.split("\0") if path]
 
 
 def collect_changed_files(args: argparse.Namespace) -> list[str]:
@@ -174,10 +174,10 @@ def collect_changed_files(args: argparse.Namespace) -> list[str]:
         return impact_validate._normalize_paths(args.files)
     if args.staged:
         return impact_validate._normalize_paths(
-            _git_lines(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+            _git_lines(["diff", "--no-renames", "--cached", "--name-only", "-z"])
         )
-    tracked = _git_lines(["diff", "--name-only", "--diff-filter=ACMR", args.base])
-    untracked = _git_lines(["ls-files", "--others", "--exclude-standard"])
+    tracked = _git_lines(["diff", "--no-renames", "--name-only", "-z", args.base])
+    untracked = _git_lines(["ls-files", "--others", "--exclude-standard", "-z"])
     return impact_validate._normalize_paths([*tracked, *untracked])
 
 
@@ -229,7 +229,7 @@ def _discover_test_files_with_git(test_roots: Sequence[str]) -> list[str]:
     if not roots:
         return []
     paths = _git_lines(
-        ["ls-files", "--cached", "--others", "--exclude-standard", "--", *roots]
+        ["ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", *roots]
     )
     return sorted(
         {

--- a/tools/impact_validate.py
+++ b/tools/impact_validate.py
@@ -190,16 +190,18 @@ def _run_git(args: Sequence[str]) -> list[str]:
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return [path for path in proc.stdout.split("\0") if path]
 
 
 def _collect_changed_files(args: argparse.Namespace) -> list[str]:
     if args.files:
         return _normalize_paths(args.files)
     if args.staged:
-        return _normalize_paths(_run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]))
-    tracked = _run_git(["diff", "--name-only", "--diff-filter=ACMR", args.base])
-    untracked = _run_git(["ls-files", "--others", "--exclude-standard"])
+        return _normalize_paths(
+            _run_git(["diff", "--no-renames", "--cached", "--name-only", "-z"])
+        )
+    tracked = _run_git(["diff", "--no-renames", "--name-only", "-z", args.base])
+    untracked = _run_git(["ls-files", "--others", "--exclude-standard", "-z"])
     return _normalize_paths([*tracked, *untracked])
 
 

--- a/tools/maintenance_memory.py
+++ b/tools/maintenance_memory.py
@@ -194,7 +194,7 @@ def _run_git(args: Sequence[str], *, repo_root: Path = REPO_ROOT) -> list[str]:
     )
     if proc.returncode:
         raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return [path for path in proc.stdout.split("\0") if path]
 
 
 def _sources_from_notes(memory_root: Path) -> list[str]:
@@ -214,7 +214,7 @@ def _collect_sources(args: argparse.Namespace) -> list[str]:
         return _sources_from_notes(memory_root)
     if args.staged:
         return _normalize_paths(
-            _run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+            _run_git(["diff", "--no-renames", "--cached", "--name-only", "-z"])
         )
     return _normalize_paths(args.files or [])
 

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -113,11 +113,15 @@ def _run_git(args: Sequence[str]) -> str:
         stderr=subprocess.PIPE,
         text=True,
     )
-    return completed.stdout.strip()
+    return completed.stdout if "-z" in args else completed.stdout.strip()
 
 
 def _split_lines(value: str) -> tuple[str, ...]:
     return tuple(line.strip() for line in value.splitlines() if line.strip())
+
+
+def _split_git_paths(value: str) -> tuple[str, ...]:
+    return tuple(path for path in value.split("\0") if path)
 
 
 def _remote_default_base(git: GitRunner) -> str:
@@ -171,7 +175,13 @@ def changed_files_from_pre_push(stdin_text: str, *, git: GitRunner = _run_git) -
 
     if not records:
         base = _remote_default_base(git)
-        return tuple(sorted(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD"]))))
+        return tuple(
+            sorted(
+                _split_git_paths(
+                    git(["diff", "--no-renames", "--name-only", "-z", f"{base}...HEAD"])
+                )
+            )
+        )
 
     for _local_ref, local_sha, remote_ref, remote_sha in records:
         if local_sha == ZERO_SHA:
@@ -182,7 +192,11 @@ def changed_files_from_pre_push(stdin_text: str, *, git: GitRunner = _run_git) -
             remote_sha=remote_sha,
             git=git,
         )
-        changed.update(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", base, local_sha])))
+        changed.update(
+            _split_git_paths(
+                git(["diff", "--no-renames", "--name-only", "-z", base, local_sha])
+            )
+        )
     return tuple(sorted(changed))
 
 

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -1771,23 +1771,30 @@ def find_docs_repository() -> Tuple[pathlib.Path | None, str | None]:
 
 def _git_status_paths(repo: pathlib.Path) -> list[str]:
     proc = subprocess.run(
-        ["git", "status", "--porcelain"],
+        ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
         cwd=str(repo),
         check=True,
         text=True,
         capture_output=True,
     )
     paths: list[str] = []
-    for line in proc.stdout.splitlines():
-        if not line:
+    records = proc.stdout.split("\0")
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if not record:
             continue
-        path = line[3:]
-        if " -> " in path:
-            path = path.split(" -> ", 1)[1]
-        path = path.strip()
-        if path:
-            paths.append(path)
-    return paths
+        if len(record) < 4 or record[2] != " ":
+            raise RuntimeError(f"unexpected git status record: {record!r}")
+        status = record[:2]
+        paths.append(record[3:])
+        if "R" in status or "C" in status:
+            if index >= len(records) or not records[index]:
+                raise RuntimeError(f"missing source path for git status record: {record!r}")
+            paths.append(records[index])
+            index += 1
+    return sorted(set(paths))
 
 
 def _is_docs_repo_release_path(path: str) -> bool:
@@ -1824,13 +1831,22 @@ def _git_ahead_behind(repo: pathlib.Path, upstream: str) -> tuple[int, int]:
 
 def _git_commit_paths(repo: pathlib.Path, revision: str) -> list[str]:
     proc = subprocess.run(
-        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", revision],
+        [
+            "git",
+            "diff-tree",
+            "--no-renames",
+            "--no-commit-id",
+            "--name-only",
+            "-z",
+            "-r",
+            revision,
+        ],
         cwd=str(repo),
         check=True,
         text=True,
         capture_output=True,
     )
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return [path for path in proc.stdout.split("\0") if path]
 
 
 def _git_commit_summary(repo: pathlib.Path, revision: str) -> str:
@@ -1890,12 +1906,12 @@ def ensure_docs_repo_release_ready(repo: pathlib.Path) -> list[str]:
     if not dirty_paths:
         return []
     release_paths = [path for path in dirty_paths if _is_docs_repo_release_path(path)]
-    ignored_paths = [path for path in dirty_paths if not _is_docs_repo_release_path(path)]
-    if ignored_paths:
-        print(
-            "[git] docs repository has unrelated dirty paths outside release-managed docs/source/; "
-            "ignoring them for docs release: "
-            + ", ".join(sorted(ignored_paths))
+    unrelated_paths = [path for path in dirty_paths if not _is_docs_repo_release_path(path)]
+    if unrelated_paths:
+        raise SystemExit(
+            "ERROR: docs repository has dirty paths outside release-managed docs/source/; "
+            "refusing to create a mixed-scope release commit: "
+            + ", ".join(sorted(unrelated_paths))
         )
     return release_paths
 
@@ -2405,7 +2421,7 @@ def git_commit_docs_repository(chosen_version: str, *, push: bool = False):
     unique_paths = sorted(set(dirty_paths))
     run(["git", "add", "-A", "--", *unique_paths], cwd=docs_repo)
     diff_status = subprocess.run(
-        ["git", "diff", "--cached", "--quiet"],
+        ["git", "diff", "--cached", "--quiet", "--", *unique_paths],
         cwd=str(docs_repo),
         check=False,
     )
@@ -2413,7 +2429,17 @@ def git_commit_docs_repository(chosen_version: str, *, push: bool = False):
         print("[git] no staged docs repository changes to commit")
         return
 
-    run(["git", "commit", "-m", f"docs(release): sync docs for {chosen_version}"], cwd=docs_repo)
+    run(
+        [
+            "git",
+            "commit",
+            "-m",
+            f"docs(release): sync docs for {chosen_version}",
+            "--",
+            *unique_paths,
+        ],
+        cwd=docs_repo,
+    )
     print(f"[git] committed docs repository changes for {chosen_version}")
     if push:
         ensure_docs_repo_push_ready(docs_repo)

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -139,7 +139,7 @@ def changed_paths_since(repo_root: Path, base_ref: str) -> list[str]:
     """Return paths changed between a base ref and HEAD."""
 
     completed = subprocess.run(
-        ["git", "diff", "--name-only", base_ref, "HEAD"],
+        ["git", "diff", "--no-renames", "--name-only", "-z", base_ref, "HEAD"],
         cwd=repo_root,
         check=False,
         capture_output=True,
@@ -148,7 +148,7 @@ def changed_paths_since(repo_root: Path, base_ref: str) -> list[str]:
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout or "").strip()
         raise ValueError(f"Could not compute changed paths since {base_ref!r}: {detail}")
-    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return [path for path in completed.stdout.split("\0") if path]
 
 
 _EXACT_INTERNAL_DEP_RE = re.compile(

--- a/tools/skill_security_scan.py
+++ b/tools/skill_security_scan.py
@@ -56,7 +56,16 @@ def changed_skill_dirs(base_ref: str, roots: Iterable[Path]) -> list[Path]:
     if not root_args:
         return []
     result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", *root_args],
+        [
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base_ref}...HEAD",
+            "--",
+            *root_args,
+        ],
         cwd=REPO_ROOT,
         text=True,
         capture_output=True,
@@ -65,7 +74,7 @@ def changed_skill_dirs(base_ref: str, roots: Iterable[Path]) -> list[Path]:
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git diff failed")
     dirs: set[Path] = set()
-    for raw in result.stdout.splitlines():
+    for raw in result.stdout.split("\0"):
         rel = Path(raw)
         if len(rel.parts) >= 3 and rel.parts[1] == "skills":
             candidate = REPO_ROOT / rel.parts[0] / rel.parts[1] / rel.parts[2]

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -560,13 +560,15 @@ def select_ui_robot_profiles_for_files(paths: Sequence[str]) -> list[str]:
 def _git_changed_files(base: str = "") -> list[str]:
     commands = []
     if base:
-        commands.append(["git", "diff", "--name-only", f"{base}...HEAD"])
+        commands.append(
+            ["git", "diff", "--no-renames", "--name-only", "-z", f"{base}...HEAD"]
+        )
     else:
         commands.extend(
             [
-                ["git", "diff", "--name-only", "HEAD"],
-                ["git", "diff", "--cached", "--name-only"],
-                ["git", "ls-files", "--others", "--exclude-standard"],
+                ["git", "diff", "--no-renames", "--name-only", "-z", "HEAD"],
+                ["git", "diff", "--no-renames", "--cached", "--name-only", "-z"],
+                ["git", "ls-files", "--others", "--exclude-standard", "-z"],
             ]
         )
     paths: list[str] = []
@@ -582,8 +584,7 @@ def _git_changed_files(base: str = "") -> list[str]:
         )
         if completed.returncode != 0:
             continue
-        for line in completed.stdout.splitlines():
-            path = line.strip()
+        for path in completed.stdout.split("\0"):
             if path and path not in seen:
                 paths.append(path)
                 seen.add(path)

--- a/tools/worktree_scope_guard.py
+++ b/tools/worktree_scope_guard.py
@@ -88,11 +88,11 @@ def _run_git(args: Sequence[str]) -> str:
         stderr=subprocess.PIPE,
         text=True,
     )
-    return completed.stdout.strip()
+    return completed.stdout
 
 
-def _split_lines(value: str) -> tuple[str, ...]:
-    return tuple(line.strip() for line in value.splitlines() if line.strip())
+def _split_git_paths(value: str) -> tuple[str, ...]:
+    return tuple(path for path in value.split("\0") if path)
 
 
 def changed_files(
@@ -101,15 +101,19 @@ def changed_files(
     include_untracked: bool = False,
     git: GitRunner = _run_git,
 ) -> tuple[str, ...]:
-    """Return changed paths from the local worktree, ignoring deleted-only noise."""
+    """Return changed paths, including tracked deletions and type changes."""
     paths: set[str] = set()
     if staged:
-        paths.update(_split_lines(git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])))
+        paths.update(
+            _split_git_paths(git(["diff", "--no-renames", "--cached", "--name-only", "-z"]))
+        )
     else:
-        paths.update(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR"])))
-        paths.update(_split_lines(git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])))
+        paths.update(_split_git_paths(git(["diff", "--no-renames", "--name-only", "-z"])))
+        paths.update(
+            _split_git_paths(git(["diff", "--no-renames", "--cached", "--name-only", "-z"]))
+        )
     if include_untracked:
-        paths.update(_split_lines(git(["ls-files", "--others", "--exclude-standard"])))
+        paths.update(_split_git_paths(git(["ls-files", "--others", "--exclude-standard", "-z"])))
     return tuple(sorted(paths))
 
 


### PR DESCRIPTION
## Summary

- make every tracked changed-path selector fail closed for deletions, type changes, rename sources, Unicode paths, and embedded newlines
- preserve both sides of cross-boundary renames with `--no-renames` and parse NUL-delimited Git output
- make docs-repository release commits reject mixed-scope dirt and commit only the exact release pathspec
- keep changed skill directories visible when `SKILL.md` is deleted so the existing critical quality rule can block

## Repro

A pure deletion was invisible to the previous `--diff-filter=ACMR` selectors. Rename detection could also collapse `src/agilab/core/agi-core/protected.py -> src/agilab/core/moved.py` to only the unprotected destination, and quoted Unicode paths did not match the protected prefix. In the docs repository, a pre-staged unrelated deletion was absorbed by the plain release commit after docs paths were staged.

## Root Cause

Changed-path discovery used a restrictive status filter, rename-aware name-only output, and newline parsing. Downstream release and skill selectors then discarded source-side or missing-entrypoint evidence, while the docs release commit was not pathspec-scoped.

## Fix

Git-backed path selectors now use unfiltered `--no-renames --name-only -z` output and NUL parsing. The docs publisher uses porcelain-v1 NUL parsing, rejects unrelated dirty paths, scopes its staged diff and commit to release paths, and preserves rename endpoints. The skill quality selector retains any remaining changed skill directory.

## Regression Test

Real temporary Git repositories cover protected-file deletion, rename-out, quoted Unicode paths, cross-boundary docs renames, unrelated pre-staged docs-repo changes, and deletion of a skill `SKILL.md`. A repository contract test enforces the changed-path command semantics across all consumers.

## Validation

- Full `./dev test`: passed
- Focused impacted suites: passed
- `./dev scope --staged`: passed
- `./dev impact`: passed
- `git diff --check`, shell syntax, and focused Ruff checks: passed
- `./dev lint`: not green on current `main`; its fixed profile reports 129 pre-existing findings in files outside this diff
- GitHub checks: passed (root tests, Windows core, Python 3.12/3.14, clean installs on Ubuntu/macOS/Windows, policy, locks, and GitGuardian)
- `public-demo-smoke`: GitHub skipped as not applicable to this diff

## Review Evidence

- Codex sub-agent `review_badge_refresh` (model: unknown; review-only, no edits) independently audited the patch, identified deletion/rename/Unicode/release/skill fail-open cases, and confirmed no blocking findings remain after fixes.
- Codex sub-agent `installer_stat_fix_plan` (model: unknown; review-only, no edits) audited security surfaces and reported separate follow-up findings outside this PR.
- Codex sub-agent `review_installer_stat_fix` (model: unknown; review-only, no edits) audited correctness surfaces and reported separate follow-up findings outside this PR.

## Agent Metadata

- Tokki: 1.0.35
- Agent/runtime: Codex CLI 0.145.0
- Model: unknown
- Reasoning effort: unknown
- `/fast` mode: not used
