### PR TITLE
feat(mlflow): register FCAS worker handoffs on manager

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/manager_mlflow_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/manager_mlflow_support.py
@@ -1,0 +1,169 @@
+"""Manager-side MLflow registration for shared worker handoffs."""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+from agi_env import mlflow_store
+
+logger = logging.getLogger(__name__)
+HANDOFF_SCHEMA = "agilab.mlflow.handoff.v1"
+
+
+def _workflow_root(agi_cls: Any) -> Path | None:
+    raw = str(getattr(agi_cls, "_workers_data_path", "") or "").strip()
+    if not raw:
+        return None
+    root = Path(raw).expanduser()
+    if not root.is_absolute():
+        root = Path(getattr(agi_cls.env, "home_abs", Path.home())) / root
+    return root.resolve()
+
+
+def _safe_relative(root: Path, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = Path(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    resolved = (root / candidate).resolve()
+    if not resolved.is_relative_to(root):
+        return None
+    return resolved
+
+
+def _numeric_metrics(payload: Any) -> dict[str, float]:
+    if not isinstance(payload, dict):
+        return {}
+    metrics: dict[str, float] = {}
+    for key, value in payload.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        numeric = float(value)
+        if math.isfinite(numeric):
+            metrics[str(key)] = numeric
+    return metrics
+
+
+def _tracking_paths(env: Any) -> tuple[Path, Path, str]:
+    tracking_dir = mlflow_store.resolve_mlflow_tracking_dir(env)
+    tracking_dir.mkdir(parents=True, exist_ok=True)
+    db_path = mlflow_store.resolve_mlflow_backend_db(tracking_dir, default_db_name="mlflow.db")
+    artifact_dir = mlflow_store.resolve_mlflow_artifact_dir(
+        tracking_dir,
+        default_artifact_dir="artifacts",
+    )
+    tracking_uri = mlflow_store.sqlite_uri_for_path(
+        db_path,
+        os_name=os.name,
+    )
+    return db_path, artifact_dir, tracking_uri
+
+
+def _register_handoff(path: Path, *, env: Any, mlflow: Any, log: Any) -> dict[str, Any]:
+    root = path.parent.resolve()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != HANDOFF_SCHEMA:
+        return {"status": "skipped", "reason": "unsupported_schema"}
+    handoff_key = str(payload.get("handoff_key") or "").strip()
+    if not handoff_key:
+        return {"status": "skipped", "reason": "missing_handoff_key"}
+
+    marker = root / "mlflow_manager_registration.json"
+    if marker.exists():
+        try:
+            previous = json.loads(marker.read_text(encoding="utf-8"))
+            if previous.get("status") == "logged" and previous.get("handoff_key") == handoff_key:
+                return {"status": "skipped", "reason": "already_logged", "run_id": previous.get("run_id")}
+        except (OSError, TypeError, ValueError):
+            pass
+
+    _db_path, artifact_dir, tracking_uri = _tracking_paths(env)
+    previous_uri = mlflow.get_tracking_uri()
+    try:
+        mlflow.set_tracking_uri(tracking_uri)
+        experiment_name = str(payload.get("experiment") or "AGILAB SB3 Trainer")
+        experiment = mlflow.get_experiment_by_name(experiment_name)
+        if experiment is None:
+            experiment_id = mlflow.create_experiment(
+                experiment_name,
+                artifact_location=artifact_dir.as_uri(),
+            )
+        else:
+            experiment_id = experiment.experiment_id
+        mlflow.set_experiment(experiment_name)
+
+        existing = mlflow.search_runs(
+            experiment_ids=[str(experiment_id)],
+            filter_string=f"tags.`agilab.handoff_key` = '{handoff_key}'",
+        )
+        if not existing.empty:
+            run_id = str(existing.iloc[0]["run_id"])
+            status = {"status": "skipped", "reason": "already_logged", "run_id": run_id}
+        else:
+            params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+            metrics = _numeric_metrics(payload.get("metrics"))
+            with mlflow.start_run(run_name=str(payload.get("run_name") or payload.get("trainer_name") or "worker")) as run:
+                mlflow.set_tags(
+                    {
+                        "agilab.handoff_key": handoff_key,
+                        "agilab.trainer_name": str(payload.get("trainer_name") or ""),
+                        "agilab.registration": "manager",
+                    }
+                )
+                for key, value in params.items():
+                    mlflow.log_param(str(key), value)
+                for key, value in metrics.items():
+                    mlflow.log_metric(key, value)
+                mlflow.log_artifact(str(path))
+                for value in payload.get("artifacts", []):
+                    artifact = _safe_relative(root, value)
+                    if artifact is None or not artifact.is_file():
+                        log.warning("Skipping invalid MLflow handoff artifact %r from %s", value, path)
+                        continue
+                    mlflow.log_artifact(str(artifact))
+                run_id = run.info.run_id
+            status = {"status": "logged", "run_id": run_id}
+    finally:
+        mlflow.set_tracking_uri(previous_uri)
+
+    marker_payload = {
+        "schema": HANDOFF_SCHEMA,
+        "handoff_key": handoff_key,
+        "tracking_uri": tracking_uri,
+        **status,
+    }
+    marker.write_text(json.dumps(marker_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return status
+
+
+def register_shared_mlflow_handoffs(agi_cls: Any, *, log: Any = logger) -> list[dict[str, Any]]:
+    """Register completed worker handoffs in the manager's local MLflow store."""
+
+    root = _workflow_root(agi_cls)
+    if root is None or not root.is_dir():
+        return []
+    try:
+        import mlflow  # type: ignore
+    except (ImportError, TypeError):
+        log.info("MLflow handoffs present but MLflow is not installed on the manager")
+        return []
+
+    results: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("mlflow_handoff.json")):
+        try:
+            resolved = path.resolve()
+            if not resolved.is_relative_to(root):
+                continue
+            results.append(_register_handoff(resolved, env=agi_cls.env, mlflow=mlflow, log=log))
+        except (OSError, TypeError, ValueError, RuntimeError) as exc:
+            log.warning("MLflow handoff registration failed for %s: %s", path, exc)
+            results.append({"status": "error", "path": str(path), "message": str(exc)})
+    return results
+
+
+__all__ = ["HANDOFF_SCHEMA", "register_shared_mlflow_handoffs"]

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -15,6 +15,7 @@ from zipfile import BadZipFile, ZipFile
 import psutil
 
 from agi_cluster.agi_distributor import background_jobs_support, deployment_remote_support
+from agi_cluster.agi_distributor.runtime import manager_mlflow_support
 from agi_cluster.agi_distributor.runtime.worker_endpoint_support import worker_host
 from agi_env.process_support import project_virtualenv_script_path
 
@@ -871,6 +872,13 @@ async def distribute(
 
     for worker, worker_log in worker_logs.items():
         log.info(f"\n=== Worker {worker} logs ===\n{worker_log}")
+
+    handoff_results = manager_mlflow_support.register_shared_mlflow_handoffs(
+        agi_cls,
+        log=log,
+    )
+    if handoff_results:
+        log.info("Registered %s shared MLflow handoff(s) on the manager", len(handoff_results))
 
     runtime = time_fn() - started_at
     log.info(f"{env.mode2str(agi_cls._mode)} {runtime}")

--- a/src/agilab/core/agi-cluster/test/test_manager_mlflow_support.py
+++ b/src/agilab/core/agi-cluster/test/test_manager_mlflow_support.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from agi_cluster.agi_distributor.runtime.manager_mlflow_support import (
+    register_shared_mlflow_handoffs,
+)
+
+
+class _Runs:
+    empty = True
+
+
+class _Run:
+    info = SimpleNamespace(run_id="manager-run-1")
+
+
+class _Mlflow:
+    def __init__(self):
+        self.uri = "file:///previous"
+        self.logged_artifacts: list[str] = []
+
+    def get_tracking_uri(self):
+        return self.uri
+
+    def set_tracking_uri(self, uri):
+        self.uri = uri
+
+    def get_experiment_by_name(self, name):
+        return None
+
+    def create_experiment(self, name, artifact_location):
+        return "7"
+
+    def set_experiment(self, name):
+        return None
+
+    def search_runs(self, experiment_ids, filter_string):
+        return _Runs()
+
+    def start_run(self, run_name):
+        class _Context:
+            def __enter__(self):
+                return _Run()
+
+            def __exit__(self, *_args):
+                return False
+
+        return _Context()
+
+    def set_tags(self, tags):
+        return None
+
+    def log_param(self, key, value):
+        return None
+
+    def log_metric(self, key, value):
+        return None
+
+    def log_artifact(self, path):
+        self.logged_artifacts.append(path)
+
+
+def test_manager_registers_shared_handoff_and_is_idempotent(tmp_path, monkeypatch):
+    share = tmp_path / "workflow"
+    output = share / "sb3_trainer" / "pipeline" / "trainer_fcas_routing_path_ac"
+    output.mkdir(parents=True)
+    artifact = output / "summary_metrics.json"
+    artifact.write_text("{}", encoding="utf-8")
+    handoff = {
+        "schema": "agilab.mlflow.handoff.v1",
+        "handoff_key": "stable-key",
+        "trainer_name": "fcas_routing_path_ac",
+        "experiment": "FCAS Routing Models",
+        "run_name": "fcas_routing_path_ac",
+        "params": {"seed": 42},
+        "metrics": {"served_bandwidth_ratio": 0.75},
+        "artifacts": ["summary_metrics.json", "../outside.txt"],
+    }
+    (output / "mlflow_handoff.json").write_text(json.dumps(handoff), encoding="utf-8")
+
+    fake_mlflow = _Mlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+    agi = SimpleNamespace(
+        _workers_data_path=str(share),
+        env=SimpleNamespace(
+            home_abs=str(tmp_path),
+            MLFLOW_TRACKING_DIR=str(tmp_path / "manager-mlflow"),
+        ),
+    )
+
+    first = register_shared_mlflow_handoffs(agi)
+    second = register_shared_mlflow_handoffs(agi)
+
+    assert first == [{"status": "logged", "run_id": "manager-run-1"}]
+    assert second == [{"status": "skipped", "reason": "already_logged", "run_id": "manager-run-1"}]
+    assert str(artifact) in fake_mlflow.logged_artifacts
+    marker = json.loads((output / "mlflow_manager_registration.json").read_text(encoding="utf-8"))
+    assert marker["status"] == "logged"


### PR DESCRIPTION
## Summary
- register FCAS MLflow handoffs on the manager after distributed execution
- keep worker tracking independent of the manager's local SQLite store
- add manager-registration regression coverage

## Repro
Distributed FCAS workers can write shared handoff files, but cannot reliably write the manager-local MLflow database directly.

## Root Cause
MLflow registration was worker-side and depended on network reachability to the manager tracking endpoint.

## Regression Test
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/agi-cluster/test`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/test`

## Review Evidence
No sub-agent review was used. Local focused shared-core tests passed.

## Agent Metadata
- Tokki: 1.0.35
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used

Direct user instruction to push and merge this MLflow implementation authorizes the shared agi-cluster change; the blast radius is manager-side distributed MLflow registration.