### PR TITLE
Fix persisted cluster-share startup recovery

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -687,6 +687,7 @@ def handle_cluster_share_startup_error(
     env_file_path: Path,
     args: argparse.Namespace,
     ports: BootstrapPorts,
+    handle_data_root_failure: Callable[..., bool] | None = None,
 ) -> None:
     """Render cluster-share recovery controls before stopping startup."""
     app_name = startup_active_app_name(streamlit, args, ports)
@@ -711,6 +712,14 @@ def handle_cluster_share_startup_error(
             if callable(rerun):
                 rerun()
             return
+
+    if handle_data_root_failure is not None:
+        handle_data_root_failure(
+            exc,
+            agi_env_cls=ports.agi_env_cls,
+            env_file_path=env_file_path,
+            render_intro=False,
+        )
 
     stop = getattr(streamlit, "stop", None)
     if callable(stop):
@@ -771,8 +780,6 @@ def bootstrap_page_environment(
                 verbose=1,
             )
         except RuntimeError as exc:
-            if handle_data_root_failure(exc, agi_env_cls=ports.agi_env_cls):
-                return BootstrapResult(env=None, handled_recovery=True)
             if is_cluster_share_startup_error(exc):
                 handle_cluster_share_startup_error(
                     streamlit=streamlit,
@@ -780,7 +787,14 @@ def bootstrap_page_environment(
                     env_file_path=env_file_path,
                     args=args,
                     ports=ports,
+                    handle_data_root_failure=handle_data_root_failure,
                 )
+                return BootstrapResult(env=None, handled_recovery=True)
+            if handle_data_root_failure(
+                exc,
+                agi_env_cls=ports.agi_env_cls,
+                env_file_path=env_file_path,
+            ):
                 return BootstrapResult(env=None, handled_recovery=True)
             raise
 

--- a/src/agilab/about_page/env_editor.py
+++ b/src/agilab/about_page/env_editor.py
@@ -137,32 +137,55 @@ def _refresh_share_dir(env: Any, new_value: str) -> None:
         st.warning(f"AGI_CLUSTER_SHARE update saved but data directory is still unreachable: {exc}")
 
 
-def _handle_data_root_failure(exc: Exception, *, agi_env_cls: Any) -> bool:
+def _handle_data_root_failure(
+    exc: Exception,
+    *,
+    agi_env_cls: Any,
+    env_file_path: Path | None = None,
+    render_intro: bool = True,
+) -> bool:
     """Render a recovery UI when the AGI share directory is unavailable."""
     message = str(exc)
     if "AGI_CLUSTER_SHARE" not in message and "data directory" not in message:
         return False
 
     agi_env_cls._ensure_defaults()
+    active_env_file_path = (env_file_path or ENV_FILE_PATH).expanduser()
+    try:
+        persisted_value = _load_env_file_map(active_env_file_path).get("AGI_CLUSTER_SHARE", "")
+    except (OSError, RuntimeError, TypeError, ValueError):
+        persisted_value = ""
     current_value = (
         st.session_state.get("agi_share_path_override_input")
         or agi_env_cls.envars.get("AGI_CLUSTER_SHARE")
         or os.environ.get("AGI_CLUSTER_SHARE")
+        or persisted_value
         or agi_env_cls.envars.get("AGI_LOCAL_SHARE")
         or ""
     )
-    share_dir_path = Path(str(current_value)).expanduser()
+    if current_value:
+        try:
+            share_dir_path: Path | None = _resolve_share_dir_path(
+                str(current_value), home_path=Path(agi_env_cls.home_abs)
+            )
+        except ValueError:
+            share_dir_path = Path(str(current_value)).expanduser()
+    else:
+        share_dir_path = None
 
-    st.error(
-        "AGILAB cannot reach the configured AGI share directory. "
-        "Mount the expected path or override `AGI_CLUSTER_SHARE` before continuing."
-    )
-    st.code(message)
+    if render_intro:
+        st.error(
+            "AGILAB cannot reach the configured AGI share directory. "
+            "Mount the expected path or override `AGI_CLUSTER_SHARE` before continuing."
+        )
+        st.code(message)
     st.info(
-        f"The value is persisted in `{ENV_FILE_PATH}` so CLI and Streamlit stay in sync. "
+        f"The value is persisted in `{active_env_file_path}` so CLI and Streamlit stay in sync. "
         "Point it to a mounted folder (local path or NFS mount) that AGILAB can create files in."
     )
-    st.write(f"Current setting: `{current_value}` (expands to `{share_dir_path}`)")
+    current_display = str(current_value) if current_value else "not configured"
+    expanded_display = str(share_dir_path) if share_dir_path is not None else "not configured"
+    st.write(f"Current setting: `{current_display}` (expands to `{expanded_display}`)")
 
     key = "agi_share_path_override_input"
     if key not in st.session_state or not st.session_state[key]:

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -977,9 +977,20 @@ def _refresh_share_dir(env: Any, new_value: str) -> None:
     _about_env_editor._refresh_share_dir(env, new_value)
 
 
-def _handle_data_root_failure(exc: Exception, *, agi_env_cls: Any) -> bool:
+def _handle_data_root_failure(
+    exc: Exception,
+    *,
+    agi_env_cls: Any,
+    env_file_path: Path | None = None,
+    render_intro: bool = True,
+) -> bool:
     _sync_env_editor_module()
-    return _about_env_editor._handle_data_root_failure(exc, agi_env_cls=agi_env_cls)
+    return _about_env_editor._handle_data_root_failure(
+        exc,
+        agi_env_cls=agi_env_cls,
+        env_file_path=env_file_path or ENV_FILE_PATH,
+        render_intro=render_intro,
+    )
 
 
 def _strip_dotenv_quotes(value: str) -> str:

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -1765,6 +1765,7 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
     monkeypatch, tmp_path
 ):
     bootstrap = about_agilab._about_bootstrap
+    generic_recovery_calls: list[dict[str, object]] = []
 
     class FailingAgiEnv:
         def __init__(self, *_args, **_kwargs):
@@ -1780,13 +1781,17 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
     fake_st = _FakeStreamlit()
     fake_st.query_params["active_app"] = "flight_telemetry_project"
 
+    def render_share_override(exc, **kwargs):
+        generic_recovery_calls.append({"exc": exc, **kwargs})
+        return True
+
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
         load_env_file_map=lambda _path: {},
         logger=object(),
         apply_active_app_request=lambda *_args: False,
-        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        handle_data_root_failure=render_share_override,
         refresh_env_from_file=lambda _env: None,
         clean_openai_key=lambda value: value,
         store_cluster_credentials=lambda *_args, **_kwargs: True,
@@ -1801,6 +1806,12 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
         body for kind, body in fake_st.events if kind == "button"
     ]
     assert "AGI_CLUSTER_SHARE" in error_message
+    assert len(generic_recovery_calls) == 1
+    recovery_call = generic_recovery_calls[0]
+    assert isinstance(recovery_call["exc"], RuntimeError)
+    assert recovery_call["agi_env_cls"] is FailingAgiEnv
+    assert recovery_call["env_file_path"] == tmp_path / ".env"
+    assert recovery_call["render_intro"] is False
 
 
 def test_bootstrap_cluster_share_startup_error_can_disable_stale_app_setting(tmp_path):
@@ -3535,6 +3546,42 @@ def test_handle_data_root_failure_renders_share_recovery_paths(tmp_path, monkeyp
     assert FakeAgiEnv.saved[-1] == ("AGI_CLUSTER_SHARE", "newshare")
     assert fake_st.session_state["first_run"] is True
     assert ("rerun", "") in fake_st.events
+
+
+def test_handle_data_root_failure_reads_persisted_share_when_runtime_state_empty(
+    tmp_path, monkeypatch
+):
+    env_file = tmp_path / ".agilab/.env"
+    env_file.parent.mkdir(parents=True)
+    persisted_share = tmp_path / "clustershare/agi"
+    env_file.write_text(f"AGI_CLUSTER_SHARE={persisted_share}\n", encoding="utf-8")
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(about_agilab, "st", fake_st)
+    monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
+    monkeypatch.delenv("AGI_LOCAL_SHARE", raising=False)
+
+    class EmptyRuntimeAgiEnv:
+        home_abs = tmp_path
+        envars: dict[str, str] = {}
+
+        @classmethod
+        def _ensure_defaults(cls):
+            return None
+
+        @classmethod
+        def set_env_var(cls, _key: str, _value: str):
+            raise AssertionError("the recovery form was not submitted")
+
+    assert about_agilab._handle_data_root_failure(
+        RuntimeError("data directory missing"),
+        agi_env_cls=EmptyRuntimeAgiEnv,
+        env_file_path=env_file,
+    )
+
+    expected_status = f"Current setting: `{persisted_share}` (expands to `{persisted_share}`)"
+    assert ("write", expected_status) in fake_st.events
+    assert fake_st.session_state["agi_share_path_override_input"] == str(persisted_share)
+    assert all("(expands to `.`)" not in body for _kind, body in fake_st.events)
 
 
 def test_render_env_editor_saves_updates_and_redacted_preview(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- route persisted cluster-share startup failures through the cluster-specific recovery before the generic data-root handler
- keep both recovery actions available: disable stale cluster mode or override `AGI_CLUSTER_SHARE`
- read the displayed override from the actual managed `.env` file when runtime and process state are empty
- render an unconfigured value explicitly instead of converting an empty string to `.`

## User impact

When cluster mode starts with an unavailable persisted share, ABOUT now shows the configured path from the managed environment file and exposes the intended recovery controls. CLI and Streamlit continue to use the same persisted source of truth.

## Repro

1. Persist `AGI_CLUSTER_SHARE=/Users/agi/clustershare/agi` in the managed `.env`.
2. Start with empty Streamlit session state, empty `AgiEnv.envars`, and no process override.
3. Let environment construction raise the cluster-mode writable-share startup error.
4. Before this fix, the broad handler intercepted the error, hid the cluster-specific action, and displayed a blank current setting that expanded to `.`.

## Root Cause

`bootstrap_page_environment` invoked the broad data-root recovery before checking for the more specific cluster-share startup failure. That broad recovery accepted any message containing `AGI_CLUSTER_SHARE`, but sourced its display only from session, class, and process state—not the persisted environment file named in the diagnostic.

## Regression Test

- the bootstrap regression now proves the cluster-specific recovery renders first and then composes the override form without a duplicate introduction
- a polluted-environment regression clears class/process state, persists `AGI_CLUSTER_SHARE` in a temporary managed `.env`, and verifies the real path initializes the form and never renders `.`

## Validation

- focused ABOUT/bootstrap slice: 185 passed
- `agi-gui` workflow-parity profile: passed all seven coverage chunks
- changed-file Ruff check: passed; the pre-existing `main_page.py` E402 bootstrap import exception was excluded
- `git diff --check`: passed
- GitHub required checks: passed, including root tests, Windows core tests, both Python compatibility jobs, all clean-install platforms, repository policy, and GitGuardian
- public demo smoke: GitHub skipped by workflow path policy; public demo assets are not changed
- `./dev lint`: default shortcut currently reports 129 pre-existing Ruff findings in untouched security/evidence/tooling targets; none of those targets are changed by this PR

## Review Evidence

- scope/root-cause inventory: GPT-5 Codex sub-agent, read-only, no file edits; identified the handler-order and persisted-value defects
- final diff review: GPT-5 Codex sub-agent, read-only, no file edits; no findings
- findings addressed: yes; the inventory findings are covered by implementation and regressions

## Agent Metadata

- Tokki: 1.0.35
- agent/runtime: OpenAI Codex CLI 0.145.0
- model: GPT-5
- reasoning effort: unknown
- `/fast` mode: not used
