### PR TITLE
fix(ci): require supply-chain evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,24 @@ jobs:
             --screenshot-dir frontend-smoke-screenshots \
             | tee frontend-smoke-robot.json
 
+      - name: Generate base supply-chain evidence
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run \
+            python tools/profile_supply_chain_scan.py \
+            --profile base \
+            --output-dir test-results/supply-chain \
+            --run
+
       - name: Validate security hygiene report
         run: |
           set -euo pipefail
-          python tools/security_hygiene_report.py --output security-hygiene.json --compact
+          python tools/security_hygiene_report.py \
+            --pip-audit-json test-results/supply-chain/base/pip-audit.json \
+            --sbom-json test-results/supply-chain/base/sbom-cyclonedx.json \
+            --require-scan-artifacts \
+            --output security-hygiene.json \
+            --compact
 
       - name: Upload local proof artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -229,6 +243,7 @@ jobs:
             frontend-smoke-robot.json
             frontend-smoke-screenshots/**
             security-hygiene.json
+            test-results/supply-chain/base/**
           if-no-files-found: ignore
 
       - name: Confirm extended test policy

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -218,6 +218,33 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "--head-ref \"$AGILAB_CORE_CHANGE_HEAD\"" in text
 
 
+def test_ci_security_hygiene_uses_required_supply_chain_artifacts() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    scan_step = text.split("- name: Generate base supply-chain evidence", 1)[1].split(
+        "- name: Validate security hygiene report", 1
+    )[0]
+    security_step = text.split("- name: Validate security hygiene report", 1)[1].split(
+        "- name: Upload local proof artifacts", 1
+    )[0]
+
+    assert "tools/profile_supply_chain_scan.py" in scan_step
+    assert "--profile base" in scan_step
+    assert "--output-dir test-results/supply-chain" in scan_step
+    assert "--run" in scan_step
+    assert "--pip-audit-json test-results/supply-chain/base/pip-audit.json" in security_step
+    assert "--sbom-json test-results/supply-chain/base/sbom-cyclonedx.json" in security_step
+    assert "--require-scan-artifacts" in security_step
+    assert text.index("Generate base supply-chain evidence") < text.index(
+        "Validate security hygiene report"
+    )
+
+    upload_step = text.split("- name: Upload local proof artifacts", 1)[1].split(
+        "- name: Confirm extended test policy", 1
+    )[0]
+    assert "security-hygiene.json" in upload_step
+    assert "test-results/supply-chain/base/**" in upload_step
+
+
 def test_root_pytest_discovers_all_existing_core_package_tests() -> None:
     config = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
     pytest_options = config["tool"]["pytest"]["ini_options"]

--- a/test/test_security_hygiene_report.py
+++ b/test/test_security_hygiene_report.py
@@ -28,6 +28,10 @@ def test_security_hygiene_report_passes_static_contract(tmp_path: Path) -> None:
 
     assert report["schema"] == "agilab.security_hygiene.v1"
     assert report["status"] == "pass"
+    assert report["summary"]["passed"] == report["summary"]["check_count"] - 2
+    assert report["summary"]["failed"] == 0
+    assert report["summary"]["skipped"] == 2
+    assert report["summary"]["scan_artifacts_required"] is False
     assert report["summary"]["pip_audit_artifact_provided"] is False
     assert report["summary"]["sbom_artifact_provided"] is False
     assert "pip-audit --format json" in report["summary"]["pip_audit_command"]
@@ -78,6 +82,8 @@ def test_security_hygiene_report_passes_static_contract(tmp_path: Path) -> None:
     assert checks["installers_expose_dry_run_profiles"]["status"] == "pass"
     assert checks["central_command_runner_shell_fallback_is_syntax_gated"]["status"] == "pass"
     assert checks["github_actions_are_pinned_to_commit_sha"]["status"] == "pass"
+    assert checks["pip_audit_artifact_valid"]["status"] == "skipped"
+    assert checks["sbom_artifact_valid"]["status"] == "skipped"
 
     output = tmp_path / "security-hygiene.json"
     assert module.main(["--output", str(output), "--compact"]) == 0
@@ -218,13 +224,63 @@ def test_security_hygiene_report_accepts_scan_artifacts(tmp_path: Path) -> None:
         repo_root=Path.cwd(),
         pip_audit_json=pip_audit,
         sbom_json=sbom,
+        require_scan_artifacts=True,
     )
 
     assert report["status"] == "pass"
+    assert report["summary"]["passed"] == report["summary"]["check_count"]
+    assert report["summary"]["failed"] == 0
+    assert report["summary"]["skipped"] == 0
+    assert report["summary"]["scan_artifacts_required"] is True
     checks = {check["id"]: check for check in report["checks"]}
+    assert checks["pip_audit_artifact_valid"]["status"] == "pass"
     assert checks["pip_audit_artifact_valid"]["details"]["provided"] is True
+    assert checks["pip_audit_artifact_valid"]["details"]["required"] is True
     assert checks["pip_audit_artifact_valid"]["details"]["vulnerability_count"] == 0
+    assert checks["sbom_artifact_valid"]["status"] == "pass"
     assert checks["sbom_artifact_valid"]["details"]["component_count"] == 1
+
+
+def test_security_hygiene_report_rejects_missing_required_scan_artifacts() -> None:
+    module = _load_module()
+
+    report = module.build_report(repo_root=Path.cwd(), require_scan_artifacts=True)
+
+    assert report["status"] == "fail"
+    assert report["summary"]["failed"] == 2
+    assert report["summary"]["skipped"] == 0
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["pip_audit_artifact_valid"]["status"] == "fail"
+    assert checks["sbom_artifact_valid"]["status"] == "fail"
+    assert module.main(["--require-scan-artifacts", "--compact"]) == 1
+
+
+def test_security_hygiene_report_rejects_vulnerable_audit_artifact(tmp_path: Path) -> None:
+    module = _load_module()
+    pip_audit = tmp_path / "pip-audit.json"
+    pip_audit.write_text(
+        json.dumps({"dependencies": [{"name": "agilab", "vulns": [{"id": "GHSA-test"}]}]}),
+        encoding="utf-8",
+    )
+
+    report = module.build_report(repo_root=Path.cwd(), pip_audit_json=pip_audit)
+
+    checks = {check["id"]: check for check in report["checks"]}
+    assert report["status"] == "fail"
+    assert checks["pip_audit_artifact_valid"]["status"] == "fail"
+    assert checks["pip_audit_artifact_valid"]["details"]["vulnerability_count"] == 1
+
+
+def test_security_hygiene_report_rejects_non_cyclonedx_sbom(tmp_path: Path) -> None:
+    module = _load_module()
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text(json.dumps({"components": []}), encoding="utf-8")
+
+    report = module.build_report(repo_root=Path.cwd(), sbom_json=sbom)
+
+    checks = {check["id"]: check for check in report["checks"]}
+    assert report["status"] == "fail"
+    assert checks["sbom_artifact_valid"]["status"] == "fail"
 
 
 def test_security_hygiene_report_rejects_invalid_scan_artifact(tmp_path: Path) -> None:
@@ -246,3 +302,4 @@ def test_security_hygiene_main_prints_pretty_json(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema"] == "agilab.security_hygiene.v1"
     assert payload["status"] == "pass"
+    assert payload["summary"]["skipped"] == 2

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -56,24 +56,32 @@ def _check_result(
     }
 
 
-def _optional_check_result(
+def _artifact_check_result(
     check_id: str,
     label: str,
     provided: bool,
     valid: bool,
     summary: str,
     *,
+    required: bool,
     evidence: Sequence[str] = (),
     details: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    status = "pass" if (not provided or valid) else "fail"
+    if not provided:
+        status = "fail" if required else "skipped"
+    else:
+        status = "pass" if valid else "fail"
     return {
         "id": check_id,
         "label": label,
         "status": status,
         "summary": summary,
         "evidence": list(evidence),
-        "details": {"provided": provided, **(details or {})},
+        "details": {
+            "provided": provided,
+            "required": required,
+            **(details or {}),
+        },
     }
 
 
@@ -749,6 +757,7 @@ def build_report(
     repo_root: Path = REPO_ROOT,
     pip_audit_json: Path | None = None,
     sbom_json: Path | None = None,
+    require_scan_artifacts: bool = False,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     security_path = repo_root / "SECURITY.md"
@@ -827,17 +836,29 @@ def build_report(
 
     pip_audit_provided, pip_audit_payload, pip_audit_error = _read_json_artifact(pip_audit_json)
     vulnerability_count = _pip_audit_vulnerability_count(pip_audit_payload)
+    pip_audit_valid = pip_audit_error is None and vulnerability_count == 0
+    if not pip_audit_provided:
+        pip_audit_summary = (
+            "required pip-audit artifact was not provided"
+            if require_scan_artifacts
+            else "pip-audit artifact not provided; check skipped"
+        )
+    elif pip_audit_error is not None or vulnerability_count is None:
+        pip_audit_summary = "pip-audit artifact is invalid"
+    elif vulnerability_count:
+        pip_audit_summary = (
+            f"pip-audit artifact reports {vulnerability_count} known vulnerabilities"
+        )
+    else:
+        pip_audit_summary = "pip-audit artifact is valid"
     checks.append(
-        _optional_check_result(
+        _artifact_check_result(
             "pip_audit_artifact_valid",
-            "pip-audit artifact is valid when provided",
+            "pip-audit artifact is present and vulnerability-free",
             pip_audit_provided,
-            pip_audit_error is None and vulnerability_count is not None,
-            "pip-audit artifact is valid"
-            if pip_audit_provided and pip_audit_error is None
-            else "pip-audit artifact not provided; command contract is documented"
-            if not pip_audit_provided
-            else "pip-audit artifact is invalid",
+            pip_audit_valid,
+            pip_audit_summary,
+            required=require_scan_artifacts,
             evidence=[str(pip_audit_json)] if pip_audit_json is not None else [],
             details={
                 "error": pip_audit_error,
@@ -851,22 +872,27 @@ def build_report(
     sbom_valid = (
         sbom_error is None
         and isinstance(sbom_payload, dict)
-        and (
-            sbom_payload.get("bomFormat") == "CycloneDX"
-            or component_count is not None
-        )
+        and sbom_payload.get("bomFormat") == "CycloneDX"
+        and component_count is not None
     )
+    if not sbom_provided:
+        sbom_summary = (
+            "required SBOM artifact was not provided"
+            if require_scan_artifacts
+            else "SBOM artifact not provided; check skipped"
+        )
+    elif sbom_valid:
+        sbom_summary = "CycloneDX SBOM artifact is valid"
+    else:
+        sbom_summary = "SBOM artifact is invalid"
     checks.append(
-        _optional_check_result(
+        _artifact_check_result(
             "sbom_artifact_valid",
-            "SBOM artifact is valid when provided",
+            "CycloneDX SBOM artifact is present and valid",
             sbom_provided,
             sbom_valid,
-            "CycloneDX SBOM artifact is valid"
-            if sbom_provided and sbom_valid
-            else "SBOM artifact not provided; command contract is documented"
-            if not sbom_provided
-            else "SBOM artifact is invalid",
+            sbom_summary,
+            required=require_scan_artifacts,
             evidence=[str(sbom_json)] if sbom_json is not None else [],
             details={
                 "error": sbom_error,
@@ -875,7 +901,9 @@ def build_report(
         )
     )
 
-    failed = [check for check in checks if check["status"] != "pass"]
+    passed = [check for check in checks if check["status"] == "pass"]
+    failed = [check for check in checks if check["status"] == "fail"]
+    skipped = [check for check in checks if check["status"] == "skipped"]
     return {
         "report": "AGILAB security hygiene report",
         "schema": SCHEMA,
@@ -888,8 +916,10 @@ def build_report(
         },
         "summary": {
             "check_count": len(checks),
-            "passed": len(checks) - len(failed),
+            "passed": len(passed),
             "failed": len(failed),
+            "skipped": len(skipped),
+            "scan_artifacts_required": require_scan_artifacts,
             "pip_audit_artifact_provided": pip_audit_provided,
             "sbom_artifact_provided": sbom_provided,
             "pip_audit_command": PIP_AUDIT_COMMAND,
@@ -905,6 +935,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--pip-audit-json", type=Path, default=None)
     parser.add_argument("--sbom-json", type=Path, default=None)
+    parser.add_argument(
+        "--require-scan-artifacts",
+        action="store_true",
+        help="Fail when pip-audit or CycloneDX SBOM evidence is missing.",
+    )
     parser.add_argument("--output", type=Path, default=None)
     parser.add_argument("--compact", action="store_true")
     return parser
@@ -915,6 +950,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     report = build_report(
         pip_audit_json=args.pip_audit_json,
         sbom_json=args.sbom_json,
+        require_scan_artifacts=args.require_scan_artifacts,
     )
     if args.output is not None:
         args.output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- distinguish absent optional pip-audit/SBOM evidence as skipped instead of passed
- implement the documented `--require-scan-artifacts` fail-closed mode
- reject vulnerable pip-audit payloads and non-CycloneDX SBOM payloads
- generate, validate, and upload base-profile supply-chain evidence in repo-guardrails CI

## Repro

`tools/security_hygiene_report.py --compact` reported 24/24 checks passed even though both artifact summaries said `provided: false`. The repo-guardrails workflow invoked the report without generating or passing either artifact.

## Root Cause

`_optional_check_result` mapped both “not provided” and “provided and valid” to `pass`. The CI workflow also had no supply-chain scan step, so the two checks could never fail there.

## Regression Test

- missing optional artifacts now produce 22 passed / 2 skipped
- required mode fails when either artifact is missing
- vulnerable pip-audit JSON fails
- malformed/non-CycloneDX SBOM JSON fails
- clean required artifacts pass
- CI contract test verifies scan generation, required artifact arguments, ordering, and upload paths

## Validation

- Focused pytest: 32 passed
- Ruff: passed on all changed Python files
- Real base-profile scan: zero vulnerabilities; valid CycloneDX SBOM
- Required security report: 24/24 passed, 0 skipped
- Staged impact analysis: low risk; required focused slice passed
- GitHub required checks: all passed, including the new repo-guardrails security gate, root tests, Windows core tests, Python 3.12/3.14 compatibility, clean public installs, and GitGuardian
- Full local repository suite: not run; the impact tool selected the focused workflow/report slice and GitHub's mandatory root-test suite passed
- Public demo smoke: GitHub skipped as not applicable to pull-request events; it runs only on schedule or manual dispatch

## Review Evidence

- GPT-5 sub-agent `security_gate_design`: read-only final diff review; no blocking findings; did not edit files
- GPT-5 sub-agent `release_tag_intent`: read-only live/repository evidence review; confirmed the dual release-tag spelling is intentional and separately exact-bound by release-proof checks; did not edit files
- All review findings were addressed or required no change

## Agent Metadata

- Tokki: 1.0.35
- Agent/runtime: Codex CLI 0.145.0
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
