### PR TITLE
fix(mlflow): make disabled tracking side-effect free

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/manager_mlflow_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/manager_mlflow_support.py
@@ -14,6 +14,26 @@ logger = logging.getLogger(__name__)
 HANDOFF_SCHEMA = "agilab.mlflow.handoff.v1"
 
 
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _request_enables_mlflow(value: Any) -> bool:
+    if isinstance(value, dict):
+        if "mlflow_enabled" in value and _truthy(value.get("mlflow_enabled")):
+            return True
+        return any(_request_enables_mlflow(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_request_enables_mlflow(item) for item in value)
+    return False
+
+
 def _workflow_root(agi_cls: Any) -> Path | None:
     raw = str(getattr(agi_cls, "_workers_data_path", "") or "").strip()
     if not raw:
@@ -144,8 +164,21 @@ def _register_handoff(path: Path, *, env: Any, mlflow: Any, log: Any) -> dict[st
 def register_shared_mlflow_handoffs(agi_cls: Any, *, log: Any = logger) -> list[dict[str, Any]]:
     """Register completed worker handoffs in the manager's local MLflow store."""
 
+    if not _request_enables_mlflow(getattr(agi_cls, "_args", None)):
+        return []
     root = _workflow_root(agi_cls)
     if root is None or not root.is_dir():
+        return []
+    handoff_paths: list[Path] = []
+    for path in sorted(root.rglob("mlflow_handoff.json")):
+        try:
+            resolved = path.resolve()
+        except OSError as exc:
+            log.warning("Failed to resolve MLflow handoff %s: %s", path, exc)
+            continue
+        if resolved.is_relative_to(root):
+            handoff_paths.append(resolved)
+    if not handoff_paths:
         return []
     try:
         import mlflow  # type: ignore
@@ -154,12 +187,9 @@ def register_shared_mlflow_handoffs(agi_cls: Any, *, log: Any = logger) -> list[
         return []
 
     results: list[dict[str, Any]] = []
-    for path in sorted(root.rglob("mlflow_handoff.json")):
+    for path in handoff_paths:
         try:
-            resolved = path.resolve()
-            if not resolved.is_relative_to(root):
-                continue
-            results.append(_register_handoff(resolved, env=agi_cls.env, mlflow=mlflow, log=log))
+            results.append(_register_handoff(path, env=agi_cls.env, mlflow=mlflow, log=log))
         except (OSError, TypeError, ValueError, RuntimeError) as exc:
             log.warning("MLflow handoff registration failed for %s: %s", path, exc)
             results.append({"status": "error", "path": str(path), "message": str(exc)})

--- a/src/agilab/core/agi-cluster/test/test_manager_mlflow_support.py
+++ b/src/agilab/core/agi-cluster/test/test_manager_mlflow_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import sys
 from pathlib import Path
@@ -64,6 +65,45 @@ class _Mlflow:
         self.logged_artifacts.append(path)
 
 
+def test_manager_does_not_scan_or_import_mlflow_when_request_is_disabled(
+    tmp_path,
+    monkeypatch,
+):
+    share = tmp_path / "workflow"
+    share.mkdir()
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "mlflow":
+            raise AssertionError("MLflow must not be imported without a handoff")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    def forbidden_rglob(_self, _pattern):
+        raise AssertionError("Disabled MLflow must not scan the workflow tree")
+
+    monkeypatch.setattr(Path, "rglob", forbidden_rglob)
+    agi = SimpleNamespace(
+        _workers_data_path=str(share),
+        _args={
+            "_agilab_run_stages": [
+                {
+                    "name": "fcas_routing_path_ac",
+                    "args": {
+                        "mlflow_enabled": False,
+                        "tracking_backend": "mlflow",
+                        "mlflow_tracking_uri": "http://192.0.2.10:5000",
+                    },
+                }
+            ]
+        },
+        env=SimpleNamespace(home_abs=str(tmp_path)),
+    )
+
+    assert register_shared_mlflow_handoffs(agi) == []
+
+
 def test_manager_registers_shared_handoff_and_is_idempotent(tmp_path, monkeypatch):
     share = tmp_path / "workflow"
     output = share / "sb3_trainer" / "pipeline" / "trainer_fcas_routing_path_ac"
@@ -86,6 +126,14 @@ def test_manager_registers_shared_handoff_and_is_idempotent(tmp_path, monkeypatc
     monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
     agi = SimpleNamespace(
         _workers_data_path=str(share),
+        _args={
+            "_agilab_run_stages": [
+                {
+                    "name": "fcas_routing_path_ac",
+                    "args": {"mlflow_enabled": True},
+                }
+            ]
+        },
         env=SimpleNamespace(
             home_abs=str(tmp_path),
             MLFLOW_TRACKING_DIR=str(tmp_path / "manager-mlflow"),


### PR DESCRIPTION
## Summary
- make manager-side MLflow handoff discovery conditional on an explicit enabled request
- avoid MLflow import and workflow-tree scanning when tracking is disabled
- preserve safe, idempotent handoff registration when enabled

## Repro
A distributed run with MLflow disabled could still invoke manager handoff discovery after worker execution. The manager would scan the workflow root and could process stale handoffs.

## Root Cause
The manager registration hook ran unconditionally after distributed work and only gated the optional import after filesystem discovery.

## Regression Test
- pytest -q src/agilab/core/agi-cluster/test/test_manager_mlflow_support.py
- pytest -q src/agilab/core/test
- changed-file Ruff check passed

## Review Evidence
Self-review by Codex; no sub-agents used. Findings were addressed in the scoped regression tests.

## Agent Metadata
- Tokki: 1.0.36
- Agent/runtime: Codex, version unavailable
- Model: unknown
- Reasoning effort: unknown
- /fast mode: not used

## Skipped Checks
- Browser/UI validation: not applicable to this shared-core runtime change.
