### PR TITLE
fix(env): report the real source of AGI_CLUSTER_SHARE in mount errors

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/runtime/runtime_bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/runtime_bootstrap_support.py
@@ -8,6 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+CLUSTER_SHARE_ORIGIN_ENV_FILE = "env_file"
+CLUSTER_SHARE_ORIGIN_PROCESS_ENV = "process_env"
+CLUSTER_SHARE_ORIGIN_DEFAULT = "default"
+
+
 @dataclass(frozen=True)
 class ShareRuntimeConfig:
     local_share: str
@@ -120,14 +125,20 @@ def resolve_share_runtime_config(
         or environ.get("AGI_LOCAL_SHARE")
         or default_local_share(environ=environ)
     )
-    cluster_share = (
-        envars.get("AGI_CLUSTER_SHARE")
-        or environ.get("AGI_CLUSTER_SHARE")
-        or default_cluster_share(environ=environ)
-    )
+    if envars.get("AGI_CLUSTER_SHARE"):
+        cluster_share = envars.get("AGI_CLUSTER_SHARE")
+        cluster_share_origin = CLUSTER_SHARE_ORIGIN_ENV_FILE
+    elif environ.get("AGI_CLUSTER_SHARE"):
+        cluster_share = environ.get("AGI_CLUSTER_SHARE")
+        cluster_share_origin = CLUSTER_SHARE_ORIGIN_PROCESS_ENV
+    else:
+        cluster_share = default_cluster_share(environ=environ)
+        cluster_share_origin = CLUSTER_SHARE_ORIGIN_DEFAULT
 
     share_dir_override = clean_envar_value_fn(envars, "AGI_CLUSTER_SHARE", fallback_to_process=True)
     if share_dir_override is not None:
+        if share_dir_override != cluster_share:
+            cluster_share_origin = CLUSTER_SHARE_ORIGIN_ENV_FILE
         cluster_share = share_dir_override
         try:
             envars["AGI_CLUSTER_SHARE"] = share_dir_override
@@ -147,6 +158,7 @@ def resolve_share_runtime_config(
         cluster_enabled=bool(cluster_enabled),
         env_path=env_path,
         home_path=home_path,
+        cluster_share_origin=cluster_share_origin,
     )
     return ShareRuntimeConfig(
         local_share=local_share,

--- a/src/agilab/core/agi-env/src/agi_env/shares/share_mount_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/shares/share_mount_support.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Callable, Mapping
 
 from agi_env.project.app_settings_support import read_app_settings
+from agi_env.runtime.runtime_bootstrap_support import (
+    CLUSTER_SHARE_ORIGIN_DEFAULT,
+    CLUSTER_SHARE_ORIGIN_ENV_FILE,
+    CLUSTER_SHARE_ORIGIN_PROCESS_ENV,
+)
 
 SETTINGS_READ_EXCEPTIONS = (OSError, ValueError)
 SETTINGS_LOOKUP_EXCEPTIONS = (OSError, TypeError, ValueError)
@@ -169,6 +174,27 @@ def is_mounted(path: str, *, home_path: Path) -> bool:
         return False
 
 
+def describe_cluster_share_origin(origin: str | None, *, env_path: Path) -> str:
+    """Describe where the active ``AGI_CLUSTER_SHARE`` value came from.
+
+    The share path is resolved from the env file, the process environment, or a
+    per-user default.  Reporting ``env=<env file>`` for every origin sends
+    operators to a file that may not define the key at all, so name the actual
+    source instead.
+    """
+
+    if origin == CLUSTER_SHARE_ORIGIN_ENV_FILE:
+        return f"set in env file {env_path}"
+    if origin == CLUSTER_SHARE_ORIGIN_PROCESS_ENV:
+        return "set in the process environment (AGI_CLUSTER_SHARE)"
+    if origin == CLUSTER_SHARE_ORIGIN_DEFAULT:
+        return (
+            "not configured; using the per-user default. Set AGI_CLUSTER_SHARE in "
+            f"{env_path} to override"
+        )
+    return f"env={env_path}"
+
+
 def resolve_share_path(
     *,
     cluster_share: str,
@@ -176,16 +202,18 @@ def resolve_share_path(
     cluster_enabled: bool,
     env_path: Path,
     home_path: Path,
+    cluster_share_origin: str | None = None,
 ) -> str:
     """Choose the active AGILAB share path or raise with a fail-fast message."""
 
     cluster_candidate = _abs_path(cluster_share, home_path=home_path)
     local_candidate = _abs_path(local_share, home_path=home_path)
+    origin_hint = describe_cluster_share_origin(cluster_share_origin, env_path=env_path)
 
     if cluster_enabled and os.path.normpath(cluster_candidate) == os.path.normpath(local_candidate):
         raise RuntimeError(
             "Cluster mode requires AGI_CLUSTER_SHARE to be distinct from AGI_LOCAL_SHARE. "
-            f"Both resolve to {cluster_candidate!r}; env={env_path}"
+            f"Both resolve to {cluster_candidate!r}; {origin_hint}"
         )
 
     mounted = is_mounted(cluster_candidate, home_path=home_path)
@@ -195,6 +223,6 @@ def resolve_share_path(
     if cluster_enabled and not mounted:
         raise RuntimeError(
             "Cluster mode requires AGI_CLUSTER_SHARE to be mounted and writable. "
-            f"Configured AGI_CLUSTER_SHARE={cluster_candidate!r} is not usable; env={env_path}"
+            f"Configured AGI_CLUSTER_SHARE={cluster_candidate!r} is not usable; {origin_hint}"
         )
     return local_share

--- a/src/agilab/core/agi-env/test/test_share_mount_support.py
+++ b/src/agilab/core/agi-env/test/test_share_mount_support.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 import agi_env.share_mount_support as share_mount_support
+import agi_env.runtime.runtime_bootstrap_support as runtime_bootstrap_support
 
 
 def test_read_cluster_setting_handles_empty_and_invalid_files(tmp_path: Path):
@@ -231,3 +232,85 @@ def test_resolve_share_path_fail_fast_and_local_fallback(tmp_path: Path, monkeyp
         )
         == "localshare"
     )
+
+
+def test_describe_cluster_share_origin_names_the_real_source(tmp_path: Path):
+    env_path = tmp_path / ".env"
+
+    assert share_mount_support.describe_cluster_share_origin(
+        runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_ENV_FILE, env_path=env_path
+    ) == f"set in env file {env_path}"
+    assert "process environment" in share_mount_support.describe_cluster_share_origin(
+        runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_PROCESS_ENV, env_path=env_path
+    )
+
+    default_hint = share_mount_support.describe_cluster_share_origin(
+        runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_DEFAULT, env_path=env_path
+    )
+    assert "not configured" in default_hint
+    assert str(env_path) in default_hint
+
+    # Callers that do not supply an origin keep the previous wording.
+    assert share_mount_support.describe_cluster_share_origin(
+        None, env_path=env_path
+    ) == f"env={env_path}"
+
+
+def test_resolve_share_path_error_does_not_blame_env_file_for_default(tmp_path: Path, monkeypatch):
+    """A defaulted share must not point operators at an env file lacking the key."""
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("APPS_PATH=/somewhere\n", encoding="utf-8")
+    monkeypatch.setattr(share_mount_support, "is_mounted", lambda _path, home_path: False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        share_mount_support.resolve_share_path(
+            cluster_share="clustershare/agi",
+            local_share="localshare/agi",
+            cluster_enabled=True,
+            env_path=env_path,
+            home_path=tmp_path,
+            cluster_share_origin=runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_DEFAULT,
+        )
+
+    message = str(excinfo.value)
+    assert "not configured" in message
+    assert f"env={env_path}" not in message
+
+
+def test_resolve_share_runtime_config_reports_origin(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    seen: dict[str, object] = {}
+
+    def _fake_resolver(**kwargs):
+        seen.update(kwargs)
+        return "localshare/agi"
+
+    def _config(envars, environ):
+        seen.clear()
+        runtime_bootstrap_support.resolve_share_runtime_config(
+            envars=envars,
+            environ=environ,
+            is_worker_env=False,
+            resolve_workspace_settings_fn=lambda: None,
+            find_source_settings_fn=lambda: None,
+            clean_envar_value_fn=lambda _envars, _key, fallback_to_process=False: None,
+            resolve_cluster_enabled_fn=lambda **_kwargs: False,
+            resolve_runtime_share_path_fn=_fake_resolver,
+            env_path=env_path,
+            home_path=tmp_path,
+        )
+        return seen["cluster_share_origin"], seen["cluster_share"]
+
+    assert _config({"AGI_CLUSTER_SHARE": "from/envfile"}, {}) == (
+        runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_ENV_FILE,
+        "from/envfile",
+    )
+    assert _config({}, {"AGI_CLUSTER_SHARE": "from/process"}) == (
+        runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_PROCESS_ENV,
+        "from/process",
+    )
+
+    origin, share = _config({}, {"USER": "agi"})
+    assert origin == runtime_bootstrap_support.CLUSTER_SHARE_ORIGIN_DEFAULT
+    assert share == "clustershare/agi"


### PR DESCRIPTION
The cluster-share fail-fast message always appended `env=<env file>`, even when the share path came from the process environment or from the per-user default.

## Symptom

On a machine with no share mounted, the ABOUT page reports:

```
Configured AGI_CLUSTER_SHARE='/Users/agi/clustershare/agi' is not usable; env=/Users/agi/.agilab/.env
```

but that env file does not define `AGI_CLUSTER_SHARE` at all — the value came from the `default_cluster_share()` fallback in `runtime_bootstrap_support.py`. The message sends operators to the wrong place, with no hint the value was defaulted.

## Change

- Track the origin of `cluster_share` in `resolve_share_runtime_config` (env file / process environment / default).
- Thread it into `resolve_share_path` as `cluster_share_origin` and name the actual source in both fail-fast messages.
- Origin constants live in `runtime_bootstrap_support` so that leaf module keeps its zero `agi_env` imports.

New message for the defaulted case:

```
... is not usable; not configured; using the per-user default.
Set AGI_CLUSTER_SHARE in /Users/agi/.agilab/.env to override
```

## Compatibility

`cluster_share_origin` defaults to `None`, which reproduces the previous `env=<path>` wording. No caller is required to change, and the existing assertions in `test_share_mount_support.py` pass unmodified.

Mount detection itself is unchanged — this is message accuracy only.

## Tests

Three added in `test_share_mount_support.py`, covering each origin, the defaulted-message regression, and origin propagation through `resolve_share_runtime_config`.

```
test_share_mount_support / test_runtime_bootstrap_support / test_share_runtime_support
test_compat_shim_imports / test_agi_env_remaining_coverage / test_agi_env_helper_branch_sweep
  -> 165 passed, 1 skipped
test_agi_env.py -> 131 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)