### PR TITLE
perf(ui): prune recursive discovery walks

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 3675f370822e6d6ff7f15fd6bdf1965a921517ff54200c9c4106492c8f12fc18
+source_sha256: e7c08bc1b8b5a99ff21eb9343c57aaf2bd2ce13bea0bd740f7dc7a2f2634122c
 title: ANALYSIS page session environment and sidecar ownership contract
-verified_commit: cf8058b53e5f5decd974038103f1eaf2f39c8a9d
+verified_commit: f778af6d3ec49d21ba8afd37d3f26990c0eb055b
 ---
 
 # ANALYSIS page session environment and sidecar ownership contract
@@ -49,3 +49,8 @@ contained hosted inline process globals behind a fail-fast lease.
 2026-07-17 re-verification: preparation ownership now survives wrapper exit,
 uses bounded process-group/tree termination, and releases the cross-session
 guard only after parent and descendant absence are both proven.
+
+2026-07-28 re-verification: notebook discovery and clone rename traversal were
+optimized without changing session-environment, sidecar-ownership, or bounded
+preparation-cleanup behavior. Focused helpers, the AGI GUI parity profile, and
+the isolated PyTorch Playground ANALYSIS browser scenario passed.

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1808,9 +1808,15 @@ def _analysis_discovery_cache_enabled(environ: Any = os.environ) -> bool:
 
 
 def _directory_tree_signature(
-    root: Path, *, file_suffixes: tuple[str, ...]
+    root: Path,
+    *,
+    file_suffixes: tuple[str, ...],
+    ignored_dirs: set[str] | None = None,
 ) -> tuple[Any, ...]:
     """Return a cheap invalidation signature for discovery-relevant files."""
+    ignored_dirs = (
+        _ANALYSIS_DISCOVERY_SKIP_DIRS if ignored_dirs is None else ignored_dirs
+    )
     try:
         resolved_root = root.expanduser().resolve()
     except (OSError, RuntimeError, TypeError, ValueError):
@@ -1831,7 +1837,7 @@ def _directory_tree_signature(
             dirnames[:] = sorted(
                 dirname
                 for dirname in dirnames
-                if dirname not in _ANALYSIS_DISCOVERY_SKIP_DIRS
+                if dirname not in ignored_dirs
                 and not dirname.startswith(".")
             )
             current_dir = Path(dirpath)
@@ -1929,12 +1935,23 @@ def _project_notebooks_root(project_root: str | Path | None) -> Path | None:
 def _discover_project_notebooks_uncached(notebooks_root: Path) -> dict[str, Path]:
     discovered: dict[str, Path] = {}
     try:
-        notebook_paths = sorted(
-            notebooks_root.rglob("*.ipynb"), key=lambda path: path.as_posix()
-        )
+        notebook_paths: list[Path] = []
+        for dirpath, dirnames, filenames in os.walk(notebooks_root):
+            dirnames[:] = sorted(
+                dirname
+                for dirname in dirnames
+                if dirname not in _NOTEBOOK_IGNORED_DIRS
+                and not dirname.startswith(".")
+            )
+            current_root = Path(dirpath)
+            notebook_paths.extend(
+                current_root / filename
+                for filename in sorted(filenames)
+                if filename.endswith(".ipynb") and not filename.startswith(".")
+            )
     except OSError:
         return {}
-    for notebook_path in notebook_paths:
+    for notebook_path in sorted(notebook_paths, key=lambda path: path.as_posix()):
         try:
             rel_path = notebook_path.resolve().relative_to(notebooks_root)
         except (OSError, ValueError):
@@ -1960,7 +1977,11 @@ def discover_project_notebooks(project_root: str | Path | None) -> dict[str, Pat
     if not _analysis_discovery_cache_enabled():
         return _discover_project_notebooks_uncached(notebooks_root)
 
-    signature = _directory_tree_signature(notebooks_root, file_suffixes=(".ipynb",))
+    signature = _directory_tree_signature(
+        notebooks_root,
+        file_suffixes=(".ipynb",),
+        ignored_dirs=_NOTEBOOK_IGNORED_DIRS,
+    )
     cached = _NOTEBOOK_DISCOVERY_CACHE.get(notebooks_root)
     if cached is not None and cached[0] == signature:
         return dict(cached[1])
@@ -2115,30 +2136,43 @@ def _rename_paths_and_contents(bundle_root: Path, rename_map: dict[str, str]) ->
     if not rename_map:
         return
 
-    for current in sorted(
-        (p for p in bundle_root.rglob("*") if p != bundle_root),
-        key=lambda p: len(p.relative_to(bundle_root).parts),
+    replace_exts = {".py", ".toml", ".md", ".txt", ".json", ".yaml", ".yml"}
+    snapshot = sorted(
+        bundle_root.rglob("*"),
+        key=lambda path: (
+            len(path.relative_to(bundle_root).parts),
+            path.as_posix(),
+        ),
         reverse=True,
-    ):
+    )
+    rename_events: list[tuple[Path, Path]] = []
+    for original_path in snapshot:
+        current = original_path
         new_name = _rename_segment(current.name, rename_map)
         if new_name != current.name:
             new_path = current.with_name(new_name)
             if not new_path.exists():
                 current.rename(new_path)
+                rename_events.append((current, new_path))
 
-    replace_exts = {".py", ".toml", ".md", ".txt", ".json", ".yaml", ".yml"}
-    for path in bundle_root.rglob("*"):
-        if not path.is_file():
+    for original_path in snapshot:
+        current = original_path
+        for old_path, new_path in rename_events:
+            try:
+                current = new_path / current.relative_to(old_path)
+            except ValueError:
+                continue
+        if not current.is_file():
             continue
-        if path.suffix.lower() not in replace_exts:
+        if current.suffix.lower() not in replace_exts:
             continue
         try:
-            text = path.read_text(encoding="utf-8")
+            text = current.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         new_text = _clone_word_substitutions(text, rename_map)
         if new_text != text:
-            path.write_text(new_text, encoding="utf-8")
+            current.write_text(new_text, encoding="utf-8")
 
 
 def _clone_source_label(option_path: Path, pages_root: Path | None = None) -> str:

--- a/src/agilab/pipeline/pipeline_recipe_memory.py
+++ b/src/agilab/pipeline/pipeline_recipe_memory.py
@@ -21,6 +21,15 @@ ELIGIBLE_STATUSES = {"validated", "pass", "passed", "success", "succeeded", "com
 FAILED_STATUSES = {"fail", "failed", "error", "errored", "invalid"}
 MAX_RECIPE_SOURCES = 200
 MAX_RECIPE_CARDS = 500
+_RECIPE_SOURCE_IGNORED_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "venv",
+}
 
 _SECRET_PATTERNS = [
     re.compile(r"(sk-[A-Za-z0-9]{6})[A-Za-z0-9_\-]{8,}"),
@@ -273,6 +282,32 @@ def load_recipe_cards_from_memory(path: Path) -> list[RecipeCard]:
     return cards
 
 
+def _discover_recipe_source_candidates(root: Path) -> list[Path]:
+    lab_steps_files: list[Path] = []
+    notebook_files: list[Path] = []
+    memory_files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(
+            dirname
+            for dirname in dirnames
+            if dirname not in _RECIPE_SOURCE_IGNORED_DIRS
+        )
+        current_root = Path(dirpath)
+        for filename in sorted(filenames):
+            candidate = current_root / filename
+            if Path(filename).match("lab_steps*.toml"):
+                lab_steps_files.append(candidate)
+            elif filename.endswith(".ipynb"):
+                notebook_files.append(candidate)
+            elif filename == "cards.jsonl":
+                memory_files.append(candidate)
+    return [
+        *sorted(lab_steps_files, key=lambda path: path.as_posix()),
+        *sorted(notebook_files, key=lambda path: path.as_posix()),
+        *sorted(memory_files, key=lambda path: path.as_posix()),
+    ]
+
+
 def discover_recipe_sources(roots: Sequence[Path | str], *, max_files: int = MAX_RECIPE_SOURCES) -> list[Path]:
     sources: list[Path] = []
     seen: set[Path] = set()
@@ -286,11 +321,7 @@ def discover_recipe_sources(roots: Sequence[Path | str], *, max_files: int = MAX
         if root.is_file():
             candidates = [root]
         elif root.is_dir():
-            candidates = [
-                *sorted(root.rglob("lab_steps*.toml")),
-                *sorted(root.rglob("*.ipynb")),
-                *sorted(root.rglob("cards.jsonl")),
-            ]
+            candidates = _discover_recipe_source_candidates(root)
         else:
             continue
         for candidate in candidates:

--- a/src/agilab/ui/page_docs.py
+++ b/src/agilab/ui/page_docs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import webbrowser
+from collections import OrderedDict
 from pathlib import Path
 from typing import Mapping
 
@@ -17,6 +18,10 @@ _DOCS_LOCAL_ALIASES: dict[str, tuple[str, ...]] = {
     "explore-help.html": ("views_help.html",),
 }
 _DOCS_MENU_ITEMS_CACHE: dict[tuple[str, str], dict[str, str]] = {}
+_LOCAL_PAGE_DOCS_CACHE_MAX_SIZE = 128
+_LOCAL_PAGE_DOCS_CACHE: OrderedDict[
+    tuple[tuple[Path, ...], str], Path
+] = OrderedDict()
 
 
 def _docs_candidates(html_file: str) -> tuple[str, ...]:
@@ -74,37 +79,65 @@ def _open_remote_docs(html_file: str, anchor: str = "") -> bool:
         return False
 
 
+def _resolve_local_page_docs_path_cached(
+    roots: tuple[Path, ...], html_file: str
+) -> Path | None:
+    """Resolve and positively cache a recursive docs fallback."""
+    cache_key = (roots, html_file)
+    cached = _LOCAL_PAGE_DOCS_CACHE.get(cache_key)
+    if cached is not None:
+        if cached.is_file():
+            _LOCAL_PAGE_DOCS_CACHE.move_to_end(cache_key)
+            return cached
+        _LOCAL_PAGE_DOCS_CACHE.pop(cache_key, None)
+
+    resolved: Path | None = None
+    for root in roots:
+        docs_root = root / "docs"
+        if docs_root.exists():
+            matches = sorted(
+                path for path in docs_root.rglob(html_file) if path.is_file()
+            )
+            if matches:
+                resolved = matches[0]
+                break
+
+    if resolved is not None:
+        _LOCAL_PAGE_DOCS_CACHE[cache_key] = resolved
+        _LOCAL_PAGE_DOCS_CACHE.move_to_end(cache_key)
+        while len(_LOCAL_PAGE_DOCS_CACHE) > _LOCAL_PAGE_DOCS_CACHE_MAX_SIZE:
+            _LOCAL_PAGE_DOCS_CACHE.popitem(last=False)
+    return resolved
+
+
 def _resolve_local_page_docs_path(env, html_file: str) -> Path | None:
-    roots: list[Path] = []
     raw_root = getattr(env, "agilab_pck", None)
     if not raw_root:
         return None
     try:
         package_root = Path(raw_root).expanduser().resolve()
+        module_file = Path(__file__).resolve()
     except (OSError, RuntimeError, TypeError, ValueError):
-        package_root = None
-    if package_root is None:
         return None
-    roots.extend([package_root, package_root.parent, package_root.parent.parent])
 
-    module_file = Path(__file__).resolve()
-    roots.extend([module_file.parent, module_file.parents[1], module_file.parents[2]])
-
-    seen: set[Path] = set()
+    roots = tuple(
+        dict.fromkeys(
+            (
+                package_root,
+                package_root.parent,
+                package_root.parent.parent,
+                module_file.parent,
+                module_file.parents[1],
+                module_file.parents[2],
+            )
+        )
+    )
     for root in roots:
-        if root in seen:
-            continue
-        seen.add(root)
         for base in (root / "docs" / "build", root / "docs" / "html"):
             candidate = base / html_file
-            if candidate.exists():
+            if candidate.is_file():
                 return candidate
-        docs_root = root / "docs"
-        if docs_root.exists():
-            matches = sorted(docs_root.rglob(html_file))
-            if matches:
-                return matches[0]
-    return None
+    return _resolve_local_page_docs_path_cached(roots, html_file)
 
 
 def _open_local_page_docs(env, html_file: str, anchor: str = "") -> str:

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -223,6 +223,158 @@ def test_discover_project_notebooks_skips_checkpoints_and_sorts(tmp_path: Path):
     assert notebooks["lab_stages.ipynb"] == (notebooks_root / "lab_stages.ipynb").resolve()
 
 
+def test_discover_project_notebooks_prunes_ignored_directories_during_walk(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    notebooks_root = tmp_path / "notebooks"
+    included = notebooks_root / "included" / "demo.ipynb"
+    excluded = notebooks_root / ".venv" / "ignored.ipynb"
+    excluded_venv = notebooks_root / "venv" / "ignored.ipynb"
+    checkpoint = (
+        notebooks_root / ".ipynb_checkpoints" / "demo-checkpoint.ipynb"
+    )
+    included.parent.mkdir(parents=True)
+    excluded.parent.mkdir(parents=True)
+    excluded_venv.parent.mkdir(parents=True)
+    checkpoint.parent.mkdir(parents=True)
+    included.write_text("{}", encoding="utf-8")
+    excluded.write_text("{}", encoding="utf-8")
+    excluded_venv.write_text("{}", encoding="utf-8")
+    checkpoint.write_text("{}", encoding="utf-8")
+    original_walk = os.walk
+    walked_roots: list[Path] = []
+
+    def guarded_walk(root, *args, **kwargs):
+        iterator = original_walk(root, *args, **kwargs)
+        for dirpath, dirnames, filenames in iterator:
+            walked_roots.append(Path(dirpath))
+            yield dirpath, dirnames, filenames
+            if Path(dirpath) == notebooks_root:
+                assert ".venv" not in dirnames
+                assert ".ipynb_checkpoints" not in dirnames
+                assert "venv" not in dirnames
+
+    def reject_rglob(*_args, **_kwargs):
+        raise AssertionError("notebook discovery must prune with os.walk")
+
+    monkeypatch.setattr(module.os, "walk", guarded_walk)
+    monkeypatch.setattr(Path, "rglob", reject_rglob)
+
+    assert module._discover_project_notebooks_uncached(notebooks_root) == {
+        "included/demo.ipynb": included.resolve()
+    }
+    assert excluded.parent not in walked_roots
+    assert excluded_venv.parent not in walked_roots
+    assert checkpoint.parent not in walked_roots
+
+
+def test_rename_paths_and_contents_uses_one_tree_snapshot(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    bundle_root = tmp_path / "bundle"
+    source_file = bundle_root / "old_project" / "old_project.py"
+    readme = bundle_root / "README.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("from old_project import run\n", encoding="utf-8")
+    readme.write_text("Clone old_project.\n", encoding="utf-8")
+    original_rglob = Path.rglob
+    traversal_count = 0
+
+    def counted_rglob(path: Path, pattern: str, *args, **kwargs):
+        nonlocal traversal_count
+        if path == bundle_root and pattern == "*":
+            traversal_count += 1
+        return original_rglob(path, pattern, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rglob", counted_rglob)
+
+    module._rename_paths_and_contents(
+        bundle_root,
+        {"old_project": "new_project"},
+    )
+
+    renamed_file = bundle_root / "new_project" / "new_project.py"
+    assert traversal_count == 1
+    assert renamed_file.read_text(encoding="utf-8") == (
+        "from new_project import run\n"
+    )
+    assert readme.read_text(encoding="utf-8") == "Clone new_project.\n"
+    assert source_file.exists() is False
+
+
+def test_rename_paths_and_contents_defers_content_writes_until_renames_succeed(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    bundle_root = tmp_path / "bundle"
+    source_root = bundle_root / "old_project"
+    source_file = source_root / "old_project.py"
+    readme = bundle_root / "README.md"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("from old_project import run\n", encoding="utf-8")
+    readme.write_text("Clone old_project.\n", encoding="utf-8")
+    original_rename = Path.rename
+
+    def fail_parent_rename(path: Path, target: Path):
+        if path == source_root:
+            raise OSError("parent rename failed")
+        return original_rename(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_parent_rename)
+
+    with pytest.raises(OSError, match="parent rename failed"):
+        module._rename_paths_and_contents(
+            bundle_root,
+            {"old_project": "new_project"},
+        )
+
+    partially_renamed_file = source_root / "new_project.py"
+    assert partially_renamed_file.read_text(encoding="utf-8") == (
+        "from old_project import run\n"
+    )
+    assert readme.read_text(encoding="utf-8") == "Clone old_project.\n"
+
+
+def test_rename_paths_and_contents_preserves_destination_collisions(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    bundle_root = tmp_path / "bundle"
+    source_root = bundle_root / "old_project"
+    old_file = source_root / "old_project.py"
+    existing_destination = source_root / "new_project.py"
+    source_root.mkdir(parents=True)
+    old_file.write_text("old_project source\n", encoding="utf-8")
+    existing_destination.write_text("old_project destination\n", encoding="utf-8")
+    original_rglob = Path.rglob
+    traversal_count = 0
+
+    def counted_rglob(path: Path, pattern: str, *args, **kwargs):
+        nonlocal traversal_count
+        if path == bundle_root and pattern == "*":
+            traversal_count += 1
+        return original_rglob(path, pattern, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rglob", counted_rglob)
+
+    module._rename_paths_and_contents(
+        bundle_root,
+        {"old_project": "new_project"},
+    )
+
+    renamed_root = bundle_root / "new_project"
+    assert traversal_count == 1
+    assert (renamed_root / "old_project.py").read_text(encoding="utf-8") == (
+        "new_project source\n"
+    )
+    assert (renamed_root / "new_project.py").read_text(encoding="utf-8") == (
+        "new_project destination\n"
+    )
+
+
 def test_discover_views_uses_cache_until_directory_signature_changes(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     module._VIEW_DISCOVERY_CACHE.clear()
@@ -275,6 +427,8 @@ def test_discover_project_notebooks_uses_cache_until_directory_signature_changes
     project_root = tmp_path / "flight_telemetry_project"
     notebooks_root = project_root / "notebooks"
     notebooks_root.mkdir(parents=True)
+    templates_root = notebooks_root / "templates"
+    templates_root.mkdir()
     first_notebook = (notebooks_root / "lab_stages.ipynb").resolve()
     first_notebook.write_text("{}", encoding="utf-8")
     calls: list[Path] = []
@@ -307,6 +461,21 @@ def test_discover_project_notebooks_uses_cache_until_directory_signature_changes
         "lab_stages.ipynb": first_notebook,
     }
     assert calls == [notebooks_root.resolve(), notebooks_root.resolve()]
+
+    template_notebook = (templates_root / "kept.ipynb").resolve()
+    template_notebook.write_text("{}", encoding="utf-8")
+    os.utime(templates_root)
+
+    assert module.discover_project_notebooks(project_root) == {
+        "extra/demo.ipynb": second_notebook,
+        "lab_stages.ipynb": first_notebook,
+        "templates/kept.ipynb": template_notebook,
+    }
+    assert calls == [
+        notebooks_root.resolve(),
+        notebooks_root.resolve(),
+        notebooks_root.resolve(),
+    ]
 
 
 def test_configured_notebook_options_filters_unavailable_entries():

--- a/test/test_page_docs.py
+++ b/test/test_page_docs.py
@@ -178,6 +178,100 @@ def test_resolve_local_page_docs_path_supports_recursive_docs_matches(tmp_path, 
     assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") == nested_doc
 
 
+def test_resolve_local_page_docs_path_caches_recursive_search(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    package_root = repo_root / "src"
+    module_file = package_root / "agilab" / "page_docs.py"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("pass\n", encoding="utf-8")
+    nested_doc = module_file.parent / "docs" / "nested" / "execute-help.html"
+    nested_doc.parent.mkdir(parents=True)
+    nested_doc.write_text("<html>ok</html>", encoding="utf-8")
+    env = types.SimpleNamespace(agilab_pck=package_root)
+    original_rglob = Path.rglob
+    recursive_searches = 0
+
+    def counted_rglob(path: Path, pattern: str, *args, **kwargs):
+        nonlocal recursive_searches
+        recursive_searches += 1
+        return original_rglob(path, pattern, *args, **kwargs)
+
+    page_docs._LOCAL_PAGE_DOCS_CACHE.clear()
+    monkeypatch.setattr(page_docs, "__file__", str(module_file))
+    monkeypatch.setattr(Path, "rglob", counted_rglob)
+
+    assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") == nested_doc
+    assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") == nested_doc
+    assert recursive_searches == 1
+
+
+def test_resolve_local_page_docs_path_refreshes_missing_and_deleted_files(
+    tmp_path,
+    monkeypatch,
+):
+    repo_root = tmp_path / "repo"
+    package_root = repo_root / "src"
+    module_file = package_root / "agilab" / "page_docs.py"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("pass\n", encoding="utf-8")
+    env = types.SimpleNamespace(agilab_pck=package_root)
+    first_doc = module_file.parent / "docs" / "first" / "execute-help.html"
+    page_docs._LOCAL_PAGE_DOCS_CACHE.clear()
+    monkeypatch.setattr(page_docs, "__file__", str(module_file))
+
+    assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") is None
+
+    first_doc.parent.mkdir(parents=True)
+    first_doc.write_text("<html>first</html>", encoding="utf-8")
+    assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") == first_doc
+
+    replacement_doc = package_root / "docs" / "html" / "execute-help.html"
+    replacement_doc.parent.mkdir(parents=True)
+    replacement_doc.write_text("<html>second</html>", encoding="utf-8")
+    assert (
+        page_docs._resolve_local_page_docs_path(env, "execute-help.html")
+        == replacement_doc
+    )
+
+    replacement_doc.unlink()
+    first_doc.unlink()
+    final_doc = module_file.parent / "docs" / "third" / "execute-help.html"
+    final_doc.parent.mkdir(parents=True)
+    final_doc.write_text("<html>third</html>", encoding="utf-8")
+    assert page_docs._resolve_local_page_docs_path(env, "execute-help.html") == final_doc
+
+
+def test_resolve_local_page_docs_cache_is_bounded_and_root_scoped(
+    tmp_path,
+    monkeypatch,
+):
+    first_root = tmp_path / "first/package"
+    second_root = tmp_path / "second/package"
+    first_doc = first_root / "docs/nested/root-scoped.html"
+    second_doc = second_root / "docs/nested/root-scoped.html"
+    for doc in (first_doc, second_doc):
+        doc.parent.mkdir(parents=True)
+        doc.write_text("<html>ok</html>", encoding="utf-8")
+    page_docs._LOCAL_PAGE_DOCS_CACHE.clear()
+    monkeypatch.setattr(page_docs, "_LOCAL_PAGE_DOCS_CACHE_MAX_SIZE", 1)
+
+    assert page_docs._resolve_local_page_docs_path(
+        types.SimpleNamespace(agilab_pck=first_root),
+        "root-scoped.html",
+    ) == first_doc
+    assert page_docs._resolve_local_page_docs_path(
+        types.SimpleNamespace(agilab_pck=second_root),
+        "root-scoped.html",
+    ) == second_doc
+    assert list(page_docs._LOCAL_PAGE_DOCS_CACHE.values()) == [second_doc]
+
+    assert page_docs._resolve_local_page_docs_path(
+        types.SimpleNamespace(agilab_pck=first_root),
+        "root-scoped.html",
+    ) == first_doc
+    assert list(page_docs._LOCAL_PAGE_DOCS_CACHE.values()) == [first_doc]
+
+
 def test_resolve_local_page_docs_path_skips_empty_recursive_docs_root(tmp_path, monkeypatch):
     repo_root = tmp_path / "repo"
     package_root = repo_root / "src"

--- a/test/test_pipeline_recipe_memory.py
+++ b/test/test_pipeline_recipe_memory.py
@@ -299,6 +299,52 @@ demo_project = [
     )
 
 
+def test_discover_recipe_sources_prunes_ignored_directories_in_one_walk(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "recipes"
+    steps_file = root / "nested/lab_steps_demo.toml"
+    notebook_file = root / "demo.ipynb"
+    memory_file = root / "cards.jsonl"
+    hidden_memory_file = root / ".agilab/pipeline_recipe_memory/cards.jsonl"
+    ignored_file = root / ".venv/lab_steps_ignored.toml"
+    for path in (
+        steps_file,
+        notebook_file,
+        memory_file,
+        hidden_memory_file,
+        ignored_file,
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+    original_walk = memory.os.walk
+    walked_roots: list[Path] = []
+
+    def guarded_walk(walk_root, *args, **kwargs):
+        iterator = original_walk(walk_root, *args, **kwargs)
+        for dirpath, dirnames, filenames in iterator:
+            walked_roots.append(Path(dirpath))
+            yield dirpath, dirnames, filenames
+            if Path(dirpath) == root:
+                assert ".venv" not in dirnames
+
+    def reject_rglob(*_args, **_kwargs):
+        raise AssertionError("recipe discovery must use one pruned os.walk")
+
+    monkeypatch.setattr(memory.os, "walk", guarded_walk)
+    monkeypatch.setattr(Path, "rglob", reject_rglob)
+
+    assert memory.discover_recipe_sources([root]) == [
+        steps_file,
+        notebook_file,
+        hidden_memory_file,
+        memory_file,
+    ]
+    assert memory.discover_recipe_sources([ignored_file]) == [ignored_file]
+    assert ignored_file.parent not in walked_roots
+
+
 def test_recipe_memory_augment_and_promotion_fallback_branches(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     memory_path = tmp_path / "cards.jsonl"


### PR DESCRIPTION
Three UI discovery paths used `rglob`, which descends into every ignored directory and only filters *after* the walk. On a checkout with per-app venvs under `src/agilab/apps-pages` (2.5 GB here), that means traversing gigabytes to find nothing.

Measured on `view_maps_network`, which contains a `.venv`:

```
unpruned rglob : 183.4 ms  (0 hits)
pruned  os.walk:   0.1 ms  (0 hits)
```

## Changes

- `pages/4_ANALYSIS.py` — `_discover_project_notebooks_uncached` now prunes `_NOTEBOOK_IGNORED_DIRS` and dotfolders *during* `os.walk` instead of filtering afterwards. `_directory_tree_signature` takes an `ignored_dirs` override so the signature and the discovery agree on scope.
- `pipeline/pipeline_recipe_memory.py` — `discover_recipe_sources` ran three separate unpruned `rglob`s over the same root (3x the traversal). Replaced with one pruned walk in `_discover_recipe_source_candidates`, preserving the previous lab_steps -> ipynb -> cards ordering, which matters because `MAX_RECIPE_SOURCES` truncates.
- `ui/page_docs.py` — bounded LRU cache over local docs resolution, which previously re-ran an uncached `rglob` per candidate root on every docs-link click.

## Behaviour note

Recipe-source discovery no longer picks up notebooks inside `.venv`/`__pycache__`/VCS folders. That is the intended fix, but it is a real change in what gets discovered, not purely an optimization.

## Tests

`test_analysis_page_helpers.py`, `test_page_docs.py`, `test_pipeline_recipe_memory.py` — 121 passed.

Note: these must run with the worktree own `.venv`; the repo mixed-checkout import guard rejects another checkout interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)