### PR TITLE
fix(mcp): redact secrets in derived run-evidence payloads

### DIFF
--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from agilab import agent_run, bridge_cli, run_manifest
-from agilab.secret_uri import redact_mapping
+from agilab.secret_uri import redact_mapping, redact_text
 
 _ALLOWED_ROOTS_ENV = "AGILAB_MCP_ALLOWED_ROOTS"
 _ALLOW_CWD_ENV = "AGILAB_MCP_ALLOW_CWD"
@@ -555,6 +555,32 @@ def validate_agent_run(manifest_path: str | Path) -> dict[str, Any]:
     }
 
 
+def _redact_evidence_payload(value: Any) -> Any:
+    """Redact secret-looking text anywhere in a derived evidence payload.
+
+    ``read_manifest`` redacts the manifest it returns, but the derived
+    summary/artifact payloads were handed back raw, so a secret pasted into a
+    run ``label`` or an artifact filename reached MCP clients verbatim.
+
+    This deliberately does *not* use :func:`redact_mapping`. That helper blanks
+    a whole value when its **key** matches ``SECRET|TOKEN|KEY|AUTH|...``, and
+    ``manifest_summary`` keys ``validation_statuses`` by validation label — so a
+    validation named ``auth_check`` would lose its pass/fail status. Redacting
+    only the text keeps every status readable.
+    """
+
+    if isinstance(value, Mapping):
+        return {
+            redact_text(key): _redact_evidence_payload(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_evidence_payload(item) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = _mcp_read_path(manifest_path, purpose="manifest")
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -585,7 +611,7 @@ def summarize_run(manifest_path: str | Path) -> dict[str, Any]:
     return {
         "schema": "agilab.mcp.summarize_run.v1",
         "manifest_path": str(resolved),
-        "summary": run_manifest.manifest_summary(manifest),
+        "summary": _redact_evidence_payload(run_manifest.manifest_summary(manifest)),
     }
 
 
@@ -597,7 +623,9 @@ def list_artifacts(manifest_path: str | Path) -> dict[str, Any]:
     return {
         "schema": "agilab.mcp.list_artifacts.v1",
         "manifest_path": str(resolved),
-        "artifacts": bridge_cli._artifact_rows(manifest, resolved),
+        "artifacts": _redact_evidence_payload(
+            bridge_cli._artifact_rows(manifest, resolved)
+        ),
     }
 
 
@@ -612,8 +640,8 @@ def compare_runs(
         right_manifest,
         purpose="right run manifest",
     )
-    left_summary = run_manifest.manifest_summary(left)
-    right_summary = run_manifest.manifest_summary(right)
+    left_summary = _redact_evidence_payload(run_manifest.manifest_summary(left))
+    right_summary = _redact_evidence_payload(run_manifest.manifest_summary(right))
     return {
         "schema": "agilab.mcp.compare_runs.v1",
         "left_manifest": str(left_path),

--- a/test/test_agilab_mcp_redaction.py
+++ b/test/test_agilab_mcp_redaction.py
@@ -1,0 +1,124 @@
+"""Redaction and read-boundary contract for the AGILAB MCP evidence tools.
+
+The MCP server hands run evidence to external agents, so every tool that returns
+manifest-derived text must redact secrets - not just the tools that return the
+manifest itself.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agilab_mcp import manifest_tools
+
+
+SECRET = "sk-LIVEKEY1234567890abcdefSECRET"
+
+# Exercises the trap that makes a blanket ``redact_mapping`` wrong here:
+# ``manifest_summary`` keys ``validation_statuses`` by validation label, and the
+# secret-key pattern matches a bare "auth"/"key" substring.
+_VALIDATION_LABEL = "auth_check"
+
+
+def _write_manifest(root: Path) -> Path:
+    payload = {
+        "schema_version": 1,
+        "kind": "agilab.run_manifest",
+        "run_id": "a" * 32,
+        "path_id": "demo",
+        "label": f"nightly {SECRET}",
+        "status": "pass",
+        "command": {"argv": ["run", "--token", SECRET], "cwd": str(root)},
+        "environment": {"password": SECRET, "python": "3.13"},
+        "timing": {"duration_seconds": 1.0, "target_seconds": 2.0},
+        "artifacts": [
+            {
+                "name": f"out-{SECRET}.csv",
+                "kind": "data",
+                "path": "out.csv",
+                "size_bytes": 3,
+                "sha256": "",
+            }
+        ],
+        "validations": [{"label": _VALIDATION_LABEL, "status": "pass"}],
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    manifest_path = root / "run_manifest.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    (root / "out.csv").write_text("a,b", encoding="utf-8")
+    return manifest_path
+
+
+@pytest.fixture
+def manifest(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+    return _write_manifest(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "tool_name, build_args",
+    [
+        ("read_manifest", lambda path: (str(path),)),
+        ("summarize_run", lambda path: (str(path),)),
+        ("list_artifacts", lambda path: (str(path),)),
+        ("compare_runs", lambda path: (str(path), str(path))),
+    ],
+)
+def test_mcp_tools_never_return_raw_secrets(manifest: Path, tool_name, build_args):
+    """No manifest-derived MCP payload may carry a secret verbatim."""
+
+    result = getattr(manifest_tools, tool_name)(*build_args(manifest))
+    assert SECRET not in json.dumps(result, sort_keys=True)
+
+
+def test_summarize_run_redacts_label_but_keeps_status(manifest: Path):
+    summary = manifest_tools.summarize_run(str(manifest))["summary"]
+
+    assert SECRET not in summary["label"]
+    assert "<redacted>" in summary["label"]
+    # Redaction must not cost us the run outcome or the counts.
+    assert summary["status"] == "pass"
+    assert summary["artifact_count"] == 1
+
+
+def test_validation_status_survives_redaction(manifest: Path):
+    """A validation label matching the secret-key pattern keeps its status.
+
+    ``redact_mapping`` blanks a value whose *key* matches SECRET|TOKEN|KEY|AUTH.
+    Because validation labels are keys here, using it would report an
+    ``auth_check`` result as ``<redacted>`` instead of ``pass``, hiding a real
+    pass/fail signal behind a redaction.
+    """
+
+    summary = manifest_tools.summarize_run(str(manifest))["summary"]
+    assert summary["validation_statuses"] == {_VALIDATION_LABEL: "pass"}
+
+
+def test_list_artifacts_redacts_name_but_keeps_metadata(manifest: Path):
+    artifacts = manifest_tools.list_artifacts(str(manifest))["artifacts"]
+
+    assert len(artifacts) == 1
+    row = artifacts[0]
+    assert SECRET not in row["name"]
+    assert row["kind"] == "data"
+    assert row["exists"] is True
+
+
+def test_compare_runs_keeps_numeric_deltas_after_redaction(manifest: Path):
+    result = manifest_tools.compare_runs(str(manifest), str(manifest))
+
+    assert SECRET not in json.dumps(result, sort_keys=True)
+    # Deltas are computed from the redacted summaries, so numbers must survive.
+    assert result["artifact_count_delta"] == 0
+    assert result["duration_delta_seconds"] == 0.0
+    assert result["status_changed"] is False
+
+
+def test_read_boundary_rejects_paths_outside_allowed_roots(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.read_manifest("/etc/passwd")


### PR DESCRIPTION
Found while auditing the MCP interface. `redact_mapping` was applied at only 2 of 16 tool sites — `read_agent_run` and `read_manifest`. The derived payloads were returned raw.

## Leak

Planting `sk-LIVEKEY…` in a run manifest and calling each tool:

```
read_manifest    secret_leaked=False
summarize_run    secret_leaked=True   .summary.label
list_artifacts   secret_leaked=True   .artifacts[0].name
compare_runs     secret_leaked=True   .left.label, .right.label
```

`agent_run` redacts at write time, so the agent-* tools read already-clean data. But `agilab.evidence.run_manifest` has no redaction at all — run manifests store raw values on disk, making the MCP layer the only boundary. `read_manifest` treats `label` as needing redaction; `summarize_run` returned the same field raw.

Exploitation needs a secret in a run label or artifact filename — a user mistake, not a default. That is exactly what redaction is for, and the inconsistency meant safety depended on which tool the agent happened to call.

## Why not `redact_mapping`

`redact_mapping` blanks a value whose **key** matches `SECRET|TOKEN|PASSWORD|KEY|CREDENTIAL|AUTH` as a bare substring. `manifest_summary` keys `validation_statuses` by *validation label*, so a validation named `auth_check` would have reported `<redacted>` instead of `pass` — hiding a real pass/fail signal behind a redaction. That is worse than the leak.

`_redact_evidence_payload` redacts text only, so labels and filenames are scrubbed while every status, count and delta stays readable.

## Tests

New `test/test_agilab_mcp_redaction.py` (9 tests). **6 fail without this change**; 3 pass either way as baselines (`read_manifest` already clean, validation status preserved, read-boundary enforced). One test pins the validation-status behaviour so a future switch to `redact_mapping` cannot silently hide run outcomes.

There was previously no `test/test_agilab_mcp*` module at all — coverage was incidental, and no test asserted MCP output was redacted. That is why this survived.

```
test_agilab_mcp_redaction + test_audience_bridges + test_headless_cli_smoke
+ test_package_split_contract  -> 78 passed, 1 pre-existing failure
```

The one failure is `test_lab_run_routes_bridge_commands`, a `MixedCheckoutImportError` from running a worktree with the main checkout interpreter. Verified it fails identically on unmodified `origin/main`.

## Not addressed here

The audit also found: tool errors returned as JSON-RPC protocol errors rather than `isError` results; all errors using code `-32000`; and the default read boundary being the whole repo when `AGILAB_MCP_ALLOWED_ROOTS` is unset. Left for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)