### PR TITLE
fix(mcp): use standard JSON-RPC codes and report tool failures as isError

### DIFF
--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import sys
 from typing import Any, Callable, Mapping
@@ -11,6 +12,15 @@ from agilab_mcp import manifest_tools
 
 
 ToolFn = Callable[..., dict[str, Any]]
+
+# Standard JSON-RPC 2.0 error codes. Every failure previously reported -32000,
+# so clients could not tell a malformed request from a server fault.
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+JSONRPC_SERVER_ERROR = -32000
 
 
 def _agent_quickstart(**kwargs: Any) -> dict[str, Any]:
@@ -263,7 +273,10 @@ def call_tool(name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _jsonrpc_response(
-    request_id: Any, result: Any = None, error: Any = None, error_code: int = -32000
+    request_id: Any,
+    result: Any = None,
+    error: Any = None,
+    error_code: int = JSONRPC_SERVER_ERROR,
 ) -> dict[str, Any]:
     response = {"jsonrpc": "2.0", "id": request_id}
     if error is not None:
@@ -271,6 +284,65 @@ def _jsonrpc_response(
     else:
         response["result"] = result
     return response
+
+
+def _tool_content(payload: Any, *, is_error: bool = False) -> dict[str, Any]:
+    """Wrap a tool outcome in an MCP ``tools/call`` result.
+
+    Tool *execution* failures are reported here with ``isError`` rather than as
+    a JSON-RPC error, so the calling model sees the message and can correct
+    itself. A JSON-RPC error means the request never ran, which a client is
+    entitled to treat as a transport fault.
+    """
+
+    text = payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True)
+    result: dict[str, Any] = {"content": [{"type": "text", "text": text}]}
+    if is_error:
+        result["isError"] = True
+    return result
+
+
+def _handle_tools_call(request_id: Any, params: Any) -> dict[str, Any]:
+    if not isinstance(params, Mapping):
+        return _jsonrpc_response(
+            request_id,
+            error="tools/call params must be an object",
+            error_code=JSONRPC_INVALID_PARAMS,
+        )
+
+    name = str(params.get("name", ""))
+    tool = TOOLS.get(name)
+    if tool is None:
+        return _jsonrpc_response(
+            request_id,
+            error=f"Unknown AGILAB MCP tool: {name}",
+            error_code=JSONRPC_INVALID_PARAMS,
+        )
+
+    arguments = params.get("arguments") or {}
+    if not isinstance(arguments, Mapping):
+        return _jsonrpc_response(
+            request_id,
+            error="tools/call arguments must be an object",
+            error_code=JSONRPC_INVALID_PARAMS,
+        )
+
+    # Bind before calling so an argument-shape mistake is reported as invalid
+    # params, and is not confused with a TypeError raised inside the tool.
+    try:
+        inspect.signature(tool).bind(**dict(arguments))
+    except TypeError as exc:
+        return _jsonrpc_response(
+            request_id, error=exc, error_code=JSONRPC_INVALID_PARAMS
+        )
+
+    try:
+        result = tool(**dict(arguments))
+    except Exception as exc:  # noqa: BLE001 - surfaced to the model as a tool error
+        return _jsonrpc_response(
+            request_id, _tool_content(f"{type(exc).__name__}: {exc}", is_error=True)
+        )
+    return _jsonrpc_response(request_id, _tool_content(result))
 
 
 def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -298,25 +370,18 @@ def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
         if method == "tools/list":
             return _jsonrpc_response(request_id, {"tools": tool_descriptors()})
         if method == "tools/call":
-            params = payload.get("params") or {}
-            if not isinstance(params, Mapping):
-                raise ValueError("tools/call params must be an object")
-            result = call_tool(
-                str(params.get("name", "")), params.get("arguments") or {}
-            )
-            return _jsonrpc_response(
-                request_id,
-                {
-                    "content": [
-                        {"type": "text", "text": json.dumps(result, sort_keys=True)}
-                    ]
-                },
-            )
+            return _handle_tools_call(request_id, payload.get("params") or {})
         if method == "notifications/initialized":
             return None
-        raise ValueError(f"Unsupported method: {method}")
-    except Exception as exc:
-        return _jsonrpc_response(request_id, error=exc)
+        return _jsonrpc_response(
+            request_id,
+            error=f"Unsupported method: {method}",
+            error_code=JSONRPC_METHOD_NOT_FOUND,
+        )
+    except Exception as exc:  # noqa: BLE001 - last-resort server fault
+        return _jsonrpc_response(
+            request_id, error=exc, error_code=JSONRPC_INTERNAL_ERROR
+        )
 
 
 def serve_stdio(stdin: Any = sys.stdin, stdout: Any = sys.stdout) -> int:
@@ -329,14 +394,14 @@ def serve_stdio(stdin: Any = sys.stdin, stdout: Any = sys.stdout) -> int:
             response = _jsonrpc_response(
                 None,
                 error=f"Parse error: {exc.msg}",
-                error_code=-32700,
+                error_code=JSONRPC_PARSE_ERROR,
             )
         else:
             if not isinstance(payload, Mapping):
                 response = _jsonrpc_response(
                     None,
                     error="Invalid request",
-                    error_code=-32600,
+                    error_code=JSONRPC_INVALID_REQUEST,
                 )
             else:
                 response = handle_jsonrpc(payload)

--- a/test/test_agilab_mcp_jsonrpc.py
+++ b/test/test_agilab_mcp_jsonrpc.py
@@ -1,0 +1,116 @@
+"""JSON-RPC conformance contract for the AGILAB MCP server.
+
+Two distinctions matter to a calling agent:
+
+* a malformed request must be told apart from a server fault, via the standard
+  JSON-RPC error codes rather than a single catch-all;
+* a tool that *ran and failed* must come back as a tool result flagged
+  ``isError``, not as a JSON-RPC error. A JSON-RPC error says the request never
+  executed, which a client may treat as a transport fault and hide from the
+  model, costing it the chance to correct itself.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agilab_mcp import server
+
+
+def _request(method: str, params: object | None = None, request_id: object = 1):
+    payload: dict[str, object] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return server.handle_jsonrpc(payload)
+
+
+@pytest.mark.parametrize(
+    "method, params, expected_code",
+    [
+        ("nope", None, server.JSONRPC_METHOD_NOT_FOUND),
+        (
+            "tools/call",
+            {"name": "ghost", "arguments": {}},
+            server.JSONRPC_INVALID_PARAMS,
+        ),
+        (
+            "tools/call",
+            {"name": "list_runs", "arguments": {"bogus": 1}},
+            server.JSONRPC_INVALID_PARAMS,
+        ),
+        (
+            "tools/call",
+            {"name": "list_runs", "arguments": {}},
+            server.JSONRPC_INVALID_PARAMS,
+        ),
+        ("tools/call", [1, 2], server.JSONRPC_INVALID_PARAMS),
+        (
+            "tools/call",
+            {"name": "list_runs", "arguments": [1, 2]},
+            server.JSONRPC_INVALID_PARAMS,
+        ),
+    ],
+)
+def test_protocol_faults_use_standard_codes(method, params, expected_code):
+    response = _request(method, params)
+
+    assert response is not None
+    assert response["error"]["code"] == expected_code
+    # The catch-all must no longer stand in for request-shape problems.
+    assert response["error"]["code"] != server.JSONRPC_SERVER_ERROR
+
+
+def test_tool_failure_is_a_tool_result_not_a_protocol_error(tmp_path, monkeypatch):
+    """A tool that runs and raises reports isError so the model can react."""
+
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+    response = _request(
+        "tools/call",
+        {"name": "read_manifest", "arguments": {"manifest_path": "/etc/passwd"}},
+    )
+
+    assert response is not None
+    assert "error" not in response
+    result = response["result"]
+    assert result["isError"] is True
+    assert "outside configured read roots" in result["content"][0]["text"]
+
+
+def test_successful_tool_call_has_no_error_flag():
+    response = _request("tools/call", {"name": "agent_quickstart", "arguments": {}})
+
+    assert response is not None
+    result = response["result"]
+    assert "isError" not in result
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["mcp_tools"]
+
+
+def test_parse_and_invalid_request_codes_are_distinct():
+    assert server.JSONRPC_PARSE_ERROR == -32700
+    assert server.JSONRPC_INVALID_REQUEST == -32600
+    assert server.JSONRPC_METHOD_NOT_FOUND == -32601
+    assert server.JSONRPC_INVALID_PARAMS == -32602
+    assert server.JSONRPC_INTERNAL_ERROR == -32603
+
+
+def test_notifications_still_receive_no_response():
+    assert server.handle_jsonrpc({"jsonrpc": "2.0", "method": "tools/list"}) is None
+    assert (
+        server.handle_jsonrpc(
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "id": 9}
+        )
+        is None
+    )
+
+
+def test_tools_list_and_initialize_remain_plain_results():
+    listed = _request("tools/list")
+    assert listed is not None and "error" not in listed
+    assert listed["result"]["tools"]
+
+    initialized = _request("initialize")
+    assert initialized is not None and "error" not in initialized
+    assert initialized["result"]["serverInfo"]["name"] == "agilab-mcp"

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1527,7 +1527,9 @@ def test_mcp_jsonrpc_error_paths_are_structured() -> None:
         {"jsonrpc": "2.0", "id": 10, "method": "tools/call", "params": ["bad"]}
     )
     assert bad_params is not None
-    assert bad_params["error"]["code"] == -32000
+    # Malformed params are a JSON-RPC "invalid params" fault, not the catch-all
+    # server-error code this previously asserted.
+    assert bad_params["error"]["code"] == mcp_server.JSONRPC_INVALID_PARAMS
     assert "tools/call params must be an object" in bad_params["error"]["message"]
 
     unknown_method = mcp_server.handle_jsonrpc(


### PR DESCRIPTION
Findings 2 and 3 from the MCP interface audit (Finding 1 landed in #889).

## Before

Every failure returned `-32000`, and tool execution failures came back as JSON-RPC errors:

```
unknown method        -> -32000
unknown tool          -> -32000
bad kwarg             -> -32000
path boundary refused -> -32000   (as a protocol error)
```

## After

```
unknown method       -> -32601 method not found
unknown tool         -> -32602 invalid params
bad kwarg            -> -32602
missing required arg -> -32602
params not an object -> -32602
tool ran and failed  -> result with isError=true, message in content
```

## Why the isError distinction matters

A JSON-RPC error means *the request never executed*. A client may reasonably treat that as a transport fault and never show it to the model. A tool that ran and failed — a rejected path, an unreadable manifest — is information the agent needs in order to correct itself, so per MCP it belongs in the result with `isError: true`.

## Argument binding

Arguments are bound with `inspect.signature(tool).bind(...)` before the call. Without that, a `TypeError` raised *inside* a tool would be misreported as invalid params. Binding first keeps the two apart.

## One existing test changed

`test_mcp_jsonrpc_error_paths_are_structured` asserted `code == -32000` for malformed params — it encoded the defect. That single assertion now asserts `JSONRPC_INVALID_PARAMS`; its message assertions are untouched. Flagging it explicitly since changing an existing assertion deserves review.

## Tests

New `test/test_agilab_mcp_jsonrpc.py` (7 tests) covering each code, the isError path, that successful calls carry no error flag, and that notifications still get no response.

```
test_agilab_mcp_jsonrpc + test_agilab_mcp_redaction + test_audience_bridges
+ test_headless_cli_smoke + test_package_split_contract  -> 89 passed
```

The 1 local failure is `test_lab_run_routes_bridge_commands`, a pre-existing `MixedCheckoutImportError` from running a worktree with the main checkout interpreter — it fails identically on unmodified `origin/main`.

## Still open from the audit

Finding 4: with `AGILAB_MCP_ALLOWED_ROOTS` unset the default read boundary is the whole repo, including `.git/`. That changes a security default, so it deserves its own decision rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)