### PR TITLE
fix(mcp): disclose the effective read boundary without widening it

### DIFF
--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -54,12 +54,40 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _configured_read_roots() -> tuple[Path, ...]:
+READ_BOUNDARY_SOURCE_CONFIGURED = "configured"
+READ_BOUNDARY_SOURCE_DEFAULT = "default"
+
+
+def read_boundary() -> dict[str, Any]:
+    """Describe the effective MCP read boundary and where it came from.
+
+    Without ``AGILAB_MCP_ALLOWED_ROOTS`` the boundary falls back to defaults
+    that include the whole repository checkout — ``.git`` and any tracked or
+    untracked file under it. That is a legitimate developer default, but it is
+    much broader than most deployments intend, and nothing previously said so.
+    Reporting it lets an operator (or a client) see the boundary instead of
+    having to infer it from a rejection message.
+    """
+
+    roots, source = _read_roots_with_source()
+    includes_repo_root = False
+    if source == READ_BOUNDARY_SOURCE_DEFAULT:
+        repo_root = _repo_root()
+        includes_repo_root = repo_root is not None and repo_root in roots
+    return {
+        "source": source,
+        "env_var": _ALLOWED_ROOTS_ENV,
+        "roots": [str(root) for root in roots],
+        "includes_repository_root": includes_repo_root,
+    }
+
+
+def _read_roots_with_source() -> tuple[tuple[Path, ...], str]:
     roots: list[Path] = []
     configured = os.environ.get(_ALLOWED_ROOTS_ENV, "")
     explicit_roots = [Path(item) for item in configured.split(os.pathsep) if item]
     if explicit_roots:
-        return _unique_roots(explicit_roots)
+        return _unique_roots(explicit_roots), READ_BOUNDARY_SOURCE_CONFIGURED
     for env_name in _CONFIGURED_ROOT_ENV_NAMES:
         env_value = os.environ.get(env_name)
         if env_value:
@@ -71,7 +99,11 @@ def _configured_read_roots() -> tuple[Path, ...]:
         roots.append(Path.cwd())
     home = Path.home()
     roots.extend((home / "log" / "agents", home / "log" / "execute"))
-    return _unique_roots(roots)
+    return _unique_roots(roots), READ_BOUNDARY_SOURCE_DEFAULT
+
+
+def _configured_read_roots() -> tuple[Path, ...]:
+    return _read_roots_with_source()[0]
 
 
 def _is_under_root(path: Path, root: Path) -> bool:

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -262,8 +262,26 @@ def server_manifest() -> dict[str, Any]:
             "local_files_only": True,
             "execution_tools_enabled": False,
             "shell_enabled": False,
+            "read_boundary": manifest_tools.read_boundary(),
         },
     }
+
+
+def read_boundary_warning() -> str | None:
+    """Return an operator warning when the read boundary is the wide default."""
+
+    boundary = manifest_tools.read_boundary()
+    if boundary["source"] != manifest_tools.READ_BOUNDARY_SOURCE_DEFAULT:
+        return None
+    if not boundary["includes_repository_root"]:
+        return None
+    return (
+        f"agilab-mcp: {boundary['env_var']} is not set, so the read boundary "
+        f"defaults to the repository checkout and every file under it "
+        f"(including .git). Set {boundary['env_var']} to the directories this "
+        f"server should expose. Effective roots: "
+        f"{', '.join(boundary['roots'])}"
+    )
 
 
 def call_tool(name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
@@ -384,7 +402,16 @@ def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
         )
 
 
-def serve_stdio(stdin: Any = sys.stdin, stdout: Any = sys.stdout) -> int:
+def serve_stdio(
+    stdin: Any = sys.stdin, stdout: Any = sys.stdout, stderr: Any = None
+) -> int:
+    # Diagnostics must never touch stdout: it carries the JSON-RPC stream, and
+    # a stray line would desynchronise the client.
+    warning = read_boundary_warning()
+    if warning:
+        stream = sys.stderr if stderr is None else stderr
+        print(warning, file=stream)
+        stream.flush()
     for line in stdin:
         if not line.strip():
             continue

--- a/test/test_agilab_mcp_boundary.py
+++ b/test/test_agilab_mcp_boundary.py
@@ -1,0 +1,79 @@
+"""Read-boundary disclosure contract for the AGILAB MCP server.
+
+The boundary itself is unchanged: what a client may read is exactly what it
+could read before. These tests pin that the boundary is *visible* - reported in
+the server manifest, and warned about on stderr when it falls back to the wide
+default that includes the whole repository checkout.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from agilab_mcp import manifest_tools, server
+
+
+def test_explicit_roots_are_reported_as_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+
+    boundary = manifest_tools.read_boundary()
+    assert boundary["source"] == manifest_tools.READ_BOUNDARY_SOURCE_CONFIGURED
+    assert boundary["roots"] == [str(tmp_path.resolve())]
+    assert boundary["includes_repository_root"] is False
+    assert server.read_boundary_warning() is None
+
+
+def test_unset_roots_fall_back_to_default_and_warn(monkeypatch):
+    monkeypatch.delenv("AGILAB_MCP_ALLOWED_ROOTS", raising=False)
+
+    boundary = manifest_tools.read_boundary()
+    assert boundary["source"] == manifest_tools.READ_BOUNDARY_SOURCE_DEFAULT
+
+    warning = server.read_boundary_warning()
+    if boundary["includes_repository_root"]:
+        assert warning is not None
+        assert "AGILAB_MCP_ALLOWED_ROOTS" in warning
+        assert ".git" in warning
+    else:  # pragma: no cover - installed layouts without a repo checkout
+        assert warning is None
+
+
+def test_server_manifest_publishes_the_effective_boundary(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+
+    policy = server.server_manifest()["policy"]
+    # Existing policy claims must not regress.
+    assert policy["read_only"] is True
+    assert policy["local_files_only"] is True
+    assert policy["execution_tools_enabled"] is False
+    assert policy["shell_enabled"] is False
+    assert policy["read_boundary"]["roots"] == [str(tmp_path.resolve())]
+
+
+def test_warning_goes_to_stderr_and_never_corrupts_the_jsonrpc_stream(monkeypatch):
+    """stdout carries the JSON-RPC stream; a stray line desynchronises clients."""
+
+    monkeypatch.delenv("AGILAB_MCP_ALLOWED_ROOTS", raising=False)
+    stdout, stderr = io.StringIO(), io.StringIO()
+    stdin = io.StringIO('{"jsonrpc":"2.0","id":1,"method":"initialize"}\n')
+
+    assert server.serve_stdio(stdin=stdin, stdout=stdout, stderr=stderr) == 0
+
+    lines = stdout.getvalue().splitlines()
+    assert len(lines) == 1
+    # Every stdout line must parse as JSON, warning or not.
+    assert json.loads(lines[0])["id"] == 1
+    if server.read_boundary_warning() is not None:
+        assert "AGILAB_MCP_ALLOWED_ROOTS" in stderr.getvalue()
+
+
+def test_boundary_disclosure_does_not_widen_access(tmp_path, monkeypatch):
+    """Reporting the boundary must not change what the boundary permits."""
+
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.read_manifest("/etc/passwd")


### PR DESCRIPTION
Finding 4 from the MCP audit — the **visibility half only**. What a client may read is unchanged; narrowing the default is a separate decision.

## Problem

With `AGILAB_MCP_ALLOWED_ROOTS` unset, `_configured_read_roots()` falls back to defaults including `_repo_root()` — the whole checkout found by walking up to `.git`. So the server can read any file in the repo, `.git/` and any `.env` included. Nothing said so; an operator could only infer the boundary from a rejection message.

## Change

- `manifest_tools.read_boundary()` reports the effective roots, whether they are `configured` or `default`, and whether the repo root is included.
- `server_manifest().policy.read_boundary` publishes it, so a client can see the boundary alongside the existing `read_only` / `local_files_only` claims.
- `serve_stdio` warns once at startup when the boundary is the repo-wide default.

```
unset  -> source=default    includes_repository_root=True   warning emitted
set    -> source=configured roots=[/private/tmp]            warning=None
```

## stdout is not touched

The warning goes to **stderr**. stdout carries the JSON-RPC stream and a stray line would desynchronise the client. `serve_stdio` gained an injectable `stderr` so this is testable, and one test asserts every stdout line still parses as JSON while the warning lands on stderr.

## Non-widening

`_configured_read_roots()` keeps its exact prior semantics — it now just delegates to a variant that also returns the source. A test asserts `/etc/passwd` is still rejected, so disclosure cannot be mistaken for relaxation.

## Tests

New `test/test_agilab_mcp_boundary.py` (5 tests).

```
test_agilab_mcp_boundary + _jsonrpc + _redaction + test_audience_bridges
+ test_headless_cli_smoke + test_package_split_contract  -> 94 passed
```

The 1 local failure is the pre-existing `MixedCheckoutImportError` in `test_lab_run_routes_bridge_commands`, which fails identically on unmodified `origin/main` and does not occur in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)