### PR TITLE
fix: align AGILAB naming contracts

### DIFF
--- a/ADOPTION.md
+++ b/ADOPTION.md
@@ -41,7 +41,7 @@ the project manually for the built-in proof:
 
 | Wizard action | What it does |
 |---|---|
-| `1. INSTALL` | Selects `flight_telemetry_project` and launches the ORCHESTRATE install. |
+| `1. Deploy scheduler & workers` | Selects `flight_telemetry_project` and launches the ORCHESTRATE deployment. |
 | `2. RUN` | Runs the project locally with cluster, benchmark, and service mode off. |
 | `3. ANALYSIS` | Opens the default analysis route after evidence exists. |
 | `Import notebook` | Starts the alternative notebook lane and exposes the notebook upload control. |

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "54598ad042ab7cfccbdb45c47e73a31829ffb281405af2730e543d27cc0138c0",
+  "source_digest_sha256": "5e41d32e28f68119894f52b92a00175c017e59b4baa333da7cbdff0feefd0edd",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "54598ad042ab7cfccbdb45c47e73a31829ffb281405af2730e543d27cc0138c0"
+  "target_digest_sha256": "5e41d32e28f68119894f52b92a00175c017e59b4baa333da7cbdff0feefd0edd"
 }

--- a/docs/source/_static/page-shots/analysis-page.svg
+++ b/docs/source/_static/page-shots/analysis-page.svg
@@ -4,7 +4,7 @@
 <defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
 <rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
 <rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
-<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGILAB</text>
 <text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
 <text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
 <text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>

--- a/docs/source/_static/page-shots/core-pages-overview.svg
+++ b/docs/source/_static/page-shots/core-pages-overview.svg
@@ -105,14 +105,15 @@
 <text x="380" y="666" class="small">Recommended path: run the built-in flight telemetry demo, then inspect the generated evidence. Notebook-first paths are below: use AGILAB's included notebook first;</text>
 <text x="380" y="688" class="small">upload your own notebook from PROJECT Create when you are ready.</text>
 <rect x="380" y="711" width="124" height="40" rx="8" fill="#0b1727" stroke="#4f6471"/>
-<text x="393" y="736" class="button">1. INSTALL demo</text>
+<text x="393" y="736" class="button">1. DEPLOY demo</text>
 <rect x="712" y="711" width="130" height="40" rx="8" fill="#0b1727" stroke="#4f6471"/>
-<text x="726" y="736" class="button">2. EXECUTE demo</text>
+<text x="726" y="736" class="button">2. RUN demo</text>
 <rect x="1044" y="711" width="131" height="40" rx="8" fill="#0b1727" stroke="#4f6471"/>
 <text x="1058" y="736" class="button">3. OPEN ANALYSIS</text>
-<text x="380" y="782" class="small">Runs ORCHESTRATE <tspan class="code">INSTALL</tspan> for</text>
-<text x="380" y="805" class="code">flight_telemetry_project.</text>
-<text x="712" y="782" class="small">Runs ORCHESTRATE <tspan class="code">EXECUTE</tspan> for the same demo.</text>
+<text x="380" y="782" class="small">Runs ORCHESTRATE</text>
+<text x="380" y="805" class="code">Deploy scheduler &amp; workers</text>
+<text x="380" y="828" class="code">for flight_telemetry_project.</text>
+<text x="712" y="782" class="small">Runs ORCHESTRATE <tspan class="code">RUN</tspan> for the same demo.</text>
 <text x="1044" y="782" class="small">Opens ANALYSIS on <tspan class="code">view_maps</tspan> for the generated</text>
 <text x="1044" y="805" class="small">evidence.</text>
 </svg>

--- a/docs/source/_static/page-shots/orchestrate-page.svg
+++ b/docs/source/_static/page-shots/orchestrate-page.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
 <title id="title">AGILAB orchestrate page vector screenshot summary</title>
-<desc id="desc">Screenshot-derived SVG summary generated from orchestrate-page.png, sha256 840b4bd8f3f33cb7. The PNG remains the canonical raster evidence.</desc>
+<desc id="desc">Synchronized vector summary of the AGILAB ORCHESTRATE page and its current deployment actions.</desc>
 <defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
 <rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
 <rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
-<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGILAB</text>
 <text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
 <rect x="20" y="111" width="260" height="28" rx="6" fill="#38546c"/>
 <text x="28" y="128" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">ORCHESTRATE</text>
@@ -21,7 +21,7 @@
 <rect x="380" y="168" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
 <text x="418" y="194" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Environment details</text>
 <rect x="380" y="224" width="980" height="92" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
-<text x="418" y="250" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">1. Resources and install</text>
+<text x="418" y="250" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">1. Resources and deployment</text>
 <rect x="412" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
 <text x="487" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Share: not used</text>
 <rect x="587" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
@@ -43,9 +43,9 @@
 <rect x="937" y="372" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
 <text x="1012" y="391" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Enable Cluster</text>
 <rect x="380" y="448" width="980" height="68" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
-<text x="418" y="474" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Generated INSTALL snippet</text>
-<rect x="412" y="484" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
-<text x="487" y="503" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">INSTALL</text>
+<text x="418" y="474" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Generated Deploy scheduler &amp; workers snippet</text>
+<rect x="412" y="484" width="286" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="555" y="503" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Deploy scheduler &amp; workers</text>
 <rect x="380" y="560" width="980" height="68" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
 <text x="418" y="586" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">2. Configure run arguments</text>
 <rect x="412" y="596" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>

--- a/docs/source/_static/page-shots/project-create-page.svg
+++ b/docs/source/_static/page-shots/project-create-page.svg
@@ -4,7 +4,7 @@
 <defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
 <rect x="0" y="0" width="1440" height="1000" rx="0" fill="#07111f"/>
 <rect x="0" y="0" width="300" height="1000" rx="0" fill="#10293b"/>
-<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGILAB</text>
 <rect x="20" y="77" width="260" height="28" rx="6" fill="#38546c"/>
 <text x="28" y="94" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">PROJECT</text>
 <text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>

--- a/docs/source/_static/page-shots/project-page.svg
+++ b/docs/source/_static/page-shots/project-page.svg
@@ -4,7 +4,7 @@
 <defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
 <rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
 <rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
-<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGILAB</text>
 <rect x="20" y="77" width="260" height="28" rx="6" fill="#38546c"/>
 <text x="28" y="94" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">PROJECT</text>
 <text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>

--- a/docs/source/_static/page-shots/screenshot_manifest.json
+++ b/docs/source/_static/page-shots/screenshot_manifest.json
@@ -20,8 +20,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "analysis-page.svg",
-      "svg_summary_sha256": "d9dc8373933b3545ae8411e60096b7f806aa4744c90c1162300a1fddf19f0081",
-      "svg_summary_size_bytes": 5491,
+      "svg_summary_sha256": "3b8c6b7c763532bac382fe3abdf5c4f30c67be99b72017123e68a8d393269e88",
+      "svg_summary_size_bytes": 5490,
       "url": "",
       "width_px": 1440
     },
@@ -40,8 +40,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "core-pages-overview.svg",
-      "svg_summary_sha256": "e95559eec36c82452cf4e867e6563d334d3623b1ae553941a153eac2a7c3600a",
-      "svg_summary_size_bytes": 8321,
+      "svg_summary_sha256": "69a51ee01767519283b033df9387c78ffcc0b96559a4f7f4e4f9a8c3b7ab3e3c",
+      "svg_summary_size_bytes": 8349,
       "url": "",
       "width_px": 1440
     },
@@ -60,8 +60,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "orchestrate-page.svg",
-      "svg_summary_sha256": "ae742b612cb359438734be4e21e2fd11bcaf7e2283f5c3473a4ea64f75ca7cdb",
-      "svg_summary_size_bytes": 5637,
+      "svg_summary_sha256": "007fb15666b896571eb8b1e85b378663de06b901c36ded2236b239dd18247e04",
+      "svg_summary_size_bytes": 5640,
       "url": "",
       "width_px": 1440
     },
@@ -80,8 +80,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "project-create-page.svg",
-      "svg_summary_sha256": "e3abe232bfc8fd8c0d1fdb8290010af2786bac0ad78536de7a6b0f4a592db916",
-      "svg_summary_size_bytes": 6976,
+      "svg_summary_sha256": "b0621e58ad63b7f70adeb10a151586cad6e5fefecdbf16e617df0b46a4de321a",
+      "svg_summary_size_bytes": 6975,
       "url": "",
       "width_px": 1440
     },
@@ -100,8 +100,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "project-page.svg",
-      "svg_summary_sha256": "77ad6c8bbdb1b2fa222c3d29a2e9f50230aded30f9cda44bae3d211c9862793f",
-      "svg_summary_size_bytes": 8519,
+      "svg_summary_sha256": "4374b08229304aa0e7d7e76a94b018f56dad88e1edc6e0d9a4797b43fcbb7076",
+      "svg_summary_size_bytes": 8518,
       "url": "",
       "width_px": 1440
     },
@@ -120,8 +120,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "workflow-page.svg",
-      "svg_summary_sha256": "32ced868e57f15534e282833228267115d66740e68346feb6b5bfb7cfe13ba1d",
-      "svg_summary_size_bytes": 6270,
+      "svg_summary_sha256": "7d6d1968236d91667b9e8d43fd50ace51ffd168f43d83966c4ea62e8c3b9eb96",
+      "svg_summary_size_bytes": 6269,
       "url": "",
       "width_px": 1440
     }

--- a/docs/source/_static/page-shots/workflow-page.svg
+++ b/docs/source/_static/page-shots/workflow-page.svg
@@ -4,7 +4,7 @@
 <defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
 <rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
 <rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
-<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGILAB</text>
 <text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
 <text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
 <rect x="20" y="145" width="260" height="28" rx="6" fill="#38546c"/>

--- a/docs/source/cluster.rst
+++ b/docs/source/cluster.rst
@@ -84,11 +84,11 @@ Workflow session directories
 
 ORCHESTRATE isolates cluster run data below the cluster share instead of writing
 directly into the user share root. When cluster mode is enabled and
-``AGI_CLUSTER_SHARE`` is usable, the default **Workers Data Path** becomes:
+``AGI_CLUSTER_SHARE`` is usable, the default **Workflow share root** becomes:
 
 .. code-block:: text
 
-   <AGI_CLUSTER_SHARE>/<cluster-user>/workflows/<app-name>/<session-id>/workers
+   <AGI_CLUSTER_SHARE>/<cluster-user>/<workflow-id>/<session-id>
 
 This avoids collisions when the same user runs several app workflows on the same
 cluster share. The cluster settings UI exposes two controls:
@@ -108,7 +108,7 @@ The same behavior can be preseeded with environment values:
 - ``AGI_WORKFLOW_SESSION=<session-id>``
 
 If the cluster share is unavailable and an explicit ``AGI_LOCAL_SHARE`` exists,
-ORCHESTRATE disables cluster mode and points **Workers Data Path** back to the
+ORCHESTRATE disables cluster mode and points **Workflow share root** back to the
 local share instead of creating a shadow cluster-share directory. Fix the mounted
 ``AGI_CLUSTER_SHARE`` before enabling cluster mode again.
 
@@ -128,7 +128,7 @@ is classified by SSH BatchMode auth, operating system, ``python3``, ``uv``,
 ``sshfs``, and reverse SSH back to the scheduler when ``--scheduler`` is
 provided.
 
-Discovery is not a trust decision. Before running ``INSTALL`` or sending files
+Discovery is not a trust decision. Before running ``Deploy scheduler & workers`` or sending files
 to a remote worker, verify each worker host-key fingerprint out of band and pin
 it in the manager user's SSH ``known_hosts`` file. Controller-to-worker SSH and
 SCP default to strict host-key verification using ``~/.ssh/known_hosts``. To use
@@ -192,8 +192,8 @@ scheduler source, or if a stale/unwritable SSHFS mount is found, AGILAB tries to
 unmount it with ``fusermount3``, ``fusermount``, or ``umount`` before
 remounting.
 
-The same contract is used by ORCHESTRATE ``INSTALL``. Keep ``AGI_CLUSTER_SHARE``
-as the scheduler-side shared root, keep **Workers Data Path** pointing to the
+The same contract is used by ORCHESTRATE ``Deploy scheduler & workers``. Keep
+``AGI_CLUSTER_SHARE`` as the scheduler-side shared root, keep **Workflow share root** pointing to the
 worker-visible mount target, and let the remote deployment mount the scheduler
 share with ``sshfs`` before worker post-install hooks read datasets or write
 outputs. Do not clear the cluster-share path just because workers are remote;
@@ -275,7 +275,7 @@ On macOS workers, make the SSHFS prerequisite explicit before running
   ``--scheduler``, because the worker-side mount command reads
   ``<scheduler-user>@<scheduler>:/...``
 - ensure the worker trusts the scheduler host key before running
-  ``--setup-share`` or ORCHESTRATE ``INSTALL``. For a new scheduler host, verify
+  ``--setup-share`` or ORCHESTRATE ``Deploy scheduler & workers``. For a new scheduler host, verify
   the fingerprint out of band, then seed ``known_hosts`` on the worker with
   ``ssh-keyscan -H <scheduler-host> >> ~/.ssh/known_hosts``.
 
@@ -365,7 +365,7 @@ after a crash, unmount the old target on the worker before rerunning setup:
    '
 
 Then rerun ``agilab doctor --cluster --setup-share sshfs --apply`` or
-ORCHESTRATE ``INSTALL``. The automatic installer already attempts this cleanup
+ORCHESTRATE ``Deploy scheduler & workers``. The automatic installer already attempts this cleanup
 for stale, unexpected-source, or unwritable mounts, but doing it manually makes
 scheduler switches explicit and easier to audit.
 

--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -160,7 +160,7 @@ README summary alone. For normal maintenance, use the compact checks first:
    uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
    uv --preview-features extra-build-dependencies run python tools/agilab_web_robot.py --target-url https://huggingface.co/spaces/jpmorard/agilab
    uv --preview-features extra-build-dependencies run python tools/production_readiness_report.py --compact
-   uv --preview-features extra-build-dependencies run python tools/supply_chain_attestation_report.py --compact
+   uv --preview-features extra-build-dependencies run python tools/supply_chain_integrity_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/public_proof_scenarios.py --compact
    uv --preview-features extra-build-dependencies run python tools/public_proof_scenarios.py --first-proof-json first-proof.json --hf-smoke-json hf-space-smoke.json --output public-proof-scenarios.json
    uv --preview-features extra-build-dependencies run python tools/first_launch_robot.py --json --output first-launch-robot.json

--- a/docs/source/demo_capture_script.md
+++ b/docs/source/demo_capture_script.md
@@ -117,7 +117,7 @@ in the `70-75s` final range and end on measurable evidence.
 Primary run path:
 
 1. `PROJECT` -> select `src/agilab/apps/builtin/mission_decision_project`.
-2. `ORCHESTRATE` -> `INSTALL`, then `EXECUTE`.
+2. `ORCHESTRATE` -> `Deploy scheduler & workers`, then `RUN`.
 3. `ANALYSIS` -> open the default `view_data_io_decision` page.
 
 Successful run indicators:

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -146,7 +146,7 @@ The static scenario contract is available as JSON:
   Use :doc:`execution-playground` when the demo objective is performance
   engineering rather than a domain story. Select ``execution_pandas_project``,
   keep the default ``typed_numeric`` kernel and Cython setting, run
-  ``INSTALL`` then ``EXECUTE``, and inspect the reducer evidence for
+  ``Deploy scheduler & workers`` then ``RUN``, and inspect the reducer evidence for
   ``kernel_mode``, ``kernel_runtime``, and ``dtype_contract``.
   The versioned local kernel proof records a large hot-loop speedup (a
   representative local figure on the order of hundreds of times, with matching

--- a/docs/source/diagrams/distributed_orchestrate_pipeline_handoff.svg
+++ b/docs/source/diagrams/distributed_orchestrate_pipeline_handoff.svg
@@ -28,7 +28,7 @@
   <rect x="170" y="180" width="226" height="34" rx="17" fill="#d7e8f7" stroke="#2f6fa3" stroke-width="2"/>
   <text class="chip-text" x="283" y="202" text-anchor="middle">Generate AGI.run(...)</text>
   <text class="card-text" x="112" y="244">1. Configure scheduler, workers, and mode flags</text>
-  <text class="card-text" x="112" y="276">2. Use INSTALL / CHECK DISTRIBUTE / RUN</text>
+  <text class="card-text" x="112" y="276">2. Use Deploy scheduler &amp; workers / CHECK distribute / RUN</text>
   <text class="card-text" x="112" y="308">3. Copy the generated snippet, do not rewrite it</text>
 
   <rect x="678" y="118" width="438" height="212" rx="24" fill="#efe8d9" stroke="#9b6c1f" stroke-width="3"/>

--- a/docs/source/distributed-workers.rst
+++ b/docs/source/distributed-workers.rst
@@ -39,16 +39,16 @@ Before configuring distributed workers, make sure the environment is ready:
   notation whenever the username is not obvious.
 - A shared writable cluster path is visible on every node. The scheduler-side
   root is ``AGI_CLUSTER_SHARE``; remote workers can see the same backing storage
-  through an SSHFS mount at **Workers Data Path**. In cluster mode, do not rely
+  through an SSHFS mount at **Workflow share root**. In cluster mode, do not rely
   on ``AGI_LOCAL_SHARE`` as a fallback.
-- For remote workers, **Workers Data Path** is the worker-visible mount target,
+- For remote workers, **Workflow share root** is the worker-visible mount target,
   not a request to rewrite the scheduler-side ``AGI_CLUSTER_SHARE``. If the
   scheduler already points ``AGI_CLUSTER_SHARE`` at an absolute share root, AGILAB
   keeps that root and passes the worker-side path separately.
 - The shared-path rule above applies to remote workers. For a local-only Dask
   cluster, where workers are ``127.0.0.1`` or ``localhost``, the scheduler and
   workers share the same local filesystem. ``AGI_CLUSTER_SHARE`` may therefore
-  be a normal local path, including APFS on macOS, and **Workers Data Path** does
+  be a normal local path, including APFS on macOS, and **Workflow share root** does
   not need to point to an SSHFS mount.
 - In multi-user environments, each operator uses a separate cluster-share root.
   Do not let several users write into the same ``AGI_CLUSTER_SHARE`` tree.
@@ -187,7 +187,7 @@ Use this short checklist the first time:
 
 1. In **ORCHESTRATE**, open **System settings** and enter the scheduler host and
    worker map.
-2. Use **INSTALL** to stage the worker runtime on the selected machines.
+2. Use **Deploy scheduler & workers** to stage the worker runtime on the selected machines.
 3. Use **CHECK DISTRIBUTE** to inspect the generated ``AGI.get_distrib(...)``
    plan and confirm the partitions land on the intended workers.
 4. Use **RUN** to generate the current ``AGI.run(...)`` snippet for that setup.
@@ -307,14 +307,14 @@ Use these habits to keep distributed runs predictable:
 - Start with one local scheduler and one remote worker before scaling to many
   nodes.
 - Treat ``AGI_CLUSTER_SHARE`` as the scheduler-side source path and
-  **Workers Data Path** as the worker-side SSHFS mount target. These paths may
+  **Workflow share root** as the worker-side SSHFS mount target. These paths may
   differ on mixed operating systems, for example a macOS scheduler path mounted
   under a Linux worker home directory, but they must expose the same backing
-  storage after SSHFS is mounted. Do not use **Workers Data Path** to replace a
+  storage after SSHFS is mounted. Do not use **Workflow share root** to replace a
   preconfigured scheduler share root.
 - Keep local-only and remote-worker clusters distinct. Local-only clusters can
   use a local ``AGI_CLUSTER_SHARE`` path directly; remote-worker clusters need a
-  worker-visible shared mount target in **Workers Data Path**.
+  worker-visible shared mount target in **Workflow share root**.
 - Keep worker SSHFS prerequisites explicit: ``sshfs`` must be installed, the
   worker must be able to SSH back to the scheduler, and the scheduler host key
   should already be present in the worker ``known_hosts`` file. AGILAB uses
@@ -323,7 +323,7 @@ Use these habits to keep distributed runs predictable:
 - Keep cluster share and local share conceptually separate. In cluster mode,
   outputs should land on the shared cluster path, not silently on local-only
   storage.
-- Re-run **INSTALL** after dependency changes, worker-environment changes, or
+- Re-run **Deploy scheduler & workers** after dependency changes, worker-environment changes, or
   app updates that affect imports.
 - Use **CHECK DISTRIBUTE** before expensive runs so the partitioning matches the
   intended worker layout.
@@ -337,18 +337,18 @@ Troubleshooting
 
 Common distributed setup failures usually fall into one of these categories:
 
-- **INSTALL hangs or never starts remotely**: verify SSH reachability, keys, and
+- **Deploy scheduler & workers hangs or never starts remotely**: verify SSH reachability, keys, and
   host trust.
 - **Workers do not join the scheduler**: verify the scheduler host is reachable
   from the workers and that the worker host definitions are correct.
 - **Outputs go to the wrong place**: verify cluster mode is enabled, the
   scheduler ``AGI_CLUSTER_SHARE`` is mounted on each remote worker with SSHFS,
-  and **Workers Data Path** matches the worker-visible mount target.
+  and **Workflow share root** matches the worker-visible mount target.
 - **Remote import errors after a successful install**: verify the worker
   environment was rebuilt from the current app and that dependencies are
   declared in the correct ``pyproject.toml`` scope.
 - **Remote Dask worker never attaches and logs mention ``Failed to spawn:
-  dask``**: re-run **INSTALL** with the current AGILAB version so the generated
+  dask``**: re-run **Deploy scheduler & workers** with the current AGILAB version so the generated
   worker environment is recreated and receives ``dask[distributed]``. This is
   part of AGILAB cluster deployment, not a dependency every app should carry.
 - **WORKFLOW runs stale cluster code**: regenerate or re-import the snippet from

--- a/docs/source/edit-help.rst
+++ b/docs/source/edit-help.rst
@@ -39,8 +39,8 @@ Sidebar
     symlink. It is fast and lightweight, but deleting or rebuilding the source
     environment can break the clone too.
   - ``Working clone (no shared .venv)`` creates the project without a shared
-    ``.venv``. This is the safer choice for real development; run ``INSTALL``
-    before ``EXECUTE`` to recreate the environment for the clone.
+    ``.venv``. This is the safer choice for real development; run ``Deploy scheduler & workers``
+    before ``RUN`` to recreate the environment for the clone.
 
 - ``Rename`` now preserves the existing project ``.venv`` while switching the
   project folder to the new name, then removes the original folder and switches
@@ -74,8 +74,8 @@ What to do next:
 
 - If you chose ``Temporary clone``, you can usually inspect or edit the clone
   immediately.
-- If you chose ``Working clone``, go to :doc:`execute-help`, run ``INSTALL``,
-  then run ``EXECUTE`` before expecting the clone to behave like the source
+- If you chose ``Working clone``, go to :doc:`execute-help`, run ``Deploy scheduler & workers``,
+  then run ``RUN`` before expecting the clone to behave like the source
   project.
 - If the clone should expose optional analysis bundles, open ``APP-SETTINGS``
   and check the ``[pages]`` section.

--- a/docs/source/execute-help.rst
+++ b/docs/source/execute-help.rst
@@ -44,7 +44,8 @@ Main Content Area
   combination will execute and the settings are written back to
   ``~/.agilab/apps/<app>/app_settings.toml``.
 - ``Install`` renders the install snippet that provisions the project's virtual
-  environments. ``INSTALL`` streams stdout/stderr into ``Install logs`` so you
+  environments. ``Deploy scheduler & workers`` streams stdout/stderr into
+  ``Deployment logs`` so you
   know when the worker is ready. A successful install automatically enables the
   ``Run`` section.
 - ``Distribute`` is split into two parts:
@@ -67,7 +68,7 @@ Main Content Area
   streams logs into the ``Run logs`` expander and stores the output timings in
   ``benchmark.json``, which is summarised under ``Benchmark results``.
 - ``Notebook`` exports the current ORCHESTRATE recipe as ``<app>_orchestrate.ipynb``.
-  It includes the generated ``INSTALL``, ``CHECK distribute``, and ``RUN``
+  It includes the generated ``Deploy scheduler & workers``, ``CHECK distribute``, and ``RUN``
   snippets that are available for the active configuration. Use it when you want
   a review, handoff, or no-lock-in copy of the orchestration work that remains
   useful outside the AGILAB UI. It is export-only: notebook import remains in
@@ -224,7 +225,7 @@ the full step-by-step deployment guide.
 For a first pass through the UI, follow this sequence exactly:
 
 1. Open ``System settings`` and configure the scheduler host and worker map.
-2. Run ``INSTALL`` so the worker runtime is staged on the configured machines.
+2. Run ``Deploy scheduler & workers`` so the worker runtime is staged on the configured machines.
 3. Run ``CHECK DISTRIBUTE`` to inspect the generated distribution tree and
    confirm the work plan matches the selected workers.
 4. Open ``Run`` and copy or export the generated ``AGI.run`` snippet.
@@ -322,7 +323,7 @@ Troubleshooting and checks
 
 Use these checks if Orchestrate actions do not behave as expected:
 
-- If ``INSTALL`` stays stuck, check cluster host reachability, SSH credentials,
+- If ``Deploy scheduler & workers`` stays stuck, check cluster host reachability, SSH credentials,
   and whether ``~/.agilab/.env`` still points to valid venv paths.
 - If the generated snippet looks wrong, compare ``[args]`` in
   ``~/.agilab/apps/<project>/app_settings.toml`` with the values shown in

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -383,7 +383,7 @@ How to run it
       uv --preview-features extra-build-dependencies run --extra ui streamlit run src/agilab/main_page.py
 
 2. In **PROJECT**, select ``src/agilab/apps/builtin/execution_pandas_project``.
-3. In **ORCHESTRATE**, run **INSTALL** once, then **EXECUTE**.
+3. In **ORCHESTRATE**, run **Deploy scheduler & workers** once, then **RUN**.
 4. Enable **Benchmark all modes** when you want AGILAB to compare execution paths.
 5. Repeat with ``src/agilab/apps/builtin/execution_polars_project``.
 6. Compare the benchmark table in **ORCHESTRATE > Benchmark results** and the generated outputs.

--- a/docs/source/experiment-help.rst
+++ b/docs/source/experiment-help.rst
@@ -253,7 +253,7 @@ Execution is intentionally conservative:
   ``RunRequest`` payload that will be sent for each stage.
   The built-in submitter is configured from the active app's saved
   **ORCHESTRATE** cluster settings: ``cluster_enabled`` must be true, a
-  scheduler, workers, and ``Workers Data Path`` must be present, and each DAG
+  scheduler, workers, and ``Workflow share root`` must be present, and each DAG
   stage ``app`` must resolve under ``src/agilab/apps/builtin`` or
   ``src/agilab/apps``. Each submitted stage runs in an isolated AGILAB
   subprocess so parallel ready stages do not share the in-process ``AGI`` class

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -62,11 +62,11 @@ What should I run first?
 
 Run one local first-proof lane before branching out:
 
-- built-in lane: landing page -> ``1. INSTALL demo`` -> ``2. EXECUTE demo`` ->
+- built-in lane: landing page -> ``1. DEPLOY demo`` -> ``2. RUN demo`` ->
   ``3. OPEN ANALYSIS`` for ``flight_telemetry_project``
 - notebook lane: landing page -> ``Create from built-in notebook`` to create
   ``flight-telemetry-from-notebook-project``, then prove it with ORCHESTRATE
-  ``INSTALL`` and ``EXECUTE``
+  ``Deploy scheduler & workers`` and ``RUN``
 
 Do not start with clusters, external apps, service mode, or broad tests. A small
 known-good local proof gives you a baseline before you debug a larger topology.
@@ -338,7 +338,7 @@ Missing worker packages during a run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If a worker virtual environment fails with ``ModuleNotFoundError``, rerun the
-matching ORCHESTRATE ``INSTALL`` path for the selected project. For source
+matching ORCHESTRATE ``Deploy scheduler & workers`` path for the selected project. For source
 debugging, check both dependency scopes:
 
 - manager dependencies in the app project ``pyproject.toml``

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -298,7 +298,7 @@ current public evaluation snapshot.
   with exact evidence commands when the proof is missing, invalid, incomplete,
   or failing
 - the release-proof profile includes the packaged notebook import lane:
-  it creates ``flight_telemetry_from_notebook_project``, runs ``INSTALL``,
+  it creates ``flight_telemetry_from_notebook_project``, runs ``Deploy scheduler & workers``,
   executes the imported project, and opens ANALYSIS far enough to prove the
   project notebook and analysis links are discoverable; it also refreshes the
   exported ``lab_stages.ipynb`` handoff and verifies the manifest, source cell
@@ -319,15 +319,14 @@ current public evaluation snapshot.
   ``agilab.public_certification_profile.v1``; it turns the compatibility
   matrix into a ``bounded_public_evidence`` profile while explicitly avoiding
   production or third-party certification claims
-- the supply-chain attestation report validates
-  ``tools/supply_chain_attestation_report.py --compact`` in
-  ``supply_chain_static_attestation`` mode against
-  ``agilab.supply_chain_attestation.v1``; it fingerprints package metadata,
+- the supply-chain integrity snapshot report validates
+  ``tools/supply_chain_integrity_report.py --compact`` and identifies itself as
+  ``agilab.supply_chain_integrity_snapshot.v1`` while retaining
+  ``agilab.supply_chain_attestation.v1`` as a compatibility schema; it fingerprints package metadata,
   lockfile, license, bundled AGI core versions, exact bundle dependency pins,
   app/page payload package versions, built-in app payload versions, runtime
   dependency lower bounds, and built-in app manifests plus package payload inventory
-  and package payload budgets without formal supply-chain
-  attestation claims
+  and package payload budgets without producing a signed provenance attestation
 - the security hygiene report validates
   ``tools/security_hygiene_report.py --compact`` in
   ``agilab.security_hygiene.v1`` mode; it checks the public security policy,
@@ -432,7 +431,7 @@ to the same contract, artifact names, stable node IDs, and provenance.
 - the distributed DAG stage smoke validator writes dry-run or live execution
   evidence with ``tools/dag_distributed_stage_smoke.py --compact``; it checks
   explicit ``nodes[].execution`` request fields, the ORCHESTRATE-derived
-  scheduler/workers/Workers Data Path contract, and the two-node distributed
+  scheduler/workers/Workflow share root contract, and the two-node distributed
   request preview before a live ``--execute`` run is attempted
 - the multi-app DAG dispatch state report writes and reads back a
   persisted run-state JSON proof with

--- a/docs/source/industrial-optimization-examples.rst
+++ b/docs/source/industrial-optimization-examples.rst
@@ -58,7 +58,7 @@ than the read-only scenario comparison or service-handoff contract.
 
 1. Install or link the apps repository that contains ``sb3_trainer_project``.
 2. Open AGILAB, select ``sb3_trainer_project`` in ``PROJECT``, then run
-   ``INSTALL`` in ``ORCHESTRATE``.
+   ``Deploy scheduler & workers`` in ``ORCHESTRATE``.
 3. Choose one of the trainer templates in the app args form:
 
    - ``Train • UAV Active Mesh • PPO``

--- a/docs/source/newcomer-guide.rst
+++ b/docs/source/newcomer-guide.rst
@@ -4,7 +4,7 @@ Newcomer Guide
 If you are new to AGILab, optimize for one outcome only: one successful local
 proof from the web UI. The default lane is the built-in
 ``flight_telemetry_project`` from the web UI landing page: click
-``1. INSTALL demo`` -> ``2. EXECUTE demo`` -> ``3. OPEN ANALYSIS``. If you
+``1. DEPLOY demo`` -> ``2. RUN demo`` -> ``3. OPEN ANALYSIS``. If you
 want to prove notebook import first, use the landing page's
 ``Create from built-in notebook`` button for AGILAB's packaged sample; there is
 no file to find or upload. Use PROJECT -> ``Create`` -> ``From notebook`` later

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -190,9 +190,9 @@ machine-readable proof record.
 
    The web UI landing page exposes the current first-proof path directly:
 
-   - click ``1. INSTALL demo`` to select ``flight_telemetry_project`` and run
-     the ORCHESTRATE install
-   - click ``2. EXECUTE demo`` to start the local ORCHESTRATE execution with
+   - click ``1. DEPLOY demo`` to select ``flight_telemetry_project`` and run
+     ORCHESTRATE ``Deploy scheduler & workers``
+   - click ``2. RUN demo`` to start the local ORCHESTRATE ``RUN`` action with
      cluster, benchmark, and service mode off
    - click ``3. OPEN ANALYSIS`` after evidence exists to open the built-in
      analysis route
@@ -206,14 +206,14 @@ machine-readable proof record.
    is no notebook file to locate or upload. The wizard opens ``PROJECT`` ->
    ``Create`` -> ``From notebook`` with the bundled sample already selected;
    then you click PROJECT ``Create`` and prove the imported project with
-   ORCHESTRATE ``INSTALL`` and ``EXECUTE``. For your own local notebook, use
+   ORCHESTRATE ``Deploy scheduler & workers`` and ``RUN``. For your own local notebook, use
    PROJECT -> ``Create`` -> ``From notebook`` instead of the first-proof wizard.
    Treat that as a separate starting lane: prove either the built-in flight
    project or a notebook-imported project first, not both at the same time.
 
    The notebook lane is the full adoption proof, not only an upload shortcut:
-   notebook -> PROJECT ``Create`` -> ORCHESTRATE ``INSTALL`` -> ORCHESTRATE
-   ``EXECUTE`` -> ANALYSIS -> WORKFLOW ``Download pipeline notebook``. The last
+   notebook -> PROJECT ``Create`` -> ORCHESTRATE ``Deploy scheduler & workers`` ->
+   ORCHESTRATE ``RUN`` -> ANALYSIS -> WORKFLOW ``Download pipeline notebook``. The last
    step is the no-lock-in check: the work remains available as
    ``lab_stages.ipynb`` running on the stable, production-grade ``agi-core``
    technology if the AGILAB UI or distributed runtime is no longer the right

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -126,7 +126,7 @@ your server IP and adjust mount paths as needed. The default ``AGI_CLUSTER_SHARE
 and writable on every node: ``AgiEnv`` now fails fast instead of silently falling back
 to ``AGI_LOCAL_SHARE`` or ``$HOME/localshare``. Ensure the chosen path exists and is writable.
 In remote-worker mode, keep ``AGI_CLUSTER_SHARE`` as the scheduler-side share root and
-use **Workers Data Path** for the worker-visible SSHFS mount target; AGILAB preserves an
+use **Workflow share root** for the worker-visible SSHFS mount target; AGILAB preserves an
 existing scheduler share when those paths intentionally differ.
 If you override the default in a multi-user setup, keep one exported share root per user
 instead of pointing several operators at the same writable cluster-share directory.

--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: e7c08bc1b8b5a99ff21eb9343c57aaf2bd2ce13bea0bd740f7dc7a2f2634122c
+source_sha256: 7920028debd1a4f37e405380d5c448f218762b0f28345234d8d2df950d9d344e
 title: ANALYSIS page session environment and sidecar ownership contract
-verified_commit: f778af6d3ec49d21ba8afd37d3f26990c0eb055b
+verified_commit: c14c94d2a0adba4b3effe2890b25e07b4b6b469f
 ---
 
 # ANALYSIS page session environment and sidecar ownership contract
@@ -54,3 +54,7 @@ guard only after parent and descendant absence are both proven.
 optimized without changing session-environment, sidecar-ownership, or bounded
 preparation-cleanup behavior. Focused helpers, the AGI GUI parity profile, and
 the isolated PyTorch Playground ANALYSIS browser scenario passed.
+
+2026-07-28 re-verification: user-facing empty-evidence guidance now names the
+current ORCHESTRATE `RUN` action; session environment and sidecar ownership
+behavior is unchanged.

--- a/src/agilab/about_page/onboarding.py
+++ b/src/agilab/about_page/onboarding.py
@@ -41,7 +41,9 @@ FIRST_PROOF_NOTEBOOK_PROJECT = "flight_telemetry_from_notebook_project"
 FIRST_PROOF_NOTEBOOK_AFTER_HINT = (
     f"Then click PROJECT `Create`; it builds `{FIRST_PROOF_NOTEBOOK_PROJECT}`."
 )
-FIRST_PROOF_NOTEBOOK_RUN_HINT = "After creation, run ORCHESTRATE `INSTALL` and `EXECUTE`."
+FIRST_PROOF_NOTEBOOK_RUN_HINT = (
+    "After creation, run ORCHESTRATE `Deploy scheduler & workers` and `RUN`."
+)
 FIRST_PROOF_OWN_NOTEBOOK_HINT = (
     "For your own notebook: open PROJECT -> Create -> From notebook -> Upload your own notebook."
 )
@@ -321,7 +323,9 @@ def _first_proof_progress_rows(state: Dict[str, Any]) -> List[Dict[str, str]]:
         run_detail = f"Run evidence found under `{output_dir}`."
     elif state["current_app_matches"]:
         run_status = "Next"
-        run_detail = "Go to `ORCHESTRATE`. Click INSTALL, then EXECUTE."
+        run_detail = (
+            "Go to `ORCHESTRATE`. Click Deploy scheduler & workers, then RUN."
+        )
     else:
         run_status = "Waiting"
         run_detail = "Select the built-in flight-telemetry project before running."
@@ -412,7 +416,10 @@ def _first_proof_next_action_model(state: Dict[str, Any]) -> Dict[str, str]:
         "tone": "next",
         "phase": "Next action",
         "title": "Run the demo once",
-        "detail": "Open `ORCHESTRATE`; keep cluster, benchmark, and service mode off; click `INSTALL`, then `EXECUTE`.",
+        "detail": (
+            "Open `ORCHESTRATE`; keep cluster, benchmark, and service mode off; "
+            "click `Deploy scheduler & workers`, then `RUN`."
+        ),
         "cta_label": "Open run page",
         "proof_hint": "Done when ANALYSIS opens and `run_manifest.json` is written.",
     }
@@ -423,13 +430,16 @@ def _first_proof_wizard_steps(state: Dict[str, Any]) -> List[Dict[str, str]]:
     return [
         {
             "id": "install",
-            "button": "1. INSTALL demo",
-            "hint": "Runs ORCHESTRATE `INSTALL` for `flight_telemetry_project`.",
+            "button": "1. DEPLOY demo",
+            "hint": (
+                "Runs ORCHESTRATE `Deploy scheduler & workers` for "
+                "`flight_telemetry_project`."
+            ),
         },
         {
             "id": "run",
-            "button": "2. EXECUTE demo",
-            "hint": "Runs ORCHESTRATE `EXECUTE` for the same demo.",
+            "button": "2. RUN demo",
+            "hint": "Runs ORCHESTRATE `RUN` for the same demo.",
         },
         {
             "id": "analysis",
@@ -673,15 +683,15 @@ def _notebook_to_validated_app_rows(env: Any) -> List[Dict[str, str]]:
             "proof": project_detail,
         },
         {
-            "stage": "Install",
+            "stage": "Deploy",
             "status": "Next" if project_exists else "Waiting",
-            "action": "Open ORCHESTRATE and click `INSTALL`.",
+            "action": "Open ORCHESTRATE and click `Deploy scheduler & workers`.",
             "proof": "A project environment and worker environment are prepared.",
         },
         {
-            "stage": "Execute",
+            "stage": "Run",
             "status": "Next" if project_exists else "Waiting",
-            "action": "Click ORCHESTRATE `EXECUTE` with cluster and service mode off.",
+            "action": "Click ORCHESTRATE `RUN` with cluster and service mode off.",
             "proof": "The imported notebook stages run as an AGILAB app.",
         },
         {

--- a/src/agilab/apps-pages/view_data_io_decision/README.md
+++ b/src/agilab/apps-pages/view_data_io_decision/README.md
@@ -10,7 +10,7 @@ Streamlit analysis page for generic decision-evidence exports.
 Use this page after running a compatible producer such as `mission_decision_project` from AGILAB:
 
 1. `PROJECT` -> select `src/agilab/apps/builtin/mission_decision_project`.
-2. `ORCHESTRATE` -> `INSTALL`, then `EXECUTE`.
+2. `ORCHESTRATE` -> `Deploy scheduler & workers`, then `RUN`.
 3. `ANALYSIS` -> open `view_data_io_decision`.
 
 The page reads decision artifacts exported by the active app and displays:

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -514,7 +514,7 @@ def page(env):
     if not st.session_state[dataset_key] and not session_loaded_df_ok:
         st.warning(
             f"No dataset found in {datadir} (filter: {ext_choice}). "
-            "Use the EXECUTE → EXPORT workflow to materialize CSV/Parquet/JSON outputs first."
+            "Use the RUN → EXPORT workflow to materialize CSV/Parquet/JSON outputs first."
         )
         st.stop()  # Stop further processing
 

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/page_meta.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/page_meta.py
@@ -1,0 +1,4 @@
+"""Display metadata for the network-map page."""
+
+PAGE_LOGO = "Network map"
+PAGE_TITLE = "Network map"

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -13,6 +13,7 @@
 
 import sys
 import importlib
+import importlib.util
 import os
 from pathlib import Path
 
@@ -52,6 +53,21 @@ from streamlit.runtime.scriptrunner import RerunException
 from typing import Any, Optional
 from agi_env.agi_logger import AgiLogger
 from agi_pages.runtime import ensure_repo_on_path
+
+
+def _load_page_meta() -> tuple[str, str]:
+    module_path = Path(__file__).with_name("page_meta.py")
+    spec = importlib.util.spec_from_file_location(
+        "view_maps_network_page_meta", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load page metadata from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.PAGE_LOGO, module.PAGE_TITLE
+
+
+PAGE_LOGO, PAGE_TITLE = _load_page_meta()
 
 try:
     from edge_selection import CUSTOM_OPTION, NONE_OPTION, resolve_edges_picker_state
@@ -392,11 +408,11 @@ def _list_subdirectories(base: Path) -> list[str]:
     return []
 
 
-configure_streamlit_page(st, title="Maps Network Graph")
+configure_streamlit_page(st, title=PAGE_TITLE)
 render_streamlit_page_header(
     st,
-    title=":world_map: Maps Network Graph",
-    logo_title="Cartography Visualization",
+    title=PAGE_TITLE,
+    logo_title=PAGE_LOGO,
 )
 
 active_app_path = resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/page_meta.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/page_meta.py
@@ -1,4 +1,4 @@
 """Shared display metadata for the queue resilience analysis page."""
 
-PAGE_LOGO = "Queue Resilience Analysis"
-PAGE_TITLE = "Queue resilience analysis"
+PAGE_LOGO = "Queue health"
+PAGE_TITLE = "Queue health"

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/page_meta.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/page_meta.py
@@ -1,0 +1,4 @@
+"""Display metadata for the promotion-gate page."""
+
+PAGE_LOGO = "Promotion gate"
+PAGE_TITLE = "Promotion gate"

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -40,6 +40,25 @@ from agilab.data_connectors.data_connector_ui_preview import build_data_connecto
 from agilab.ci.ci_artifact_harvest import SCHEMA as CI_ARTIFACT_HARVEST_SCHEMA
 from agi_node.reduction import ReduceArtifact
 
+
+def _load_page_meta() -> tuple[str, str]:
+    if __package__:
+        from .page_meta import PAGE_LOGO, PAGE_TITLE
+
+        return PAGE_LOGO, PAGE_TITLE
+    module_path = Path(__file__).with_name("page_meta.py")
+    spec = importlib.util.spec_from_file_location(
+        "view_release_decision_page_meta", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load page metadata from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.PAGE_LOGO, module.PAGE_TITLE
+
+
+PAGE_LOGO, PAGE_TITLE = _load_page_meta()
+
 LOWER_IS_BETTER_KEYWORDS = ("mae", "rmse", "mape", "loss", "error", "latency", "duration")
 HIGHER_IS_BETTER_KEYWORDS = ("accuracy", "f1", "precision", "recall", "throughput", "score", "auc", "r2")
 REDUCE_ARTIFACT_GLOB = "**/reduce_summary_worker_*.json"
@@ -2079,8 +2098,8 @@ _reset_app_scoped_session_defaults(st, env)
 
 render_streamlit_page_header(
     st,
-    title="Evidence cockpit",
-    logo_title="Evidence Cockpit",
+    title=PAGE_TITLE,
+    logo_title=PAGE_LOGO,
     caption=(
         "Review baseline versus candidate evidence, explain gate failures, "
         "and export a portable promotion decision."

--- a/src/agilab/apps/builtin/data_quality_gate_project/README.md
+++ b/src/agilab/apps/builtin/data_quality_gate_project/README.md
@@ -25,7 +25,7 @@ training begins.
 ## Run In AGILAB
 
 Select `data_quality_gate_project`, then open `ORCHESTRATE`. Keep the default
-arguments for the first run, click `INSTALL`, then click `RUN`.
+arguments for the first run, click `Deploy scheduler & workers`, then click `RUN`.
 
 The default configuration creates a deterministic candidate dataset with a
 small business distribution shift. The run should complete locally and write

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "data_quality_gate_project"
+name = "data_quality_gate_worker"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB data quality gate app"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/execution_pandas_project/README.md
+++ b/src/agilab/apps/builtin/execution_pandas_project/README.md
@@ -22,8 +22,8 @@ explicit so Cython runs can be audited instead of treated as a black box.
 
 1. Select `execution_pandas_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`.
-4. Run `EXECUTE` with the default `typed_numeric` kernel.
+3. Run `Deploy scheduler & workers`.
+4. Run `RUN` with the default `typed_numeric` kernel.
 5. Inspect the result files under `execution_pandas/results`.
 
 ## Expected Inputs
@@ -53,7 +53,7 @@ change.
 
 ## Troubleshooting
 
-If `INSTALL` fails, rerun the app-local install from `ORCHESTRATE` before
+If `Deploy scheduler & workers` fails, rerun the app-local install from `ORCHESTRATE` before
 changing code. If outputs are missing, check that shared storage is writable and
 that `execution_pandas/results` was not deleted by a stale run cleanup.
 

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "execution_pandas_project"
+name = "execution_pandas_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/execution_polars_project/README.md
+++ b/src/agilab/apps/builtin/execution_polars_project/README.md
@@ -21,8 +21,8 @@ reducer evidence that can be compared against the pandas app.
 
 1. Select `execution_polars_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`.
-4. Run `EXECUTE` with the default settings.
+3. Run `Deploy scheduler & workers`.
+4. Run `RUN` with the default settings.
 5. Inspect generated CSV or Parquet outputs under `execution_polars/results`.
 
 ## Expected Inputs
@@ -49,7 +49,7 @@ totals stable.
 
 ## Troubleshooting
 
-If polars cannot be imported, run `INSTALL` again for this app instead of using
+If polars cannot be imported, run `Deploy scheduler & workers` again for this app instead of using
 the root environment. If result files are stale, enable reset in the app args or
 remove only the app-owned `execution_polars/results` directory.
 

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "execution_polars_project"
+name = "execution_polars_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/flight_telemetry_project/README.md
+++ b/src/agilab/apps/builtin/flight_telemetry_project/README.md
@@ -25,7 +25,7 @@ analysis views over the produced flight dataframe.
 
 1. Select `flight_telemetry_project` in `PROJECT`.
 2. Open `ORCHESTRATE` and review the input path.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `WORKFLOW` to inspect or extend the generated recipe.
 5. Open `ANALYSIS`, then use `view_maps` or `view_maps_network`.
 
@@ -57,7 +57,7 @@ analysis views should update while the reducer contract remains the same.
 
 ## Troubleshooting
 
-If `ANALYSIS` shows no map data, confirm that `EXECUTE` produced dataframe
+If `ANALYSIS` shows no map data, confirm that `RUN` produced dataframe
 artifacts before opening the page. If a notebook import does not suggest flight
 views, check `notebook_import_views.toml` instead of hard-coding page names.
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "flight_telemetry_project"
+name = "flight_telemetry_worker"
 version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.12,<3.15"

--- a/src/agilab/apps/builtin/minimal_app_project/README.md
+++ b/src/agilab/apps/builtin/minimal_app_project/README.md
@@ -20,7 +20,7 @@ one sitting.
 
 1. Select `minimal_app_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`.
+3. Run `Deploy scheduler & workers`.
 4. Use it as a code reference before adapting a real app.
 
 ## Expected Inputs

--- a/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "minimal_app_project"
+name = "minimal_app_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/mission_decision_project/README.md
+++ b/src/agilab/apps/builtin/mission_decision_project/README.md
@@ -23,7 +23,7 @@ does not require private services.
 
 1. Select `mission_decision_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `ANALYSIS` and select `view_data_io_decision`.
 
 ## Expected Inputs

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mission_decision_project"
+name = "mission_decision_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/README.md
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/README.md
@@ -22,7 +22,7 @@ AGILAB still owns orchestration, artifacts, manifests, and reducer evidence.
 1. Install `Rscript` and the R package `jsonlite`.
 2. Select `r_runtime_bridge_project` in `PROJECT`.
 3. Open `ORCHESTRATE`.
-4. Keep the default payload and run `INSTALL`, then `EXECUTE`.
+4. Keep the default payload and run `Deploy scheduler & workers`, then `RUN`.
 
 ## Expected Inputs
 

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "r_runtime_bridge_project"
+name = "r_runtime_bridge_worker"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB R runtime bridge app"
 requires-python = ">=3.12"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/README.md
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/README.md
@@ -22,7 +22,7 @@ and a run manifest.
 1. Select `sklearn_pipeline_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
 3. Keep the default arguments.
-4. Run `INSTALL`, then `RUN`.
+4. Run `Deploy scheduler & workers`, then `RUN`.
 
 ## Expected Inputs
 
@@ -48,7 +48,7 @@ Keep `seed=2026` so differences remain easy to explain.
 
 ## Troubleshooting
 
-If model artifacts are missing, confirm `RUN` completed after `INSTALL`. If
+If model artifacts are missing, confirm `RUN` completed after `Deploy scheduler & workers`. If
 metrics change unexpectedly, check the seed and generated dataset settings
 before changing estimator code.
 

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
@@ -31,10 +31,10 @@ strategy, open-weight model review, and inference or token-cost optimization.
 
 1. Select `tescia_diagnostic_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`.
+3. Run `Deploy scheduler & workers`.
 4. Keep the bundled cases for the first run, or select the bundled classroom
    sample.
-5. Run `EXECUTE`, then open the TeSciA analysis tabs.
+5. Run `RUN`, then open the TeSciA analysis tabs.
 
 ## Expected Inputs
 

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "tescia_diagnostic_project"
+name = "tescia_diagnostic_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"

--- a/src/agilab/apps/builtin/uav_queue_project/README.md
+++ b/src/agilab/apps/builtin/uav_queue_project/README.md
@@ -21,7 +21,7 @@ queue-health, topology, and trajectory evidence inside AGILAB.
 1. Select `uav_queue_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
 3. Review routing and path arguments.
-4. Run `INSTALL`, then `EXECUTE`.
+4. Run `Deploy scheduler & workers`, then `RUN`.
 5. Open `ANALYSIS` and inspect scenario, queue, and network-map views.
 
 ## Expected Inputs

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "uav_queue_project"
+name = "uav_queue_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"

--- a/src/agilab/apps/builtin/uav_relay_queue_project/README.md
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/README.md
@@ -20,7 +20,7 @@ change when a UAV source can route through different relay paths.
 
 1. Select `uav_relay_queue_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `ANALYSIS` and inspect relay, scenario, and network views.
 
 ## Expected Inputs
@@ -48,7 +48,7 @@ readable by `view_maps_network`.
 
 ## Troubleshooting
 
-If relay views show no data, confirm `EXECUTE` completed and exported queue
+If relay views show no data, confirm `RUN` completed and exported queue
 analysis artifacts. If a copied scenario gives impossible routes, check node ids
 and relay names before changing the worker.
 

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "uav_relay_queue_project"
+name = "uav_relay_queue_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/README.md
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/README.md
@@ -22,7 +22,7 @@ ids and paths available.
 1. Select `weather_forecast_legacy_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
 3. Review paths and forecast parameters.
-4. Run `INSTALL`, then `EXECUTE`.
+4. Run `Deploy scheduler & workers`, then `RUN`.
 5. Open `ANALYSIS` with `view_forecast_analysis` or `view_release_decision`.
 
 ## Expected Inputs

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "weather_forecast_legacy_project"
+name = "weather_forecast_legacy_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"

--- a/src/agilab/apps/builtin/weather_forecast_project/README.md
+++ b/src/agilab/apps/builtin/weather_forecast_project/README.md
@@ -22,7 +22,7 @@ views, and release-decision evidence.
 1. Select `weather_forecast_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
 3. Review paths and forecasting parameters.
-4. Run `INSTALL`, then `EXECUTE`.
+4. Run `Deploy scheduler & workers`, then `RUN`.
 5. Open `ANALYSIS` with `view_forecast_analysis` or `view_release_decision`.
 
 ## Expected Inputs
@@ -49,8 +49,8 @@ change while artifact names remain stable.
 
 ## Troubleshooting
 
-If `skforecast` is missing, run `INSTALL` for this app and test from the app
-environment. If analysis pages are empty, confirm `EXECUTE` produced forecast
+If `skforecast` is missing, run `Deploy scheduler & workers` for this app and test from the app
+environment. If analysis pages are empty, confirm `RUN` produced forecast
 artifacts before opening `ANALYSIS`.
 
 ## Scope

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "weather_forecast_project"
+name = "weather_forecast_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.12"

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/run_request_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/run_request_support.py
@@ -51,6 +51,7 @@ class RunRequest:
     scheduler: str | None = None
     workers: dict[str, int] | None = None
     workers_data_path: str | None = None
+    workflow_share_root: str | None = None
     verbose: int = 0
     mode: RunMode = None
     rapids_enabled: bool = False
@@ -70,6 +71,21 @@ class RunRequest:
         object.__setattr__(self, "stages", tuple(_coerce_stage_request(stage) for stage in self.stages))
         if self.workers is not None and not isinstance(self.workers, dict):
             raise ValueError("workers must be a dict. {'ip-address':nb-worker}")
+        if (
+            self.workflow_share_root is not None
+            and self.workers_data_path is not None
+            and self.workflow_share_root != self.workers_data_path
+        ):
+            raise ValueError(
+                "workflow_share_root and legacy workers_data_path must match when both are set"
+            )
+        workflow_share_root = (
+            self.workflow_share_root
+            if self.workflow_share_root is not None
+            else self.workers_data_path
+        )
+        object.__setattr__(self, "workflow_share_root", workflow_share_root)
+        object.__setattr__(self, "workers_data_path", workflow_share_root)
 
     def to_app_kwargs(self) -> dict[str, Any]:
         payload = dict(self.params)
@@ -94,6 +110,7 @@ class RunRequest:
         allowed = {
             "scheduler",
             "workers",
+            "workflow_share_root",
             "workers_data_path",
             "verbose",
             "mode",
@@ -103,4 +120,8 @@ class RunRequest:
         unknown = set(updates) - allowed
         if unknown:
             raise TypeError(f"Unknown execution field(s): {', '.join(sorted(unknown))}")
+        if "workflow_share_root" in updates and "workers_data_path" not in updates:
+            updates["workers_data_path"] = updates["workflow_share_root"]
+        elif "workers_data_path" in updates and "workflow_share_root" not in updates:
+            updates["workflow_share_root"] = updates["workers_data_path"]
         return replace(self, **updates)

--- a/src/agilab/core/test/test_agi_distributor_run_request_support.py
+++ b/src/agilab/core/test/test_agi_distributor_run_request_support.py
@@ -64,3 +64,19 @@ def test_run_request_with_execution_updates_only_runtime_controls() -> None:
     assert request.mode == 0
     with pytest.raises(TypeError, match="Unknown execution field"):
         request.with_execution(params={"seed": 1})
+
+
+def test_run_request_uses_workflow_share_root_with_legacy_alias() -> None:
+    request = RunRequest(workflow_share_root="clustershare/user/workflow/session")
+
+    assert request.workflow_share_root == "clustershare/user/workflow/session"
+    assert request.workers_data_path == "clustershare/user/workflow/session"
+    assert request.with_execution(workers_data_path="clustershare/other").workflow_share_root == (
+        "clustershare/other"
+    )
+
+    legacy = RunRequest(workers_data_path="clustershare/legacy")
+    assert legacy.workflow_share_root == "clustershare/legacy"
+
+    with pytest.raises(ValueError, match="must match"):
+        RunRequest(workflow_share_root="clustershare/new", workers_data_path="clustershare/old")

--- a/src/agilab/evidence/first_proof_wizard.py
+++ b/src/agilab/evidence/first_proof_wizard.py
@@ -284,13 +284,14 @@ def newcomer_first_proof_content(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
             ),
             (
                 "ORCHESTRATE",
-                "Keep cluster, benchmark, and service options off. Click `INSTALL`, then `EXECUTE`.",
+                "Keep cluster, benchmark, and service options off. Click "
+                "`Deploy scheduler & workers`, then `RUN`.",
             ),
             ("ANALYSIS", "Open the default built-in view and confirm generated evidence is visible."),
         ),
         success_criteria=(
             "A visible `ANALYSIS` result opens for the built-in flight-telemetry project.",
-            "`INSTALL` and `EXECUTE` finish without an error.",
+            "`Deploy scheduler & workers` and `RUN` finish without an error.",
             "`run_manifest.json` and generated files appear under `~/log/execute/flight_telemetry/`.",
         ),
         links=(
@@ -472,7 +473,8 @@ def _first_proof_remediation(
             "status": "missing",
             "title": "No first-proof run manifest yet.",
             "actions": (
-                "In the UI: select the demo, then open the run page and click INSTALL and EXECUTE.",
+                "In the UI: select the demo, then open the run page and click "
+                "Deploy scheduler & workers and RUN.",
                 "Or run the first-proof JSON command from the repository root.",
                 "Run the compatibility report command after `run_manifest.json` appears.",
             ),
@@ -576,7 +578,9 @@ def newcomer_first_proof_state(env: Any, repo_root: Path = REPO_ROOT) -> dict[st
     elif not current_app_matches:
         next_step = "Select the built-in flight-telemetry demo (`flight_telemetry_project`) from this page."
     elif not run_manifest_loaded and not visible_outputs:
-        next_step = "Go to `ORCHESTRATE`. Click INSTALL, then EXECUTE."
+        next_step = (
+            "Go to `ORCHESTRATE`. Click Deploy scheduler & workers, then RUN."
+        )
     elif not run_manifest_loaded:
         next_step = "Generate `run_manifest.json` with the first-proof JSON command."
     elif run_manifest_loaded and not run_manifest_passed:

--- a/src/agilab/evidence/supply_chain_attestation.py
+++ b/src/agilab/evidence/supply_chain_attestation.py
@@ -1,7 +1,12 @@
 # BSD 3-Clause License
 #
 # Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
-"""Static supply-chain attestation evidence for AGILAB public review."""
+"""Static supply-chain integrity inventory for AGILAB public review.
+
+The legacy module and schema names remain available for compatibility. This
+artifact fingerprints repository metadata; it is not a signed provenance
+attestation.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +19,7 @@ from typing import Any, Mapping
 
 
 SCHEMA = "agilab.supply_chain_attestation.v1"
+CANONICAL_SCHEMA = "agilab.supply_chain_integrity_snapshot.v1"
 CREATED_AT = "2026-04-25T00:00:34Z"
 UPDATED_AT = "2026-07-23T00:00:00Z"
 CORE_PYPROJECTS = {
@@ -612,7 +618,9 @@ def build_supply_chain_attestation(repo_root: Path) -> dict[str, Any]:
         )
     return {
         "schema": SCHEMA,
-        "run_id": "supply-chain-attestation-proof",
+        "canonical_schema": CANONICAL_SCHEMA,
+        "evidence_kind": "inventory_snapshot",
+        "run_id": "supply-chain-integrity-snapshot",
         "created_at": CREATED_AT,
         "updated_at": UPDATED_AT,
         "run_status": "validated" if not issues else "invalid",
@@ -620,6 +628,8 @@ def build_supply_chain_attestation(repo_root: Path) -> dict[str, Any]:
         "package": root_metadata,
         "summary": {
             "schema": SCHEMA,
+            "canonical_schema": CANONICAL_SCHEMA,
+            "evidence_kind": "inventory_snapshot",
             "package_name": root_metadata.get("name", ""),
             "package_version": root_version,
             "requires_python": root_metadata.get("requires_python", ""),

--- a/src/agilab/lib/agi-app-data-quality-gate/README.md
+++ b/src/agilab/lib/agi-app-data-quality-gate/README.md
@@ -53,8 +53,8 @@ built wheel.
 
 ## Run In AGILAB
 
-Select `data_quality_gate_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Open `ANALYSIS` or inspect the exported evidence directory to review
+Select `data_quality_gate_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Open `ANALYSIS` or inspect the exported evidence directory to review
 the contract, drift metrics, gate decision, and artifact manifest.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-flight-telemetry/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/README.md
@@ -39,7 +39,7 @@ package in isolation.
 ## Run In AGILAB
 
 From the UI, select `flight_telemetry_project`, open `ORCHESTRATE`, then run
-`INSTALL` and `EXECUTE`. From Python, create an AGILAB environment with
+`Deploy scheduler & workers` and `RUN`. From Python, create an AGILAB environment with
 `AgiEnv(app="flight_telemetry_project")` and run the project through the normal
 `AGI.run(..., request=RunRequest(...))` path.
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
@@ -25,7 +25,7 @@ analysis views over the produced flight dataframe.
 
 1. Select `flight_telemetry_project` in `PROJECT`.
 2. Open `ORCHESTRATE` and review the input path.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `WORKFLOW` to inspect or extend the generated recipe.
 5. Open `ANALYSIS`, then use `view_maps` or `view_maps_network`.
 
@@ -57,7 +57,7 @@ analysis views should update while the reducer contract remains the same.
 
 ## Troubleshooting
 
-If `ANALYSIS` shows no map data, confirm that `EXECUTE` produced dataframe
+If `ANALYSIS` shows no map data, confirm that `RUN` produced dataframe
 artifacts before opening the page. If a notebook import does not suggest flight
 views, check `notebook_import_views.toml` instead of hard-coding page names.
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "flight_telemetry_project"
+name = "flight_telemetry_worker"
 version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.12,<3.15"

--- a/src/agilab/lib/agi-app-mission-decision/README.md
+++ b/src/agilab/lib/agi-app-mission-decision/README.md
@@ -34,7 +34,7 @@ package in isolation.
 ## Run In AGILAB
 
 From the UI, select `mission_decision_project`, open `ORCHESTRATE`, then run
-`INSTALL` and `EXECUTE`. Open `ANALYSIS` with the decision-evidence page to
+`Deploy scheduler & workers` and `RUN`. Open `ANALYSIS` with the decision-evidence page to
 inspect strategy deltas and the adaptation timeline.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/README.md
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/README.md
@@ -23,7 +23,7 @@ does not require private services.
 
 1. Select `mission_decision_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `ANALYSIS` and select `view_data_io_decision`.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mission_decision_project"
+name = "mission_decision_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-pandas-execution/README.md
+++ b/src/agilab/lib/agi-app-pandas-execution/README.md
@@ -35,8 +35,8 @@ package in isolation.
 
 ## Run In AGILAB
 
-Select `execution_pandas_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Keep the default local settings for a first proof, or disable Cython
+Select `execution_pandas_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Keep the default local settings for a first proof, or disable Cython
 when you specifically want to compare the pure Python worker path. Increase
 partitions or worker count when you want a stronger distribution check.
 

--- a/src/agilab/lib/agi-app-polars-execution/README.md
+++ b/src/agilab/lib/agi-app-polars-execution/README.md
@@ -34,8 +34,8 @@ package in isolation.
 
 ## Run In AGILAB
 
-Select `execution_polars_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Start locally, then compare the output with
+Select `execution_polars_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Start locally, then compare the output with
 `execution_pandas_project` if you want an engine-level contrast.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-pytorch-playground/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/README.md
@@ -72,7 +72,7 @@ replayable circles, XOR feature engineering, spiral capacity, and gaussian
 sanity-check variants.
 
 Open `ORCHESTRATE` when you want the reproducible AGILAB execution path: tune
-the sidebar fields, then run `INSTALL` and `RUN`. Enable loss-landscape
+the sidebar fields, then run `Deploy scheduler & workers` and `RUN`. Enable loss-landscape
 computation only when you want the heavier 3D projection in the evidence
 bundle.
 

--- a/src/agilab/lib/agi-app-sklearn-pipeline/README.md
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/README.md
@@ -37,7 +37,7 @@ root.
 ## Run In AGILAB
 
 Select `sklearn_pipeline_project`, then open `ORCHESTRATE`. Keep the defaults,
-run `INSTALL`, then run `RUN`. The worker exports model quality evidence and a
+run `Deploy scheduler & workers`, then run `RUN`. The worker exports model quality evidence and a
 manifest under `sklearn_pipeline/evidence`.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-tescia-diagnostic/README.md
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/README.md
@@ -55,8 +55,8 @@ a locally built wheel.
 
 ## Run In AGILAB
 
-Select `tescia_diagnostic_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE` with bundled cases. Inspect the exported reports under `ANALYSIS` or
+Select `tescia_diagnostic_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN` with bundled cases. Inspect the exported reports under `ANALYSIS` or
 the project output directory. The argument form includes the student-answer JSON
 contract used for self-evaluation.
 For a classroom batch, select `Bundled classroom sample` in ORCHESTRATE, or

--- a/src/agilab/lib/agi-app-uav-queue/README.md
+++ b/src/agilab/lib/agi-app-uav-queue/README.md
@@ -43,8 +43,8 @@ wheel.
 
 ## Run In AGILAB
 
-Select `uav_queue_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Open the scenario cockpit, queue-resilience view, or network-map view
+Select `uav_queue_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Open the scenario cockpit, queue-resilience view, or network-map view
 from `ANALYSIS` to inspect the produced artifacts.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-uav-relay-queue/README.md
+++ b/src/agilab/lib/agi-app-uav-relay-queue/README.md
@@ -33,8 +33,8 @@ package in isolation.
 
 ## Run In AGILAB
 
-Select `uav_relay_queue_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Inspect `view_relay_resilience`, `view_scenario_cockpit`, or
+Select `uav_relay_queue_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Inspect `view_relay_resilience`, `view_scenario_cockpit`, or
 `view_maps_network` from `ANALYSIS`.
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/README.md
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/README.md
@@ -20,7 +20,7 @@ change when a UAV source can route through different relay paths.
 
 1. Select `uav_relay_queue_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
-3. Run `INSTALL`, then `EXECUTE`.
+3. Run `Deploy scheduler & workers`, then `RUN`.
 4. Open `ANALYSIS` and inspect relay, scenario, and network views.
 
 ## Expected Inputs
@@ -48,7 +48,7 @@ readable by `view_maps_network`.
 
 ## Troubleshooting
 
-If relay views show no data, confirm `EXECUTE` completed and exported queue
+If relay views show no data, confirm `RUN` completed and exported queue
 analysis artifacts. If a copied scenario gives impossible routes, check node ids
 and relay names before changing the worker.
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "uav_relay_queue_project"
+name = "uav_relay_queue_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/README.md
+++ b/src/agilab/lib/agi-app-weather-forecast/README.md
@@ -33,8 +33,8 @@ package in isolation.
 
 ## Run In AGILAB
 
-Select `weather_forecast_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Open `view_forecast_analysis` from `ANALYSIS`; use
+Select `weather_forecast_project`, open `ORCHESTRATE`, then run `Deploy scheduler & workers` and
+`RUN`. Open `view_forecast_analysis` from `ANALYSIS`; use
 `view_release_decision` when you want baseline-versus-candidate promotion
 evidence.
 

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/README.md
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/README.md
@@ -22,7 +22,7 @@ views, and release-decision evidence.
 1. Select `weather_forecast_project` in `PROJECT`.
 2. Open `ORCHESTRATE`.
 3. Review paths and forecasting parameters.
-4. Run `INSTALL`, then `EXECUTE`.
+4. Run `Deploy scheduler & workers`, then `RUN`.
 5. Open `ANALYSIS` with `view_forecast_analysis` or `view_release_decision`.
 
 ## Expected Inputs
@@ -49,8 +49,8 @@ change while artifact names remain stable.
 
 ## Troubleshooting
 
-If `skforecast` is missing, run `INSTALL` for this app and test from the app
-environment. If analysis pages are empty, confirm `EXECUTE` produced forecast
+If `skforecast` is missing, run `Deploy scheduler & workers` for this app and test from the app
+environment. If analysis pages are empty, confirm `RUN` produced forecast
 artifacts before opening `ANALYSIS`.
 
 ## Scope

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "weather_forecast_project"
+name = "weather_forecast_worker"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.12"

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1796,10 +1796,13 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             st.session_state[workers_data_path_widget_key] = cluster_params.get("workers_data_path", "")
 
         workers_data_path_input = st.text_input(
-            "Workers Data Path",
+            "Workflow share root",
             key=workers_data_path_widget_key,
-            placeholder="/path/to/data",
-            help="Path to data directory on workers.",
+            placeholder="/path/to/clustershare/user/workflow/session",
+            help=(
+                "Shared workflow-session root visible to the manager and workers. "
+                "App module data_in and data_out paths are resolved below this root."
+            ),
         )
         workers_data_path_value = str(workers_data_path_input or "").strip()
         if (

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -635,7 +635,7 @@ def build_run_snippet(
         f"        mode={run_mode!r},",
         f"        scheduler={scheduler},",
         f"        workers={workers},",
-        f"        workers_data_path={workers_data_path_expr},",
+        f"        workflow_share_root={workers_data_path_expr},",
         f"        rapids_enabled={bool(rapids_enabled)!r},",
         f"        benchmark_best_single_node={bool(benchmark_best_single_node)!r},",
         "    )",
@@ -903,16 +903,16 @@ def benchmark_workers_data_path_issue(
     data_path_text = str(workers_data_path or "").strip()
     if not data_path_text or data_path_text.lower() == "none":
         return (
-            "Benchmark modes using Dask with non-local workers require Workers Data Path. "
-            "Use a shared path visible from the remote workers."
+            "Benchmark modes using Dask with non-local workers require a workflow share root. "
+            "Use a shared path visible from the manager and remote workers."
         )
 
     data_path = _resolved_path(data_path_text)
     local_share = _resolved_path(local_share_path)
     if data_path is not None and local_share is not None and data_path == local_share:
         return (
-            "Workers Data Path points to the local share. For Dask benchmark modes with "
-            "non-local workers, use a shared workers path instead of the manager-local path."
+            "Workflow share root points to the local share. For Dask benchmark modes with "
+            "non-local workers, use a shared workflow path instead of the manager-local path."
         )
     return ""
 

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -966,7 +966,7 @@ def _cluster_args_share_warning(env: Any, cluster_params: dict[str, Any]) -> str
     except (OSError, RuntimeError, TypeError, ValueError):
         pass
     # SSHFS cluster-share contract: the scheduler-side AGI_CLUSTER_SHARE can be a
-    # normal local filesystem; remote workers mount it at Workers Data Path.
+    # normal local filesystem; remote workers mount it at the workflow share root.
     if (
         is_symlink
         or looks_shared
@@ -988,7 +988,7 @@ def _cluster_args_share_warning(env: Any, cluster_params: dict[str, Any]) -> str
     return (
         f"Cluster is enabled but the data directory `{share_resolved}` appears local. "
         f"(detected fstype: `{fstype}`) "
-        "Set `AGI_CLUSTER_SHARE` to the scheduler-side source path and `Workers Data Path` "
+        "Set `AGI_CLUSTER_SHARE` to the scheduler-side source path and `Workflow share root` "
         "to the worker-side SSHFS/shared mount target, or point `AGI_CLUSTER_SHARE` "
         "at a shared mount/symlink when not using the SSHFS cluster-share contract."
         f"{extra}"

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -3067,11 +3067,11 @@ def _render_analysis_workspace_overview(
             )
         if not artifact_summary["exists"]:
             st.info(
-                "No analysis workspace found. Run ORCHESTRATE -> EXECUTE, then return here to review manifests, tables, figures, logs, and notebooks."
+                "No analysis workspace found. Run ORCHESTRATE -> RUN, then return here to review manifests, tables, figures, logs, and notebooks."
             )
         elif not artifact_summary["examples"]:
             st.info(
-                "No evidence files detected yet. Run ORCHESTRATE -> EXECUTE or WORKFLOW, then use ANALYSIS to inspect the generated outputs."
+                "No evidence files detected yet. Run ORCHESTRATE -> RUN or WORKFLOW, then use ANALYSIS to inspect the generated outputs."
             )
 
 

--- a/src/agilab/pages/PROJECT_EDITOR.py
+++ b/src/agilab/pages/PROJECT_EDITOR.py
@@ -357,7 +357,7 @@ CLONE_ENV_STRATEGY_LABELS = {
 CLONE_ENV_STRATEGY_CAPTIONS = {
     "detach_venv": (
         "Safer for real development. The clone is created without .venv, "
-        "so run INSTALL before EXECUTE."
+        "so run Deploy scheduler & workers before RUN."
     ),
     "share_source_venv": (
         "Fast and lightweight. The clone keeps the source .venv by symlink, "
@@ -1006,7 +1006,7 @@ def _finalize_cloned_project_environment(
             _remove_path_if_present(dest_venv)
         return (
             f"Project '{dest_root.name}' was created without sharing the source .venv. "
-            "Run INSTALL before EXECUTE."
+            "Run Deploy scheduler & workers before RUN."
         )
 
     if strategy == "share_source_venv":
@@ -3452,7 +3452,7 @@ def _create_project_clone_action(
         return ActionResult.error(
             f"Project '{new_name}' was created, but local source paths could not be repaired.",
             detail=str(exc),
-            next_action="Inspect the cloned pyproject.toml files, then rerun INSTALL before EXECUTE.",
+            next_action="Inspect the cloned pyproject.toml files, then rerun Deploy scheduler & workers before RUN.",
             data={
                 "new_name": new_name,
                 "dest_root": dest_root,
@@ -3471,7 +3471,7 @@ def _create_project_clone_action(
         return ActionResult.error(
             f"Project '{new_name}' was created, but environment finalization failed.",
             detail=str(exc),
-            next_action="Check the cloned .venv state, then rerun INSTALL before EXECUTE.",
+            next_action="Check the cloned .venv state, then rerun Deploy scheduler & workers before RUN.",
             data={
                 "new_name": new_name,
                 "dest_root": dest_root,
@@ -4295,7 +4295,7 @@ def _create_project_from_notebook_action(
         )
 
     next_action = (
-        "Project created. Open ORCHESTRATE, run INSTALL, then EXECUTE. Open WORKFLOW to inspect "
+        "Project created. Open ORCHESTRATE, run Deploy scheduler & workers, then RUN. Open WORKFLOW to inspect "
         "the imported notebook stages."
         if source_kind == "packaged_sample_notebook"
         else (
@@ -4386,7 +4386,7 @@ def _rename_project_action(
             f"Project '{new_name}' was cloned, but environment preservation failed.",
             detail=str(exc),
             next_action=(
-                f"Inspect {src_path} and {dest_path}, then rerun INSTALL before EXECUTE."
+                f"Inspect {src_path} and {dest_path}, then rerun Deploy scheduler & workers before RUN."
             ),
             data={
                 "current": current,
@@ -4619,7 +4619,7 @@ def handle_project_creation():
             st.info(
                 "AGILAB's included notebook is selected. "
                 f"Click Create to build `{normalized_project_name}` from `{guided_template_name}`; "
-                "ORCHESTRATE opens next for INSTALL and EXECUTE."
+                "ORCHESTRATE opens next for Deploy scheduler & workers and RUN."
             )
             st.sidebar.caption(f"Included notebook -> `{normalized_project_name}`.")
         elif notebook_defaults:

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -3399,7 +3399,7 @@ def _render_global_runner_state_view(
                 else:
                     st.warning(
                         "Distributed backend is selected, but the active ORCHESTRATE cluster settings "
-                        "do not provide a complete scheduler, workers, and Workers Data Path request."
+                        "do not provide a complete scheduler, workers, and workflow share root request."
                     )
         run_next_col, run_ready_col = st.columns(2)
         with run_next_col:

--- a/src/agilab/pipeline/pipeline_stages.py
+++ b/src/agilab/pipeline/pipeline_stages.py
@@ -933,12 +933,12 @@ def snippet_source_guidance(has_snippets: bool, app_name: str) -> str:
     if has_snippets:
         return (
             f"Snippets are refreshed from the latest ORCHESTRATE run for `{app_name}`. "
-            "If they look stale, rerun INSTALL → DISTRIBUTE → RUN in ORCHESTRATE."
+            "If they look stale, rerun Deploy scheduler & workers → CHECK distribute → RUN in ORCHESTRATE."
         )
     return (
         "No ORCHESTRATE-generated snippet is available yet. "
-        "Run INSTALL → DISTRIBUTE → RUN in ORCHESTRATE first (same project) "
-        "to generate the INSTALL / DISTRIBUTE / RUN snippets, then come back to WORKFLOW."
+        "Run Deploy scheduler & workers → CHECK distribute → RUN in ORCHESTRATE first (same project) "
+        "to generate the Deploy scheduler & workers / CHECK distribute / RUN snippets, then come back to WORKFLOW."
     )
 
 

--- a/src/agilab/resources/notebook_pipeline_import_sample.ipynb
+++ b/src/agilab/resources/notebook_pipeline_import_sample.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# AGILAB notebook import sample\n",
         "\n",
-                "Use this tiny notebook with PROJECT -> Create -> From notebook. It creates flight_telemetry_from_notebook_project from flight_telemetry_project, then writes one local CSV and one summary artifact. After import, open ORCHESTRATE, run INSTALL, then EXECUTE."
+                "Use this tiny notebook with PROJECT -> Create -> From notebook. It creates flight_telemetry_from_notebook_project from flight_telemetry_project, then writes one local CSV and one summary artifact. After import, open ORCHESTRATE, run Deploy scheduler & workers, then RUN."
       ]
     },
     {

--- a/src/agilab/resources/reuse_catalog.toml
+++ b/src/agilab/resources/reuse_catalog.toml
@@ -106,7 +106,7 @@ checked_against = []
 
 [[page]]
 id = "view_maps_network"
-title = "Network geospatial map"
+title = "Network map"
 package = "agi-page-network-map"
 purpose = "Synchronizes topology, routes, allocations, trajectories, and geographic views."
 when_to_use = "Use for relay or satellite queue-analysis runs where route choice and link availability need visual inspection."
@@ -119,7 +119,7 @@ checked_against = []
 
 [[page]]
 id = "view_queue_resilience"
-title = "Queue resilience"
+title = "Queue health"
 package = "agi-page-queue-health"
 purpose = "Reviews queue occupancy, packet events, routing summaries, and run metadata."
 when_to_use = "Use for compact queue-analysis artifacts from any producer writing the AGILAB queue contract."
@@ -145,7 +145,7 @@ checked_against = []
 
 [[page]]
 id = "view_release_decision"
-title = "Release decision cockpit"
+title = "Promotion gate"
 package = "agi-page-promotion-gate"
 purpose = "Builds an evidence cockpit for candidate/baseline review and promotion gates."
 when_to_use = "Use before handoff when a run needs explicit gates, indexed evidence, and a promotion_decision.json export."

--- a/src/agilab/workflow/workflow_ui.py
+++ b/src/agilab/workflow/workflow_ui.py
@@ -400,7 +400,7 @@ def _project_install_status(env: Any | None) -> tuple[str, str, str]:
     if manager_ready and (workerless or worker_ready):
         return "Ready", "manager and worker ready" if not workerless else "manager ready", "ready"
     if manager_exists or worker_exists:
-        return "Incomplete", "rerun Deploy scheduler & workers before EXECUTE", "incomplete"
+        return "Incomplete", "rerun Deploy scheduler & workers before RUN", "incomplete"
     return "Not installed", "run ORCHESTRATE -> Deploy scheduler & workers", "incomplete"
 
 
@@ -499,7 +499,7 @@ def _project_next_action(
     return {
         "id": "execute",
         "label": "Create evidence",
-        "detail": "Run ORCHESTRATE -> EXECUTE so ANALYSIS has outputs to inspect.",
+        "detail": "Run ORCHESTRATE -> RUN so ANALYSIS has outputs to inspect.",
         "url": _project_page_url("ORCHESTRATE", env),
         "type": "primary",
     }
@@ -542,7 +542,7 @@ def _project_cockpit_cards(page_label: str, env: Any | None) -> list[dict[str, s
         evidence_state = "ready"
     else:
         evidence_value = "No evidence"
-        evidence_caption = "run ORCHESTRATE -> EXECUTE"
+        evidence_caption = "run ORCHESTRATE -> RUN"
         evidence_state = "incomplete"
     return [
         {
@@ -623,7 +623,7 @@ def render_project_evidence_drawer(
             _call_container_method(
                 expander,
                 "caption",
-                "No evidence files found yet. Run ORCHESTRATE -> EXECUTE first.",
+                "No evidence files found yet. Run ORCHESTRATE -> RUN first.",
             )
         return
     render_artifact_drawer(

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -5933,10 +5933,10 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
         "markdown",
         "**First proof: built-in demo**",
     )
-    install_button = _event_index(fake_st.events, "link_button", "1. INSTALL demo")
-    install_hint = _event_index(fake_st.events, "caption", "ORCHESTRATE `INSTALL`")
-    run_button = _event_index(fake_st.events, "link_button", "2. EXECUTE demo")
-    run_hint = _event_index(fake_st.events, "caption", "ORCHESTRATE `EXECUTE`")
+    install_button = _event_index(fake_st.events, "link_button", "1. DEPLOY demo")
+    install_hint = _event_index(fake_st.events, "caption", "ORCHESTRATE `Deploy scheduler & workers`")
+    run_button = _event_index(fake_st.events, "link_button", "2. RUN demo")
+    run_hint = _event_index(fake_st.events, "caption", "ORCHESTRATE `RUN`")
     open_analysis = _event_index(fake_st.events, "link_button", "3. OPEN ANALYSIS")
     link_types = {
         body.rsplit(":", 1)[0]: body.rsplit(":", 1)[1]
@@ -6018,9 +6018,9 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     )
     assert (
         caption_bodies[1]
-        == "Runs ORCHESTRATE `INSTALL` for `flight_telemetry_project`."
+        == "Runs ORCHESTRATE `Deploy scheduler & workers` for `flight_telemetry_project`."
     )
-    assert caption_bodies[2] == "Runs ORCHESTRATE `EXECUTE` for the same demo."
+    assert caption_bodies[2] == "Runs ORCHESTRATE `RUN` for the same demo."
     assert (
         caption_bodies[3] == "Opens ANALYSIS on `view_maps` for the generated evidence."
     )
@@ -6032,7 +6032,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
         "Then click PROJECT `Create`; it builds `flight_telemetry_from_notebook_project`."
     )
     assert (
-        caption_bodies[7] == "After creation, run ORCHESTRATE `INSTALL` and `EXECUTE`."
+        caption_bodies[7] == "After creation, run ORCHESTRATE `Deploy scheduler & workers` and `RUN`."
     )
     assert caption_bodies[8] == (
         "For your own notebook: open PROJECT -> Create -> From notebook -> Upload your own notebook."
@@ -6051,8 +6051,8 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     assert "Validate engineering evidence" in caption_bodies[12]
     assert "Capability Map" in caption_bodies[12]
     assert link_types == {
-        "1. INSTALL demo": "secondary",
-        "2. EXECUTE demo": "secondary",
+        "1. DEPLOY demo": "secondary",
+        "2. RUN demo": "secondary",
         "3. OPEN ANALYSIS": "secondary",
         "Create from built-in notebook": "secondary",
     }
@@ -6089,7 +6089,7 @@ def test_first_proof_action_columns_width_tracks_longest_text():
         notebook_hint="Upload.",
     )
     long_spec, long_width = onboarding._first_proof_action_columns_layout(
-        [{"button": "Run", "hint": "Then press `INSTALL`, then `EXECUTE`."}],
+        [{"button": "Run", "hint": "Then press `Deploy scheduler & workers`, then `RUN`."}],
         notebook_hint="Upload.",
     )
 
@@ -6372,8 +6372,8 @@ def test_first_proof_wizard_omits_redundant_select_demo_step(
     assert activated == []
     assert ("button", "1. Select demo") not in fake_st.events
     assert ("link_button", "1. Select demo") not in fake_st.events
-    assert ("link_button", "1. INSTALL demo") in fake_st.events
-    assert ("link_button", "2. EXECUTE demo") in fake_st.events
+    assert ("link_button", "1. DEPLOY demo") in fake_st.events
+    assert ("link_button", "2. RUN demo") in fake_st.events
     assert ("link_button", "3. OPEN ANALYSIS") in fake_st.events
     assert not any(kind == "switch_page" for kind, _body in fake_st.events)
 
@@ -6385,7 +6385,7 @@ def test_first_proof_wizard_install_link_opens_orchestrate_in_new_tab(
     apps_path = tmp_path / "apps"
     flight_telemetry_project = apps_path / "builtin" / "flight_telemetry_project"
     flight_telemetry_project.mkdir(parents=True)
-    fake_st = _FakeStreamlit(button_values={"1. INSTALL demo": True})
+    fake_st = _FakeStreamlit(button_values={"1. DEPLOY demo": True})
     env = SimpleNamespace(
         apps_path=apps_path,
         app="minimal_app_project",
@@ -6405,7 +6405,7 @@ def test_first_proof_wizard_install_link_opens_orchestrate_in_new_tab(
     install_url = next(
         body.split(":", 1)[1]
         for kind, body in fake_st.events
-        if kind == "link_url" and body.startswith("1. INSTALL demo:")
+        if kind == "link_url" and body.startswith("1. DEPLOY demo:")
     )
     parsed_url = urlparse(install_url)
     query = parse_qs(parsed_url.query)
@@ -6424,7 +6424,7 @@ def test_first_proof_wizard_run_link_opens_orchestrate_in_new_tab(
     apps_path = tmp_path / "apps"
     flight_telemetry_project = apps_path / "builtin" / "flight_telemetry_project"
     flight_telemetry_project.mkdir(parents=True)
-    fake_st = _FakeStreamlit(button_values={"2. EXECUTE demo": True})
+    fake_st = _FakeStreamlit(button_values={"2. RUN demo": True})
     env = SimpleNamespace(
         apps_path=apps_path,
         app="minimal_app_project",
@@ -6444,7 +6444,7 @@ def test_first_proof_wizard_run_link_opens_orchestrate_in_new_tab(
     run_url = next(
         body.split(":", 1)[1]
         for kind, body in fake_st.events
-        if kind == "link_url" and body.startswith("2. EXECUTE demo:")
+        if kind == "link_url" and body.startswith("2. RUN demo:")
     )
     parsed_url = urlparse(run_url)
     query = parse_qs(parsed_url.query)
@@ -6470,7 +6470,7 @@ def test_first_proof_wizard_links_do_not_replace_current_page(
     apps_path = tmp_path / "apps"
     flight_telemetry_project = apps_path / "builtin" / "flight_telemetry_project"
     flight_telemetry_project.mkdir(parents=True)
-    fake_st = _FakeStreamlit(button_values={"1. INSTALL demo": True})
+    fake_st = _FakeStreamlit(button_values={"1. DEPLOY demo": True})
     env = SimpleNamespace(
         apps_path=apps_path,
         app="flight_telemetry_project",
@@ -6493,7 +6493,7 @@ def test_first_proof_wizard_links_do_not_replace_current_page(
     about_agilab.render_newcomer_first_proof(env)
 
     assert ("button", "1. Demo selected") not in fake_st.events
-    assert ("link_button", "1. INSTALL demo") in fake_st.events
+    assert ("link_button", "1. DEPLOY demo") in fake_st.events
     assert ("switch_page", "ORCHESTRATE_PAGE_OBJECT") not in fake_st.events
     assert ("switch_page", "pages/2_ORCHESTRATE.py") not in fake_st.events
     assert fake_st.query_params == {}

--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -1580,7 +1580,7 @@ class _FakeBrowserPage:
         self.url = url
         self.visited.append(url)
         if "ORCHESTRATE" in url:
-            self.body_text = "ORCHESTRATE Deploy scheduler & workers EXECUTE"
+            self.body_text = "ORCHESTRATE Deploy scheduler & workers RUN"
         elif "ANALYSIS" in url and "current_page=" in url:
             self.body_text = "View: selected analysis view"
         elif "ANALYSIS" in url:

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -908,14 +908,14 @@ def test_above_fold_result_probe_reports_missing_primary_target() -> None:
         app_name="flight_telemetry_project",
         display="ORCHESTRATE",
         url="http://demo/ORCHESTRATE",
-        expected_labels=("ORCHESTRATE", "Deploy scheduler & workers", "EXECUTE"),
+        expected_labels=("ORCHESTRATE", "Deploy scheduler & workers", "RUN"),
         seen_labels=("ORCHESTRATE", "Deploy scheduler & workers"),
         fold=900,
     )
 
     assert probe.status == "failed"
     assert probe.kind == "above_fold"
-    assert "EXECUTE" in probe.detail
+    assert "RUN" in probe.detail
 
 
 def test_above_fold_result_probe_accepts_primary_targets() -> None:
@@ -925,8 +925,8 @@ def test_above_fold_result_probe_accepts_primary_targets() -> None:
         app_name="flight_telemetry_project",
         display="ORCHESTRATE",
         url="http://demo/ORCHESTRATE",
-        expected_labels=("ORCHESTRATE", "Deploy scheduler & workers", "EXECUTE"),
-        seen_labels=("ORCHESTRATE", "Deploy scheduler & workers action", "EXECUTE action"),
+        expected_labels=("ORCHESTRATE", "Deploy scheduler & workers", "RUN"),
+        seen_labels=("ORCHESTRATE", "Deploy scheduler & workers action", "RUN action"),
         fold=900,
     )
 
@@ -4788,7 +4788,7 @@ def test_action_buttons_are_probed_by_default(tmp_path) -> None:
 
     status, detail = module._probe_widget(
         _Page(),
-        {"id": "w1", "kind": "button", "label": "EXECUTE"},
+        {"id": "w1", "kind": "button", "label": "RUN"},
         timeout_ms=100,
         interaction_mode="full",
         action_button_policy="trial",

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -307,10 +307,13 @@ def test_app_contract_matrix_detects_promoted_catalog_drift():
 
 def test_worker_projects_depend_on_node_cli_runtime_without_cluster_stack() -> None:
     missing_dependency: list[str] = []
+    mismatched_distribution_name: list[str] = []
     unexpected_cluster_dependency: list[str] = []
     unexpected_cluster_source: list[str] = []
     for pyproject in sorted((ROOT / "src" / "agilab").rglob("*_worker/pyproject.toml")):
         metadata = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        if metadata.get("project", {}).get("name") != pyproject.parent.name:
+            mismatched_distribution_name.append(pyproject.relative_to(ROOT).as_posix())
         dependencies = tuple(metadata.get("project", {}).get("dependencies", ()))
         if not any(dependency.startswith("agi-node") for dependency in dependencies):
             missing_dependency.append(pyproject.relative_to(ROOT).as_posix())
@@ -322,6 +325,7 @@ def test_worker_projects_depend_on_node_cli_runtime_without_cluster_stack() -> N
                 unexpected_cluster_source.append(pyproject.relative_to(ROOT).as_posix())
 
     assert missing_dependency == []
+    assert mismatched_distribution_name == []
     assert unexpected_cluster_dependency == []
     assert unexpected_cluster_source == []
 

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -191,7 +191,7 @@ def test_adoption_guide_uses_current_first_proof_wizard() -> None:
     adoption = Path("ADOPTION.md").read_text(encoding="utf-8")
 
     assert "landing-page first-proof wizard" in adoption
-    assert "`1. INSTALL`" in adoption
+    assert "`1. Deploy scheduler & workers`" in adoption
     assert "`2. RUN`" in adoption
     assert "`3. ANALYSIS`" in adoption
     assert "`Import notebook`" in adoption

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -777,7 +777,7 @@ def test_orchestrate_page_support_snippet_and_mode_helpers():
     assert "workers_data_path=None" in manager_install_snippet
     assert "RunRequest(" in run_snippet
     assert "mode=15" in run_snippet
-    assert 'workers_data_path="/tmp/share"' in run_snippet
+    assert 'workflow_share_root="/tmp/share"' in run_snippet
     assert "rapids_enabled=True" in run_snippet
     assert "benchmark_best_single_node=True" in run_snippet
     assert 'RUN_PARAMS = json.loads(\'{"foo": "bar", "n": 2}\')' in run_snippet

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -124,7 +124,7 @@ def test_build_install_and_run_snippets_embed_expected_values():
     assert "RunRequest(" in run_snippet
     assert "mode=15" in run_snippet
     assert 'scheduler="127.0.0.1:8786"' in run_snippet
-    assert 'workers_data_path="/tmp/share"' in run_snippet
+    assert 'workflow_share_root="/tmp/share"' in run_snippet
     assert "rapids_enabled=True" in run_snippet
     assert "benchmark_best_single_node=True" in run_snippet
     assert 'RUN_PARAMS = json.loads(\'{"foo": "bar", "n": 2}\')' in run_snippet
@@ -675,7 +675,7 @@ def test_benchmark_workers_data_path_requires_shared_path_for_remote_dask(tmp_pa
         workers_data_path="",
         local_share_path=local_share,
     ) == ""
-    assert "require Workers Data Path" in orchestrate_page_support.benchmark_workers_data_path_issue(
+    assert "require a workflow share root" in orchestrate_page_support.benchmark_workers_data_path_issue(
         modes=[4],
         workers={"192.168.1.20": 1},
         workers_data_path="",

--- a/test/test_pipeline_stages.py
+++ b/test/test_pipeline_stages.py
@@ -745,7 +745,7 @@ def test_pipeline_stages_virtualenv_helpers_and_guidance(tmp_path):
     assert env_root.resolve() in roots
     assert (child / ".venv").resolve() in roots
     assert pipeline_stages._normalize_venv_root(tmp_path / "missing") is None
-    assert "Run INSTALL" in pipeline_stages.snippet_source_guidance(False, "flight_telemetry_project")
+    assert "Run Deploy scheduler & workers" in pipeline_stages.snippet_source_guidance(False, "flight_telemetry_project")
     assert "Snippets are refreshed" in pipeline_stages.snippet_source_guidance(True, "flight_telemetry_project")
 
 

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -1014,7 +1014,7 @@ def test_create_project_clone_action_reports_environment_finalization_failure(
         "Project 'partial_clone_project' was created, but environment finalization failed."
     )
     assert result.detail == "bad strategy"
-    assert "rerun INSTALL" in str(result.next_action)
+    assert "rerun Deploy scheduler & workers" in str(result.next_action)
     assert (tmp_path / "partial_clone_project").is_dir()
 
 
@@ -1836,9 +1836,9 @@ def test_notebook_import_create_copy_uses_newcomer_friendly_labels():
     assert "This notebook will create" in source
     assert "Upload your own notebook file" in source
     assert "AGILAB's included notebook is selected" in source
-    assert "ORCHESTRATE opens next for INSTALL and EXECUTE" in source
+    assert "ORCHESTRATE opens next for Deploy scheduler & workers and RUN" in source
     assert "Advanced" in source
-    assert "then EXECUTE" in source
+    assert "then RUN" in source
     assert "create_notebook_use_sample" not in source
     assert "create_notebook_sample_download" not in source
     assert 'st.session_state["project_selectbox"] = new_name' not in source
@@ -1848,7 +1848,7 @@ def test_notebook_import_create_copy_uses_newcomer_friendly_labels():
     assert 'return "workflow", "WORKFLOW", False' in source
     assert 'return "orchestrate", "ORCHESTRATE", True' in source
     assert "Notebook source" not in source
-    assert "INSTALL then RUN" not in source
+    assert "Deploy scheduler & workers then RUN" not in source
     assert "chosen app or template source" not in source
 
 
@@ -2285,7 +2285,7 @@ def test_rename_project_action_reports_environment_preservation_failure(
         "Project 'renamed_project' was cloned, but environment preservation failed."
     )
     assert result.detail == "venv locked"
-    assert "rerun INSTALL" in str(result.next_action)
+    assert "rerun Deploy scheduler & workers" in str(result.next_action)
     assert (tmp_path / "renamed_project").is_dir()
 
 

--- a/test/test_supply_chain_attestation_report.py
+++ b/test/test_supply_chain_attestation_report.py
@@ -8,6 +8,7 @@ import pytest
 
 
 REPORT_PATH = Path("tools/supply_chain_attestation_report.py").resolve()
+CANONICAL_REPORT_PATH = Path("tools/supply_chain_integrity_report.py").resolve()
 CORE_PATH = Path("src/agilab/supply_chain_attestation.py").resolve()
 
 
@@ -35,7 +36,7 @@ def supply_chain_attestation_artifacts(tmp_path_factory):
 
 def test_supply_chain_attestation_report_passes_contract(supply_chain_attestation_artifacts) -> None:
     report, _state = supply_chain_attestation_artifacts
-    assert report["report"] == "Supply-chain attestation report"
+    assert report["report"] == "Supply-chain integrity snapshot report"
     assert report["status"] == "pass"
     assert report["summary"]["schema"] == "agilab.supply_chain_attestation.v1"
     assert report["summary"]["execution_mode"] == "supply_chain_static_attestation"
@@ -83,6 +84,25 @@ def test_supply_chain_attestation_report_passes_contract(supply_chain_attestatio
         "supply_chain_attestation_persistence",
         "supply_chain_attestation_docs_reference",
     }
+
+
+def test_supply_chain_integrity_report_is_canonical_compatibility_surface(tmp_path: Path) -> None:
+    module = _load_module(
+        CANONICAL_REPORT_PATH, "supply_chain_integrity_report_test_module"
+    )
+
+    report = module.build_report(
+        repo_root=Path.cwd(),
+        output_path=tmp_path / "supply_chain_integrity_snapshot.json",
+    )
+
+    assert report["report"] == "Supply-chain integrity snapshot report"
+    assert report["summary"]["canonical_schema"] == (
+        "agilab.supply_chain_integrity_snapshot.v1"
+    )
+    assert report["summary"]["legacy_schema"] == "agilab.supply_chain_attestation.v1"
+    assert report["summary"]["evidence_kind"] == "inventory_snapshot"
+    assert report["summary"]["formal_supply_chain_attestation"] is False
 
 
 def test_supply_chain_attestation_records_core_and_app_manifests(supply_chain_attestation_artifacts) -> None:

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -340,7 +340,7 @@ def test_view_maps_network_warns_when_no_dataset_exists(
     )
 
     assert not at.exception
-    assert any("Maps Network Graph" in title.value for title in at.title)
+    assert any("Network map" in title.value for title in at.title)
     assert any("No files found" in warning.value for warning in at.warning)
 
 

--- a/test/test_view_release_decision.py
+++ b/test/test_view_release_decision.py
@@ -398,7 +398,7 @@ def test_view_release_decision_renders_promotable_candidate_and_exports_json(tmp
     at = _run_release_page(tmp_path, monkeypatch, project_dir)
 
     assert not at.exception
-    assert any(title.value == "Evidence cockpit" for title in at.title)
+    assert any(title.value == "Promotion gate" for title in at.title)
     assert any(header.value == "Run review cockpit" for header in at.subheader)
     assert any("Promotable" in message.value for message in at.success)
     assert any(header.value == "Connector path registry" for header in at.subheader)

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -720,7 +720,7 @@ def test_workflow_ui_project_context_remaining_edges(monkeypatch, tmp_path) -> N
     )
     assert (
         "caption",
-        "No evidence files found yet. Run ORCHESTRATE -> EXECUTE first.",
+        "No evidence files found yet. Run ORCHESTRATE -> RUN first.",
     ) in fake_st.events
     assert workflow_ui._normalize_artifact({"description": "Description only"}) == {
         "label": "Artifact",

--- a/tools/agilab_web_robot.py
+++ b/tools/agilab_web_robot.py
@@ -968,7 +968,7 @@ def run_browser_robot(
                     assert_page_healthy(
                         page,
                         label="orchestrate page",
-                        expect_any=("ORCHESTRATE", "Deploy scheduler & workers", "EXECUTE"),
+                        expect_any=("ORCHESTRATE", "Deploy scheduler & workers", "RUN"),
                         timeout_ms=timeout_ms,
                         screenshot_dir=screenshot_dir,
                     ),

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -155,7 +155,6 @@ INSTALL_POSTCONDITION_ACTION_LABELS = (
     "CHECK distribute",
     "DISTRIBUTE",
     "Run now",
-    "EXECUTE",
     "RUN",
     "Run -> Load -> Export",
 )

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -654,7 +654,7 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
             _check(
                 f"{project_name}:worker_pyproject",
                 f"{project_name} worker pyproject",
-                bool(worker_data.get("project", {}).get("name"))
+                worker_data.get("project", {}).get("name") == worker_module.name
                 and bool(worker_data.get("project", {}).get("version"))
                 and not missing_worker_deps
                 and source_paths
@@ -666,6 +666,7 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
                 evidence=(_relative(repo_root, worker_pyproject),),
                 details={
                     "name": worker_data.get("project", {}).get("name"),
+                    "expected_name": worker_module.name,
                     "version": worker_data.get("project", {}).get("version"),
                     "missing_worker_dependencies": missing_worker_deps,
                     "source_paths": source_paths,
@@ -1295,6 +1296,36 @@ def _global_checks(
     )
 
     page_catalog_rows = _apps_pages_catalog_rows(repo_root)
+    reuse_catalog_data = _read_toml(repo_root / REUSE_CATALOG_REL)
+    reuse_page_titles = {
+        str(row.get("id")): str(row.get("title"))
+        for row in reuse_catalog_data.get("page", [])
+        if isinstance(row, dict) and row.get("id") and row.get("title")
+    }
+    page_display_title_mismatches: dict[str, dict[str, Any]] = {}
+    for module in sorted(source_page_modules):
+        page_meta_path = repo_root / APPS_PAGES_REL / module / "src" / module / "page_meta.py"
+        if not page_meta_path.is_file():
+            continue
+        page_meta = _literal_string_assignments(page_meta_path, {"PAGE_TITLE"})
+        page_title = page_meta.get("PAGE_TITLE")
+        catalog_title = reuse_page_titles.get(module)
+        if page_title != catalog_title:
+            page_display_title_mismatches[module] = {
+                "page_title": page_title,
+                "catalog_title": catalog_title,
+                "page_meta": _relative(repo_root, page_meta_path),
+            }
+    checks.append(
+        _check(
+            "page_display_titles_match_catalog",
+            "Page display titles match the reuse catalog",
+            not page_display_title_mismatches,
+            "side-effect-free page metadata uses the catalog display title",
+            evidence=(str(REUSE_CATALOG_REL), str(APPS_PAGES_REL)),
+            details={"mismatches": page_display_title_mismatches},
+        )
+    )
     expected_page_catalog = {
         module: package for package, module in page_package_to_module.items()
     }

--- a/tools/dag_distributed_stage_smoke.py
+++ b/tools/dag_distributed_stage_smoke.py
@@ -100,7 +100,7 @@ def build_smoke_report(
     elif execute:
         report["message"] = (
             "Distributed DAG stage execution requires enabled cluster settings with scheduler, "
-            "workers, and Workers Data Path."
+            "workers, and workflow share root."
         )
     if execute and config is not None and require_two_nodes and config.worker_nodes < 2:
         report["message"] = "Distributed DAG stage execution requires at least two configured worker nodes."

--- a/tools/kpi_evidence_bundle.py
+++ b/tools/kpi_evidence_bundle.py
@@ -419,12 +419,14 @@ def _check_supply_chain_attestation_report(repo_root: Path) -> dict[str, Any]:
     try:
         supply_chain_attestation_report = _load_tool_module(
             repo_root,
-            "supply_chain_attestation_report",
+            "supply_chain_integrity_report",
         )
         report = supply_chain_attestation_report.build_report(repo_root=repo_root)
         summary = report.get("summary", {})
         ok = (
             report.get("status") == "pass"
+            and summary.get("canonical_schema")
+            == "agilab.supply_chain_integrity_snapshot.v1"
             and summary.get("schema") == "agilab.supply_chain_attestation.v1"
             and summary.get("execution_mode") == "supply_chain_static_attestation"
             and summary.get("package_name") == "agilab"
@@ -462,16 +464,17 @@ def _check_supply_chain_attestation_report(repo_root: Path) -> dict[str, Any]:
         details = {"error": str(exc)}
     return _check_result(
         "supply_chain_attestation_report_contract",
-        "Supply-chain attestation report contract",
+        "Supply-chain integrity snapshot report contract",
         ok,
         (
-            "supply-chain attestation report fingerprints package metadata, "
+            "supply-chain integrity snapshot fingerprints package metadata, "
             "lockfile, core versions, app manifests, and package payload "
             "inventory without formal claims"
             if ok
-            else "supply-chain attestation report is failing or disconnected"
+            else "supply-chain integrity snapshot is failing or disconnected"
         ),
         evidence=[
+            "tools/supply_chain_integrity_report.py",
             "tools/supply_chain_attestation_report.py",
             "src/agilab/supply_chain_attestation.py",
             "pyproject.toml",
@@ -2361,7 +2364,7 @@ def _check_public_docs_links(repo_root: Path) -> dict[str, Any]:
             "tools/production_readiness_report.py",
             "tools/revision_traceability_report.py",
             "tools/public_certification_profile_report.py",
-            "tools/supply_chain_attestation_report.py",
+            "tools/supply_chain_integrity_report.py",
             "tools/repository_knowledge_report.py",
             "tools/run_diff_evidence_report.py",
             "tools/ci_artifact_harvest_report.py",

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -763,7 +763,7 @@ def build_report(
     security_path = repo_root / "SECURITY.md"
     pyproject_path = repo_root / "pyproject.toml"
     lock_path = repo_root / "uv.lock"
-    supply_chain_tool = repo_root / "tools" / "supply_chain_attestation_report.py"
+    supply_chain_tool = repo_root / "tools" / "supply_chain_integrity_report.py"
     public_proof_tool = repo_root / "tools" / "public_proof_scenarios.py"
 
     security_text = security_path.read_text(encoding="utf-8") if security_path.is_file() else ""
@@ -801,7 +801,7 @@ def build_report(
             supply_chain_tool.is_file() and public_proof_tool.is_file(),
             "supply-chain and public-proof evidence tools are available",
             evidence=[
-                "tools/supply_chain_attestation_report.py",
+                "tools/supply_chain_integrity_report.py",
                 "tools/public_proof_scenarios.py",
             ],
         ),

--- a/tools/supply_chain_attestation_report.py
+++ b/tools/supply_chain_attestation_report.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Emit AGILAB static supply-chain attestation evidence."""
+"""Compatibility entry point for AGILAB supply-chain integrity snapshots.
+
+Prefer ``tools/supply_chain_integrity_report.py`` for new automation. This
+module preserves the historical schema and command path for existing consumers.
+"""
 
 from __future__ import annotations
 
@@ -62,12 +66,12 @@ def _check_result(
 
 def _docs_check(repo_root: Path) -> dict[str, Any]:
     required = [
-        "supply-chain attestation report",
-        "tools/supply_chain_attestation_report.py --compact",
-        "agilab.supply_chain_attestation.v1",
-        "supply_chain_static_attestation",
+        "supply-chain integrity snapshot report",
+        "tools/supply_chain_integrity_report.py --compact",
+        "agilab.supply_chain_integrity_snapshot.v1",
+        "compatibility schema",
         "package payload inventory",
-        "budgets without formal",
+        "without producing",
     ]
     doc_path = repo_root / DOC_RELATIVE_PATH
     try:
@@ -80,12 +84,12 @@ def _docs_check(repo_root: Path) -> dict[str, Any]:
         details = {"error": str(exc)}
     return _check_result(
         "supply_chain_attestation_docs_reference",
-        "Supply-chain attestation docs reference",
+        "Supply-chain integrity snapshot docs reference",
         ok,
         (
-            "features docs expose the supply-chain attestation command"
+            "features docs expose the supply-chain integrity snapshot command"
             if ok
-            else "features docs do not expose the supply-chain attestation command"
+            else "features docs do not expose the supply-chain integrity snapshot command"
         ),
         evidence=[str(DOC_RELATIVE_PATH)],
         details=details,
@@ -114,11 +118,11 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
     checks = [
         _check_result(
             "supply_chain_attestation_schema",
-            "Supply-chain attestation schema",
+            "Supply-chain integrity snapshot schema",
             proof["ok"]
             and state.get("schema") == SCHEMA
             and state.get("execution_mode") == "supply_chain_static_attestation",
-            "supply-chain attestation uses the supported schema",
+            "supply-chain integrity snapshot uses the supported schema",
             evidence=["src/agilab/supply_chain_attestation.py"],
             details={
                 "schema": state.get("schema"),
@@ -129,7 +133,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_package_metadata",
-            "Supply-chain attestation package metadata",
+            "Supply-chain integrity snapshot package metadata",
             summary.get("package_name") == "agilab"
             and bool(summary.get("package_version"))
             and summary.get("lockfile_present") is True
@@ -140,7 +144,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_core_alignment",
-            "Supply-chain attestation core alignment",
+            "Supply-chain integrity snapshot core alignment",
             summary.get("core_component_count") == 4
             and summary.get("core_release_graph_aligned") is True
             and summary.get("pinned_core_dependency_count", 0) >= 1,
@@ -155,7 +159,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_page_lib_alignment",
-            "Supply-chain attestation page library alignment",
+            "Supply-chain integrity snapshot page library alignment",
             summary.get("page_lib_component_count") == 2
             and summary.get("page_lib_release_graph_aligned") is True
             and summary.get("pinned_page_lib_dependency_count", 0) >= 1,
@@ -170,7 +174,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_app_lib_alignment",
-            "Supply-chain attestation app library alignment",
+            "Supply-chain integrity snapshot app library alignment",
             summary.get("app_lib_component_count") == 1
             and summary.get("app_lib_release_graph_aligned") is True
             and summary.get("pinned_app_lib_dependency_count", 0) >= 1,
@@ -185,7 +189,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_internal_dependency_pins",
-            "Supply-chain attestation internal dependency pins",
+            "Supply-chain integrity snapshot internal dependency pins",
             summary.get("aligned_internal_dependency_pins") is True
             and summary.get("internal_dependency_pin_count", 0) >= 1
             and summary.get("mismatched_internal_dependency_pin_count") == 0,
@@ -204,7 +208,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_app_manifests",
-            "Supply-chain attestation app manifests",
+            "Supply-chain integrity snapshot app manifests",
             summary.get("builtin_app_pyproject_count") == len(state.get("builtin_app_pyprojects", []))
             and all(row.get("sha256") for row in state.get("builtin_app_pyprojects", [])),
             "built-in app pyproject manifests are included in the attestation",
@@ -213,7 +217,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_builtin_app_alignment",
-            "Supply-chain attestation built-in app alignment",
+            "Supply-chain integrity snapshot built-in app alignment",
             summary.get("builtin_app_pyproject_count") == len(state.get("builtin_app_pyprojects", []))
             and summary.get("aligned_builtin_app_versions") is True
             and summary.get("mismatched_builtin_app_version_count") == 0
@@ -238,7 +242,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_payload_inventory",
-            "Supply-chain attestation payload inventory",
+            "Supply-chain integrity snapshot payload inventory",
             summary.get("package_data_pattern_count", 0) >= 1
             and summary.get("builtin_payload_file_count", 0) >= 1
             and isinstance(summary.get("builtin_payload_extension_counts"), dict),
@@ -274,7 +278,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_payload_budget",
-            "Supply-chain attestation payload budget",
+            "Supply-chain integrity snapshot payload budget",
             summary.get("builtin_payload_within_budget") is True,
             (
                 "built-in app package payload stays within the public wheel budget"
@@ -286,7 +290,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_no_execution",
-            "Supply-chain attestation no execution",
+            "Supply-chain integrity snapshot no execution",
             summary.get("command_execution_count") == 0
             and summary.get("network_probe_count") == 0
             and summary.get("formal_supply_chain_attestation") is False,
@@ -296,9 +300,9 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
         ),
         _check_result(
             "supply_chain_attestation_persistence",
-            "Supply-chain attestation persistence",
+            "Supply-chain integrity snapshot persistence",
             proof["round_trip_ok"] and Path(proof["path"]).is_file(),
-            "supply-chain attestation is unchanged after JSON write/read",
+            "supply-chain integrity snapshot is unchanged after JSON write/read",
             evidence=[proof["path"]],
             details={"path": proof["path"], "round_trip_ok": proof["round_trip_ok"]},
         ),
@@ -307,7 +311,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
     passed = sum(1 for check in checks if check["status"] == "pass")
     failed = sum(1 for check in checks if check["status"] == "fail")
     return {
-        "report": "Supply-chain attestation report",
+        "report": "Supply-chain integrity snapshot report",
         "status": "pass" if failed == 0 else "fail",
         "scope": (
             "Fingerprints package metadata, lockfile, license, bundled AGI core "
@@ -394,7 +398,7 @@ def _build_report_with_path(*, repo_root: Path, output_path: Path) -> dict[str, 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Emit AGILAB static supply-chain attestation evidence."
+        description="Emit AGILAB static supply-chain integrity snapshot evidence."
     )
     parser.add_argument("--output", type=Path, default=None)
     parser.add_argument("--compact", action="store_true")

--- a/tools/supply_chain_integrity_report.py
+++ b/tools/supply_chain_integrity_report.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Emit AGILAB static supply-chain integrity inventory evidence.
+
+This is the canonical operator entry point. The older
+``supply_chain_attestation_report.py`` command remains as a compatibility alias
+for existing automation and schema-v1 consumers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+CANONICAL_SCHEMA = "agilab.supply_chain_integrity_snapshot.v1"
+
+
+def _load_legacy_build_report():
+    module_path = Path(__file__).with_name("supply_chain_attestation_report.py")
+    spec = importlib.util.spec_from_file_location(
+        "agilab_supply_chain_attestation_report_compat", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load compatibility report: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.build_report
+
+
+def build_report(
+    *,
+    repo_root: Path | None = None,
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"output_path": output_path}
+    if repo_root is not None:
+        kwargs["repo_root"] = repo_root
+    report = _load_legacy_build_report()(**kwargs)
+    summary = report.setdefault("summary", {})
+    summary["canonical_schema"] = CANONICAL_SCHEMA
+    summary["legacy_schema"] = summary.get("schema")
+    summary["evidence_kind"] = "inventory_snapshot"
+    summary["formal_supply_chain_attestation"] = False
+    report["report"] = "Supply-chain integrity snapshot report"
+    report["scope"] = (
+        "Fingerprints local package, dependency, license, lockfile, and payload "
+        "metadata without producing a signed provenance attestation."
+    )
+    return report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit AGILAB static supply-chain integrity inventory evidence."
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    report = build_report(output_path=args.output)
+    if args.compact:
+        print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ui_robot_canary.py
+++ b/tools/ui_robot_canary.py
@@ -205,7 +205,7 @@ def run_browser_canaries(widget_robot: Any, *, browser_name: str, headless: bool
             )
 
             page.set_content(
-                "<main><h1>ORCHESTRATE</h1><div style='margin-top:2000px'>INSTALL</div></main>",
+                "<main><h1>ORCHESTRATE</h1><div style='margin-top:2000px'>Deploy scheduler & workers</div></main>",
                 wait_until="domcontentloaded",
             )
             payload = page.evaluate(widget_robot.ABOVE_FOLD_COLLECTOR_JS)


### PR DESCRIPTION
## Summary
- align onboarding, pages, docs, app guidance, and UI robots with the live Deploy scheduler & workers / RUN actions
- expose Workflow share root as the accurate RunRequest and UI term while preserving workers_data_path compatibility
- align worker distribution names with worker module names and enforce that contract
- introduce the canonical supply-chain integrity snapshot entry point while preserving the legacy command and schema
- centralize drift-prone page display titles and verify them against the reuse catalog

## Repro
The naming audit found stale INSTALL / EXECUTE guidance, a workflow-session root labeled as Workers Data Path, twelve worker distributions named after manager projects, a static inventory called an attestation, and page titles that disagreed with their catalog names.

## Root Cause
Naming evolved independently across UI copy, generated snippets, package metadata, evidence tooling, page bundles, canonical docs, and test robots. Existing guards checked presence but did not enforce cross-surface equality.

## Regression Test
- worker pyproject names must equal their worker module names
- side-effect-free page metadata titles must match reuse_catalog.toml
- RunRequest tests cover canonical and legacy share-root aliases plus mismatch rejection
- integrity snapshot tests cover canonical schema metadata and the legacy compatibility schema
- focused UI, robot, docs, evidence, app-contract, core, and app-local suites pass

## Validation
- 803 focused naming and UI tests passed
- 350 evidence, page, pipeline, and catalog tests passed; the catalog pollution-sensitive slice also passed alone
- 230 impact-inferred UI, cluster, map, and screenshot tests passed
- full shared-core test slice passed
- all seven supported built-in app-local targets passed; six other touched apps have no app-local target and are covered by the central contract matrix
- app contract matrix, docs workflow parity, agi-gui workflow parity, Sphinx -W build, docs mirror stamp, SVG XML/render inspection, and maintenance-memory check passed
- focused Ruff checks for new and contract files passed
- repository-wide ./dev lint remains a pre-existing baseline failure with 131 unrelated findings; no changed-line lint finding remains

## Agent Metadata
- Tokki: 1.0.35
- Runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast: not used

## Review Evidence
- No sub-agents or separate model review were used.