### PR TITLE
fix: refresh AgenticWeb discovery

### DIFF
--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-07-27"
+updated: "2026-07-28"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary
- regenerate agenticweb.md after the capability manifest refresh

## Repro
The post-merge root suite for PR #893 failed test_real_agenticweb_manifest_is_current.

## Root Cause
agenticweb.md embeds the capability-manifest digest, so regenerating agilab-capabilities.json requires regenerating this downstream discovery artifact too.

## Regression Test
- capability manifest and AgenticWeb manifest tests: 9 passed together
- agent instruction contract check passed

## Validation
Validation passed.

## Agent Metadata
- Tokki: 1.0.35
- Runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast: not used

## Review Evidence
- No sub-agents or separate model review were used.