### PR TITLE
fix(ui): recover locally from unavailable cluster share

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -4,19 +4,32 @@ from __future__ import annotations
 
 import argparse
 import os
-import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, Mapping, MutableMapping, Optional
 
-from agi_env.app_settings_support import update_app_settings
+from agi_env.app_settings_support import (
+    find_source_app_settings_file,
+    read_app_settings,
+    update_app_settings,
+)
 from agi_env.credential_store_support import CLUSTER_CREDENTIALS_KEY, KEYRING_SENTINEL
+from agi_env.project.app_provider_registry import (
+    discover_installed_app_projects,
+    resolve_installed_app_project,
+)
+from agi_env.runtime.process_support import fix_windows_drive
+from agi_env.runtime.repository_support import get_apps_repository_root
 from agi_env.ui.sidecar_registry import hosted_inline_render_guard
 
 try:  # pragma: no cover - optional import fallback is exercised through behavior tests
     import tomli_w as _tomli_writer
 except ModuleNotFoundError:  # pragma: no cover - dependency is present in AGILAB envs
     _tomli_writer = None
+
+
+DEFAULT_STARTUP_APP_NAME = "flight_telemetry_project"
 
 
 @dataclass
@@ -38,6 +51,20 @@ class BootstrapPorts:
     load_last_active_app: Callable[[], Any]
     store_last_active_app: Callable[[Path], Any]
     environ: MutableMapping[str, str]
+
+
+@dataclass(frozen=True)
+class StartupAppRequest:
+    """Project selection resolved before an ``AgiEnv`` instance exists."""
+
+    name: str
+    target_path: Path
+    source: str
+    authorized_container_roots: tuple[Path, ...] = field(
+        default_factory=tuple,
+        compare=False,
+        repr=False,
+    )
 
 
 def default_bootstrap_ports() -> BootstrapPorts:
@@ -211,15 +238,59 @@ def _streamlit_session_factory(agi_env_cls: Any) -> Callable[..., Any]:
     return session_factory
 
 
-def _create_streamlit_session_env(agi_env_cls: Any, *, apps_path: Path, verbose: int) -> Any:
+def _startup_runtime_authorized_roots(
+    startup_app: StartupAppRequest,
+    env: Any,
+) -> tuple[Path, ...]:
+    """Extend startup trust with the runtime-owned built-in app container."""
+    roots = list(startup_app.authorized_container_roots)
+    builtin_apps_path = _normalize_path(getattr(env, "builtin_apps_path", None))
+    if builtin_apps_path is not None and builtin_apps_path not in roots:
+        roots.append(builtin_apps_path)
+    return tuple(roots)
+
+
+def _streamlit_env_matches_startup_request(
+    env: Any,
+    startup_app: StartupAppRequest,
+) -> bool:
+    """Accept the exact target or a same-name fallback under runtime built-ins."""
+    if getattr(env, "app", None) != startup_app.name:
+        return False
+    if _active_app_path_matches(env, startup_app.target_path):
+        return True
+    active_app = _normalize_path(getattr(env, "active_app", None))
+    builtin_apps_path = _normalize_path(getattr(env, "builtin_apps_path", None))
+    if active_app is None or builtin_apps_path is None:
+        return False
+    return active_app == (builtin_apps_path / startup_app.name).resolve(strict=False)
+
+
+def _create_streamlit_session_env(
+    agi_env_cls: Any,
+    *,
+    apps_path: Path,
+    startup_app: StartupAppRequest,
+    verbose: int,
+) -> Any:
     """Create a UI-owned environment without borrowing the CLI singleton."""
 
     session_factory = _streamlit_session_factory(agi_env_cls)
-    env = session_factory(apps_path=apps_path, verbose=verbose)
+    env = session_factory(
+        apps_path=apps_path,
+        active_app=startup_app.target_path,
+        verbose=verbose,
+    )
     if not getattr(env, "_agilab_session_scoped", False):
         raise RuntimeError(
             "AgiEnv.session() returned a legacy shared environment. Upgrade agi-env, "
             "restart AGILAB, and open a new browser session."
+        )
+    if not _streamlit_env_matches_startup_request(env, startup_app):
+        raise RuntimeError(
+            "AgiEnv.session() initialized a different project than the validated "
+            f"startup target `{startup_app.target_path}`. Restart AGILAB and select "
+            "the project again."
         )
     return env
 
@@ -452,6 +523,7 @@ def _active_app_path_matches(env: Any, target_path: Path) -> bool:
 def _rebootstrap_active_app_path(env: Any, target_path: Path, target_name: str, *, streamlit: Any) -> bool:
     """Switch to a resolved project path without using name-only change_app."""
     previous_init_done = getattr(env, "init_done", None)
+    authorized_roots = getattr(env, "_agilab_authorized_app_container_roots", ())
     try:
         reinitialize = getattr(env, "reinitialize_for_app", None)
         if callable(reinitialize):
@@ -482,13 +554,30 @@ def _rebootstrap_active_app_path(env: Any, target_path: Path, target_name: str, 
                     )
         if previous_init_done is not None:
             env.init_done = previous_init_done
+        if authorized_roots:
+            env._agilab_authorized_app_container_roots = authorized_roots
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
         streamlit.warning(_project_switch_failure_message(target_name, exc))
         return False
     return True
 
 
-def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name: str, *, streamlit: Any) -> bool:
+def _bind_authorized_app_container_roots(
+    env: Any,
+    roots: tuple[Path, ...],
+) -> None:
+    """Bind immutable startup containers used for later query authorization."""
+    normalized: list[Path] = []
+    for root in roots:
+        resolved = _normalize_path(root)
+        if resolved is not None and resolved not in normalized:
+            normalized.append(resolved)
+    env._agilab_authorized_app_container_roots = tuple(normalized)
+
+
+def _rebootstrap_same_named_active_app(
+    env: Any, target_path: Path, target_name: str, *, streamlit: Any
+) -> bool:
     """Switch to the same project name under another root without using name-only change_app."""
     return _rebootstrap_active_app_path(
         env,
@@ -516,10 +605,8 @@ def sync_active_app_from_query(
     env: Any,
     *,
     streamlit: Any,
-    store_last_active_app: Callable[[Path], Any],
-    apply_request: Callable[[Any, Optional[str]], bool],
-) -> None:
-    """Honor ?active_app=... query parameter so all pages stay in sync."""
+) -> bool:
+    """Schedule a cold, atomic transition for a valid query-driven app change."""
     try:
         requested = streamlit.query_params.get("active_app")
     except (AttributeError, RuntimeError, TypeError):
@@ -530,21 +617,41 @@ def sync_active_app_from_query(
     else:
         requested_value = requested
 
-    changed = False
-    if requested_value:
-        changed = apply_request(env, str(requested_value))
+    transition_scheduled = False
+    if requested_value and str(requested_value) != str(getattr(env, "app", "")):
+        target_path = resolve_active_app_query_target(env, str(requested_value))
+        target_matches_current = (
+            target_path is not None
+            and target_path.name == getattr(env, "app", None)
+            and _active_app_path_matches(env, target_path)
+        )
+        if target_path is not None and not target_matches_current:
+            rerun = getattr(streamlit, "rerun", None)
+            session_state = getattr(streamlit, "session_state", None)
+            if callable(rerun) and session_state is not None:
+                try:
+                    previous_first_run = session_state.get("first_run", False)
+                except (AttributeError, RuntimeError, TypeError, ValueError):
+                    previous_first_run = False
+                try:
+                    session_state["first_run"] = True
+                    streamlit.query_params["active_app"] = str(target_path)
+                except (AttributeError, RuntimeError, TypeError, ValueError):
+                    try:
+                        session_state["first_run"] = previous_first_run
+                    except (AttributeError, RuntimeError, TypeError, ValueError):
+                        pass
+                else:
+                    transition_scheduled = True
+                    rerun()
+                    return True
 
-    if not requested_value or changed or requested_value != env.app:
+    if not requested_value or requested_value != env.app:
         try:
             streamlit.query_params["active_app"] = env.app
         except (AttributeError, RuntimeError, TypeError):
             pass
-
-    try:
-        if changed:
-            store_last_active_app(active_app_store_path(env))
-    except (OSError, RuntimeError, TypeError, ValueError):
-        pass
+    return transition_scheduled
 
 
 def persist_bootstrap_env(
@@ -618,9 +725,342 @@ def cluster_share_startup_error_message(exc: BaseException) -> str:
     return (
         f"{exc}\n\n"
         "Cluster mode is enabled for the active project, but the configured cluster share "
-        "is not available. Mount or create a writable `AGI_CLUSTER_SHARE`, then reload "
-        "AGILAB. You can also disable the stale cluster setting for this app and reload."
+        "is not mounted and writable. Mount `AGI_CLUSTER_SHARE`, then reload AGILAB. "
+        "To keep working locally, choose **Disable cluster mode and reload** below. "
+        "Cluster execution stays disabled until you mount the share and re-enable it."
     )
+
+
+def _startup_app_candidate(value: Any) -> tuple[str, str] | None:
+    """Return a valid raw startup request and project basename."""
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else None
+    text = str(value or "").strip()
+    if not text:
+        return None
+    app_name = Path(text).name
+    if not app_name.endswith(("_project", "_worker")):
+        return None
+    return text, app_name
+
+
+def _startup_apps_repository_root(
+    saved_env: Mapping[str, str], ports: BootstrapPorts
+) -> Path | None:
+    """Resolve the configured external apps root with the runtime's own rules."""
+    configured = str(
+        saved_env.get("APPS_REPOSITORY") or ports.environ.get("APPS_REPOSITORY") or ""
+    ).strip()
+    if not configured:
+        return None
+    return get_apps_repository_root(
+        envars={"APPS_REPOSITORY": configured},
+        environ=ports.environ,
+        logger=None,
+        fix_windows_drive_fn=fix_windows_drive,
+    )
+
+
+def _path_matches_startup_root_candidate(
+    path: Path,
+    app_name: str,
+    roots: tuple[Path, ...],
+) -> bool:
+    """Return whether ``path`` is an exact app candidate under an allowed root."""
+    normalized_path = _normalize_path(path)
+    if normalized_path is None:
+        return False
+    for root in roots:
+        try:
+            candidate = (root.expanduser() / app_name).resolve(strict=False)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if normalized_path == candidate:
+            return True
+    return False
+
+
+def _path_is_allowed_startup_target(
+    path: Path,
+    app_name: str,
+    *,
+    container_roots: tuple[Path, ...],
+    installed_projects: tuple[Any, ...],
+) -> bool:
+    """Allow exact configured-root candidates or provider-advertised paths."""
+    if _path_matches_startup_root_candidate(path, app_name, container_roots):
+        return True
+    normalized_path = _normalize_path(path)
+    if normalized_path is None:
+        return False
+    return any(
+        normalized_path == _normalize_path(project.project_root)
+        for project in installed_projects
+    )
+
+
+def _resolve_startup_candidate_path(
+    raw_value: str,
+    app_name: str,
+    *,
+    resolver_env: Any,
+    allowed_roots: tuple[Path, ...],
+    installed_projects: tuple[Any, ...],
+) -> Path | None:
+    """Resolve one existing startup project without accepting arbitrary paths."""
+    try:
+        provided = Path(raw_value).expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+    is_plain_name = not provided.is_absolute() and provided.parent == Path(".")
+    if is_plain_name:
+        target = normalize_active_app_input(resolver_env, raw_value)
+        if target is None or not _path_is_allowed_startup_target(
+            target,
+            app_name,
+            container_roots=allowed_roots,
+            installed_projects=installed_projects,
+        ):
+            installed = resolve_installed_app_project(
+                app_name,
+                projects=installed_projects,
+            )
+            target = installed
+    else:
+        try:
+            target = provided.resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+    if target is None or not _path_is_allowed_startup_target(
+        target,
+        app_name,
+        container_roots=allowed_roots,
+        installed_projects=installed_projects,
+    ):
+        return None
+    try:
+        if not target.is_dir():
+            return None
+        return target.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def resolve_active_app_query_target(env: Any, raw_value: str) -> Path | None:
+    """Resolve a warm-session query through the cold-start trust boundary."""
+    candidate = _startup_app_candidate(raw_value)
+    if candidate is None:
+        return None
+    raw_value, app_name = candidate
+    allowed_roots = tuple(
+        root
+        for raw_root in getattr(
+            env,
+            "_agilab_authorized_app_container_roots",
+            (),
+        )
+        if (root := _normalize_path(raw_root)) is not None
+    )
+    if not allowed_roots:
+        return None
+
+    target_path = _resolve_startup_candidate_path(
+        raw_value,
+        app_name,
+        resolver_env=env,
+        allowed_roots=allowed_roots,
+        installed_projects=(),
+    )
+    if target_path is not None:
+        return target_path
+
+    try:
+        installed_projects = tuple(discover_installed_app_projects())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        installed_projects = ()
+    if not installed_projects:
+        return None
+    return _resolve_startup_candidate_path(
+        raw_value,
+        app_name,
+        resolver_env=env,
+        allowed_roots=allowed_roots,
+        installed_projects=installed_projects,
+    )
+
+
+def resolve_startup_app_request(
+    *,
+    streamlit: Any,
+    args: argparse.Namespace,
+    ports: BootstrapPorts,
+    apps_path: Path,
+    saved_env: Mapping[str, str],
+    warm_env: Any | None = None,
+) -> StartupAppRequest:
+    """Resolve one existing project identity for construction and recovery.
+
+    Explicit browser and CLI requests are authoritative but must resolve under
+    the selected apps tree, configured apps repository, or an installed provider
+    root. Remembered paths may rebase by project name into those current roots.
+    """
+    builtin_apps_path = (
+        apps_path if apps_path.name == "builtin" else apps_path / "builtin"
+    )
+    apps_repository_root = _startup_apps_repository_root(saved_env, ports)
+    try:
+        installed_projects = tuple(discover_installed_app_projects())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        installed_projects = ()
+    allowed_roots = tuple(
+        root
+        for root in (
+            apps_path,
+            builtin_apps_path,
+            apps_repository_root,
+        )
+        if root is not None
+    )
+    resolver_env = SimpleNamespace(
+        apps_path=apps_path,
+        builtin_apps_path=builtin_apps_path,
+        apps_repository_root=apps_repository_root,
+        projects={project.name for project in installed_projects},
+    )
+
+    def request_for(target_path: Path, source: str) -> StartupAppRequest:
+        return StartupAppRequest(
+            target_path.name,
+            target_path,
+            source,
+            authorized_container_roots=allowed_roots,
+        )
+
+    def resolve_explicit(value: Any, source: str) -> StartupAppRequest | None:
+        if isinstance(value, (list, tuple)):
+            value = value[0] if value else None
+        raw_value = str(value or "").strip()
+        if not raw_value:
+            return None
+        candidate = _startup_app_candidate(raw_value)
+        if candidate is None:
+            raise ValueError(
+                f"The {source} startup project must end in '_project' or '_worker'; "
+                f"got {raw_value!r}."
+            )
+        raw_value, app_name = candidate
+        target_path = _resolve_startup_candidate_path(
+            raw_value,
+            app_name,
+            resolver_env=resolver_env,
+            allowed_roots=allowed_roots,
+            installed_projects=installed_projects,
+        )
+        if target_path is None:
+            raise ValueError(
+                f"The {source} startup project {raw_value!r} does not resolve to an "
+                "existing app in the selected apps tree or a configured provider."
+            )
+        return request_for(target_path, source)
+
+    try:
+        query_value = streamlit.query_params.get("active_app")
+    except (AttributeError, RuntimeError, TypeError):
+        query_value = None
+
+    for source, value in (("query", query_value), ("cli", args.active_app)):
+        request = resolve_explicit(value, source)
+        if request is not None:
+            return request
+
+    try:
+        remembered_value = ports.load_last_active_app()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        remembered_value = None
+    remembered = _startup_app_candidate(remembered_value)
+    if remembered is not None:
+        raw_value, app_name = remembered
+        target_path = _resolve_startup_candidate_path(
+            raw_value,
+            app_name,
+            resolver_env=resolver_env,
+            allowed_roots=allowed_roots,
+            installed_projects=installed_projects,
+        )
+        if target_path is None:
+            target_path = _resolve_startup_candidate_path(
+                app_name,
+                app_name,
+                resolver_env=resolver_env,
+                allowed_roots=allowed_roots,
+                installed_projects=installed_projects,
+            )
+        if target_path is not None:
+            return request_for(target_path, "last")
+
+    if getattr(
+        warm_env, "_agilab_session_scoped", False
+    ) and _existing_env_matches_apps_path(warm_env, apps_path):
+        warm_candidate = _startup_app_candidate(getattr(warm_env, "app", None))
+        warm_path = _normalize_path(getattr(warm_env, "active_app", None))
+        if warm_candidate is not None and warm_path is not None:
+            _raw_value, app_name = warm_candidate
+            validated_warm_path = _resolve_startup_candidate_path(
+                str(warm_path),
+                app_name,
+                resolver_env=resolver_env,
+                allowed_roots=allowed_roots,
+                installed_projects=installed_projects,
+            )
+            if validated_warm_path is not None:
+                return request_for(validated_warm_path, "warm")
+
+    configured_default_value = str(saved_env.get("APP_DEFAULT") or "").strip()
+    if configured_default_value:
+        request = resolve_explicit(configured_default_value, "APP_DEFAULT")
+        if request is not None:
+            return request_for(request.target_path, "default")
+
+    request = resolve_explicit(DEFAULT_STARTUP_APP_NAME, "built-in default")
+    if request is None:  # pragma: no cover - the constant is non-empty
+        raise ValueError("The built-in default project is empty.")
+    return request_for(request.target_path, "default")
+
+
+def startup_app_source_settings_file(
+    startup_app: StartupAppRequest,
+    *,
+    apps_path: Path,
+    saved_env: Mapping[str, str],
+    ports: BootstrapPorts,
+) -> Path | None:
+    """Resolve source settings through the same search contract as ``AgiEnv``."""
+    builtin_apps_path = (
+        apps_path if apps_path.name == "builtin" else apps_path / "builtin"
+    )
+    source_envars = dict(ports.environ)
+    source_envars.update(saved_env)
+    source_settings = find_source_app_settings_file(
+        target_app=startup_app.name,
+        current_app=startup_app.name,
+        app_src=startup_app.target_path / "src",
+        active_app=startup_app.target_path,
+        apps_path=apps_path,
+        builtin_apps_path=builtin_apps_path,
+        apps_repository_root=_startup_apps_repository_root(saved_env, ports),
+        home_abs=Path.home(),
+        envars=source_envars,
+    )
+    if source_settings is None:
+        return None
+    try:
+        return source_settings if source_settings.is_file() else None
+    except OSError:
+        # Preserve an inaccessible selected path so the recovery write fails
+        # closed instead of treating it as an authoritatively source-less app.
+        return source_settings
 
 
 def startup_active_app_name(streamlit: Any, args: argparse.Namespace, ports: BootstrapPorts) -> str | None:
@@ -639,13 +1079,9 @@ def startup_active_app_name(streamlit: Any, args: argparse.Namespace, ports: Boo
         pass
 
     for value in candidates:
-        if isinstance(value, (list, tuple)):
-            value = value[0] if value else None
-        text = str(value or "").strip()
-        if not text:
-            continue
-        app_name = Path(text).name
-        if app_name.endswith(("_project", "_worker")):
+        candidate = _startup_app_candidate(value)
+        if candidate is not None:
+            _raw_value, app_name = candidate
             return app_name
     return None
 
@@ -654,27 +1090,83 @@ def workspace_app_settings_file(env_file_path: Path, app_name: str | None) -> Pa
     """Return the mutable per-user app settings path for a pre-init app name."""
     if not app_name:
         return None
-    return env_file_path.expanduser().parent / "apps" / app_name / "app_settings.toml"
+    settings_path = (
+        env_file_path.expanduser().parent / "apps" / app_name / "app_settings.toml"
+    )
+    _resolve_confined_workspace_settings_path(settings_path)
+    return settings_path
 
 
-def disable_cluster_in_app_settings(settings_path: Path) -> bool:
-    """Set ``[cluster].cluster_enabled`` to false in a workspace settings file."""
+def _resolve_confined_workspace_settings_path(settings_path: Path) -> Path:
+    """Resolve one direct workspace settings target without following redirects."""
+    lexical_path = settings_path.expanduser()
+    try:
+        workspace_apps_root = lexical_path.parents[1].resolve(strict=False)
+        resolved_app_dir = lexical_path.parent.resolve(strict=False)
+        resolved_settings = lexical_path.resolve(strict=False)
+    except (IndexError, OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(
+            f"Cannot safely resolve workspace settings path `{lexical_path}`."
+        ) from exc
+
+    expected_app_dir = workspace_apps_root / lexical_path.parent.name
+    expected_settings = expected_app_dir / lexical_path.name
+    if resolved_app_dir != expected_app_dir or resolved_settings != expected_settings:
+        raise ValueError(
+            f"Workspace settings path `{lexical_path}` resolves outside its direct "
+            f"workspace app directory `{expected_app_dir}`."
+        )
+    return resolved_settings
+
+
+def disable_cluster_in_app_settings(
+    settings_path: Path,
+    *,
+    source_settings_path: Path | None = None,
+    source_settings_resolved: bool = False,
+) -> bool:
+    """Seed complete workspace settings, then disable cluster mode atomically."""
     if _tomli_writer is None:
         raise RuntimeError("Writing settings requires the 'tomli-w' package.")
-    if not settings_path.exists():
-        return False
+    settings_path = _resolve_confined_workspace_settings_path(settings_path)
 
     def _disable_cluster(payload: dict[str, Any]) -> bool:
+        missing_workspace = not settings_path.exists()
+        if missing_workspace:
+            if source_settings_path is not None:
+                try:
+                    source_exists = source_settings_path.is_file()
+                except OSError as exc:
+                    raise OSError(
+                        "Cannot safely create workspace settings because the selected "
+                        f"source settings `{source_settings_path}` cannot be inspected."
+                    ) from exc
+                if not source_exists:
+                    raise FileNotFoundError(
+                        "Cannot safely create workspace settings because the selected "
+                        f"source settings `{source_settings_path}` no longer exist."
+                    )
+                payload.update(read_app_settings(source_settings_path))
+            elif not source_settings_resolved:
+                raise FileNotFoundError(
+                    "Cannot safely create workspace settings because the complete "
+                    f"source settings for `{settings_path.parent.name}` were not found."
+                )
         cluster = payload.get("cluster")
-        if not isinstance(cluster, dict) or cluster.get("cluster_enabled") is False:
-            return False
+        if cluster is None:
+            cluster = {}
+            payload["cluster"] = cluster
+        elif not isinstance(cluster, dict):
+            raise ValueError("The [cluster] settings section must be a TOML table.")
+        if cluster.get("cluster_enabled") is False:
+            return missing_workspace
         cluster["cluster_enabled"] = False
         return True
 
     _payload, changed = update_app_settings(
         settings_path,
         _disable_cluster,
-        create_missing=False,
+        create_missing=True,
         dump_fn=_tomli_writer.dump,
     )
     return changed
@@ -687,31 +1179,52 @@ def handle_cluster_share_startup_error(
     env_file_path: Path,
     args: argparse.Namespace,
     ports: BootstrapPorts,
+    app_name: str | None = None,
+    source_settings_path: Path | None = None,
+    source_settings_resolved: bool = False,
     handle_data_root_failure: Callable[..., bool] | None = None,
 ) -> None:
     """Render cluster-share recovery controls before stopping startup."""
-    app_name = startup_active_app_name(streamlit, args, ports)
-    settings_path = workspace_app_settings_file(env_file_path, app_name)
+    app_name = app_name or startup_active_app_name(streamlit, args, ports)
+    settings_path_error: str | None = None
+    try:
+        settings_path = workspace_app_settings_file(env_file_path, app_name)
+    except (OSError, RuntimeError, ValueError) as path_err:
+        settings_path = None
+        settings_path_error = str(path_err)
     message = cluster_share_startup_error_message(exc)
     if settings_path is not None:
         message = f"{message}\n\nWorkspace settings: `{settings_path}`"
+    elif settings_path_error:
+        message = (
+            f"{message}\n\nAutomatic local recovery is unavailable: "
+            f"{settings_path_error}"
+        )
     streamlit.error(message)
 
     button = getattr(streamlit, "button", None)
     if callable(button) and settings_path is not None and button("Disable cluster mode and reload"):
         try:
-            changed = disable_cluster_in_app_settings(settings_path)
-        except (OSError, RuntimeError, tomllib.TOMLDecodeError) as write_err:
-            streamlit.error(f"Could not disable cluster mode in `{settings_path}`: {write_err}")
+            changed = disable_cluster_in_app_settings(
+                settings_path,
+                source_settings_path=source_settings_path,
+                source_settings_resolved=source_settings_resolved,
+            )
+        except (OSError, RuntimeError, ValueError) as write_err:
+            streamlit.error(
+                f"Could not disable cluster mode in `{settings_path}`: {write_err}"
+            )
         else:
             if changed:
                 streamlit.success(f"Disabled cluster mode in `{settings_path}`.")
-            else:
-                streamlit.info(f"Cluster mode was already disabled or missing in `{settings_path}`.")
-            rerun = getattr(streamlit, "rerun", None)
-            if callable(rerun):
-                rerun()
-            return
+                rerun = getattr(streamlit, "rerun", None)
+                if callable(rerun):
+                    rerun()
+                return
+            streamlit.error(
+                f"Cluster mode was already disabled in `{settings_path}`; startup "
+                "was not reloaded because the reported cluster failure would persist."
+            )
 
     if handle_data_root_failure is not None:
         handle_data_root_failure(
@@ -730,7 +1243,7 @@ def bootstrap_page_environment(
     *,
     streamlit: Any,
     env_file_path: Path,
-    load_env_file_map: Callable[[Path], Mapping[str, str]],
+    load_env_file_map: Callable[..., Mapping[str, str]],
     logger: Any,
     apply_active_app_request: Callable[[Any, Optional[str]], bool],
     handle_data_root_failure: Callable[..., bool],
@@ -759,6 +1272,28 @@ def bootstrap_page_environment(
 
     streamlit.session_state["apps_path"] = str(apps_path)
     preinit_updates = source_launch_env_updates(apps_path)
+    warm_env = streamlit.session_state.get("env")
+    try:
+        startup_env = load_env_file_map(env_file_path, include_commented=False)
+        startup_app = resolve_startup_app_request(
+            streamlit=streamlit,
+            args=args,
+            ports=ports,
+            apps_path=apps_path,
+            saved_env=startup_env,
+            warm_env=warm_env,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        stop_startup_with_error(
+            streamlit, f"Unable to resolve AGILAB startup project: {exc}"
+        )
+        return BootstrapResult(env=None, handled_recovery=True)
+    source_settings_path = startup_app_source_settings_file(
+        startup_app,
+        apps_path=apps_path,
+        saved_env=startup_env,
+        ports=ports,
+    )
     persist_preinit_launch_env(
         ports.agi_env_cls,
         preinit_updates,
@@ -766,10 +1301,11 @@ def bootstrap_page_environment(
     )
 
     _streamlit_session_factory(ports.agi_env_cls)
-    warm_env = streamlit.session_state.get("env")
     if (
         getattr(warm_env, "_agilab_session_scoped", False)
         and _existing_env_matches_apps_path(warm_env, apps_path)
+        and getattr(warm_env, "app", None) == startup_app.name
+        and _active_app_path_matches(warm_env, startup_app.target_path)
     ):
         env = warm_env
     else:
@@ -777,6 +1313,7 @@ def bootstrap_page_environment(
             env = _create_streamlit_session_env(
                 ports.agi_env_cls,
                 apps_path=apps_path,
+                startup_app=startup_app,
                 verbose=1,
             )
         except RuntimeError as exc:
@@ -787,6 +1324,9 @@ def bootstrap_page_environment(
                     env_file_path=env_file_path,
                     args=args,
                     ports=ports,
+                    app_name=startup_app.name,
+                    source_settings_path=source_settings_path,
+                    source_settings_resolved=True,
                     handle_data_root_failure=handle_data_root_failure,
                 )
                 return BootstrapResult(env=None, handled_recovery=True)
@@ -798,13 +1338,10 @@ def bootstrap_page_environment(
                 return BootstrapResult(env=None, handled_recovery=True)
             raise
 
-    requested_app = args.active_app
-    if not requested_app:
-        last_app = ports.load_last_active_app()
-        if last_app:
-            requested_app = persisted_active_app_request(env, last_app)
-    apply_active_app_request(env, requested_app)
-
+    _bind_authorized_app_container_roots(
+        env,
+        _startup_runtime_authorized_roots(startup_app, env),
+    )
     env.init_done = True
     streamlit.session_state["env"] = env
     streamlit.session_state["IS_SOURCE_ENV"] = env.is_source_env

--- a/src/agilab/about_page/env_editor.py
+++ b/src/agilab/about_page/env_editor.py
@@ -151,6 +151,7 @@ def _handle_data_root_failure(
 
     agi_env_cls._ensure_defaults()
     active_env_file_path = (env_file_path or ENV_FILE_PATH).expanduser()
+    home_path = Path(getattr(agi_env_cls, "home_abs", None) or Path.home())
     try:
         persisted_value = _load_env_file_map(active_env_file_path).get("AGI_CLUSTER_SHARE", "")
     except (OSError, RuntimeError, TypeError, ValueError):
@@ -166,7 +167,7 @@ def _handle_data_root_failure(
     if current_value:
         try:
             share_dir_path: Path | None = _resolve_share_dir_path(
-                str(current_value), home_path=Path(agi_env_cls.home_abs)
+                str(current_value), home_path=home_path
             )
         except ValueError:
             share_dir_path = Path(str(current_value)).expanduser()
@@ -201,7 +202,7 @@ def _handle_data_root_failure(
             st.warning("AGI_CLUSTER_SHARE cannot be empty.")
         else:
             try:
-                _resolve_share_dir_path(new_value, home_path=Path(agi_env_cls.home_abs))
+                _resolve_share_dir_path(new_value, home_path=home_path)
             except ValueError as share_exc:
                 st.warning(str(share_exc))
                 return True

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -944,13 +944,11 @@ def _apply_active_app_request(env, request_value: Optional[str]) -> bool:
     return _about_bootstrap.apply_active_app_request(env, request_value, streamlit=st)
 
 
-def _sync_active_app_from_query(env) -> None:
+def _sync_active_app_from_query(env) -> bool:
     """Honor ?active_app=… query parameter so all pages stay in sync."""
-    _about_bootstrap.sync_active_app_from_query(
+    return _about_bootstrap.sync_active_app_from_query(
         env,
         streamlit=st,
-        store_last_active_app=store_last_active_app,
-        apply_request=_apply_active_app_request,
     )
 
 
@@ -1190,7 +1188,8 @@ def _ensure_navigation_environment(
 
     env = st.session_state["env"]
     _refresh_env_from_file(env)
-    _sync_active_app_from_query(env)
+    if _sync_active_app_from_query(env):
+        return None
     try:
         store_last_active_app(_about_bootstrap.active_app_store_path(env))
     except (OSError, RuntimeError, TypeError, ValueError):

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -264,7 +264,12 @@ def _make_bootstrap_ports(
     ):
         @classmethod
         def session(cls, *args, **kwargs):
+            active_app = kwargs.pop("active_app", None)
+            if active_app is not None:
+                kwargs["app"] = Path(active_app).name
             env = cls(*args, **kwargs)
+            if active_app is not None:
+                env.active_app = Path(active_app)
             env._agilab_session_scoped = True
             return env
 
@@ -279,6 +284,15 @@ def _make_bootstrap_ports(
         environ=environ if environ is not None else {},
     )
     return ports, calls
+
+
+@pytest.fixture(autouse=True)
+def _isolate_bootstrap_installed_provider_discovery(monkeypatch):
+    monkeypatch.setattr(
+        about_agilab._about_bootstrap,
+        "discover_installed_app_projects",
+        lambda: (),
+    )
 
 
 def _event_index(events: list[tuple[str, str]], kind: str, text: str) -> int:
@@ -1530,7 +1544,7 @@ def test_bootstrap_page_environment_keeps_source_root_when_last_app_is_agi_space
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=apply_request,
         handle_data_root_failure=lambda *_args, **_kwargs: False,
@@ -1543,7 +1557,7 @@ def test_bootstrap_page_environment_keeps_source_root_when_last_app_is_agi_space
 
     assert result.env.active_app == source_project
     assert result.env.apps_path == source_apps
-    assert requested_apps == ["flight_telemetry_project"]
+    assert requested_apps == []
     assert port_calls.stored == [source_project]
     assert fake_st.query_params["active_app"] == "flight_telemetry_project"
 
@@ -1572,7 +1586,13 @@ def test_bootstrap_page_environment_repairs_enduser_env_before_source_agi_env_in
             events.append(("set", f"{key}={value}"))
             cls.persisted[key] = value
 
-        def __init__(self, *, apps_path: Path, verbose: int = 1):
+        def __init__(
+            self,
+            *,
+            apps_path: Path,
+            app: str = "flight_telemetry_project",
+            verbose: int = 1,
+        ):
             events.append(
                 ("init", f"IS_SOURCE_ENV={self.persisted.get('IS_SOURCE_ENV')}")
             )
@@ -1580,7 +1600,7 @@ def test_bootstrap_page_environment_repairs_enduser_env_before_source_agi_env_in
             self.builtin_apps_path = apps_path / "builtin"
             self.apps_repository_root = None
             self.verbose = verbose
-            self.app = "flight_telemetry_project"
+            self.app = app
             self.active_app = self.builtin_apps_path / self.app
             self.projects = {"flight_telemetry_project"}
             self.is_source_env = self.persisted.get("IS_SOURCE_ENV") == "1"
@@ -1604,7 +1624,7 @@ def test_bootstrap_page_environment_repairs_enduser_env_before_source_agi_env_in
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {
+        load_env_file_map=lambda _path, **_kwargs: {
             "APPS_PATH": str(stale_apps),
             "IS_SOURCE_ENV": "0",
             "IS_WORKER_ENV": "0",
@@ -1765,10 +1785,15 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
     monkeypatch, tmp_path
 ):
     bootstrap = about_agilab._about_bootstrap
+    (tmp_path / "apps/flight_telemetry_project").mkdir(parents=True)
     generic_recovery_calls: list[dict[str, object]] = []
+    constructed_apps: list[str] = []
 
     class FailingAgiEnv:
-        def __init__(self, *_args, **_kwargs):
+        def __init__(self, *, apps_path: Path, app: str, verbose: int):
+            assert apps_path == tmp_path / "apps"
+            assert verbose == 1
+            constructed_apps.append(app)
             raise RuntimeError(
                 "Cluster mode requires AGI_CLUSTER_SHARE to be mounted and writable. "
                 "Configured AGI_CLUSTER_SHARE='/missing/share' is not usable; env=/tmp/.env"
@@ -1779,7 +1804,6 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
     )
     ports, _port_calls = _make_bootstrap_ports(FailingAgiEnv)
     fake_st = _FakeStreamlit()
-    fake_st.query_params["active_app"] = "flight_telemetry_project"
 
     def render_share_override(exc, **kwargs):
         generic_recovery_calls.append({"exc": exc, **kwargs})
@@ -1788,7 +1812,7 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=render_share_override,
@@ -1801,7 +1825,10 @@ def test_bootstrap_page_environment_handles_cluster_share_startup_error(
 
     assert result.handled_recovery is True
     assert fake_st.stopped is True
+    assert constructed_apps == ["flight_telemetry_project"]
     error_message = _event_body(fake_st.events, "error", "Cluster mode is enabled")
+    expected_settings = tmp_path / "apps/flight_telemetry_project/app_settings.toml"
+    assert f"Workspace settings: `{expected_settings}`" in error_message
     assert "Disable cluster mode and reload" in [
         body for kind, body in fake_st.events if kind == "button"
     ]
@@ -1865,6 +1892,130 @@ user = "agi"
     assert fake_st.stopped is False
 
 
+def test_bootstrap_cluster_share_recovery_seeds_source_settings_on_first_click(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    project_path = apps_path / "builtin/flight_telemetry_project"
+    source_settings = project_path / "src/app_settings.toml"
+    source_settings.parent.mkdir(parents=True)
+    source_settings.write_text(
+        '[args]\ndata_in = "flight_telemetry/dataset"\n\n'
+        "[cluster]\ncluster_enabled = true\nworkers = 4\n",
+        encoding="utf-8",
+    )
+    construction_targets: list[Path] = []
+
+    class FailingAgiEnv:
+        @classmethod
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            assert apps_path == tmp_path / "apps"
+            assert verbose == 1
+            construction_targets.append(Path(active_app))
+            raise RuntimeError(
+                "Cluster mode requires AGI_CLUSTER_SHARE to be mounted and writable. "
+                "Configured AGI_CLUSTER_SHARE='/missing/share' is not usable"
+            )
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    fake_st = _FakeStreamlit(button_values={"Disable cluster mode and reload": True})
+    ports, _calls = _make_bootstrap_ports(FailingAgiEnv, last_app=None, environ={})
+    env_file_path = tmp_path / ".agilab/.env"
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=env_file_path,
+        load_env_file_map=lambda _path, **_kwargs: {},
+        logger=None,
+        apply_active_app_request=lambda *_args: False,
+        handle_data_root_failure=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "successful app-local recovery must not use generic recovery"
+            )
+        ),
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    workspace_settings = (
+        tmp_path / ".agilab/apps/flight_telemetry_project/app_settings.toml"
+    )
+    payload = tomllib.loads(workspace_settings.read_text(encoding="utf-8"))
+    assert result.handled_recovery is True
+    assert construction_targets == [project_path.resolve()]
+    assert payload["args"] == {"data_in": "flight_telemetry/dataset"}
+    assert payload["cluster"] == {"cluster_enabled": False, "workers": 4}
+    assert "cluster_enabled = true" in source_settings.read_text(encoding="utf-8")
+    assert ("rerun", "") in fake_st.events
+    assert fake_st.stopped is False
+
+
+def test_bootstrap_cluster_share_recovery_creates_source_less_workspace_on_click(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    project_path = apps_path / "builtin/source_less_project"
+    (project_path / "src").mkdir(parents=True)
+    construction_targets: list[Path] = []
+
+    class FailingAgiEnv:
+        @classmethod
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            assert apps_path == tmp_path / "apps"
+            assert verbose == 1
+            construction_targets.append(Path(active_app))
+            raise RuntimeError(
+                "Cluster mode requires AGI_CLUSTER_SHARE to be mounted and writable. "
+                "Configured AGI_CLUSTER_SHARE='/missing/share' is not usable"
+            )
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    fake_st = _FakeStreamlit(
+        button_values={"Disable cluster mode and reload": True},
+    )
+    fake_st.query_params["active_app"] = "source_less_project"
+    ports, _calls = _make_bootstrap_ports(FailingAgiEnv, last_app=None, environ={})
+    env_file_path = tmp_path / ".agilab/.env"
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=env_file_path,
+        load_env_file_map=lambda _path, **_kwargs: {"AGI_CLUSTER_ENABLED": "true"},
+        logger=None,
+        apply_active_app_request=lambda *_args: False,
+        handle_data_root_failure=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "successful app-local recovery must not use generic recovery"
+            )
+        ),
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    workspace_settings = tmp_path / ".agilab/apps/source_less_project/app_settings.toml"
+    assert result.handled_recovery is True
+    assert construction_targets == [project_path.resolve()]
+    workspace_payload = tomllib.loads(workspace_settings.read_text(encoding="utf-8"))
+    assert workspace_payload["cluster"] == {"cluster_enabled": False}
+    assert (project_path / "src/app_settings.toml").exists() is False
+    assert ("rerun", "") in fake_st.events
+    assert fake_st.stopped is False
+
+
 def test_bootstrap_cluster_share_recovery_handles_disabled_missing_and_write_errors(
     tmp_path, monkeypatch
 ):
@@ -1876,7 +2027,31 @@ def test_bootstrap_cluster_share_recovery_handles_disabled_missing_and_write_err
             bootstrap.disable_cluster_in_app_settings(tmp_path / "missing.toml")
 
     missing_settings = tmp_path / "missing.toml"
-    assert bootstrap.disable_cluster_in_app_settings(missing_settings) is False
+    with pytest.raises(FileNotFoundError, match="complete source settings"):
+        bootstrap.disable_cluster_in_app_settings(missing_settings)
+
+    source_settings = tmp_path / "source/seeded_project/src/app_settings.toml"
+    source_settings.parent.mkdir(parents=True)
+    source_settings.write_text(
+        '[args]\ndata_in = "seeded/dataset"\n\n'
+        "[cluster]\ncluster_enabled = true\nworkers = 3\n",
+        encoding="utf-8",
+    )
+    seeded_settings = tmp_path / ".agilab/apps/seeded_project/app_settings.toml"
+    assert (
+        bootstrap.disable_cluster_in_app_settings(
+            seeded_settings,
+            source_settings_path=source_settings,
+        )
+        is True
+    )
+    seeded_payload = tomllib.loads(seeded_settings.read_text(encoding="utf-8"))
+    assert seeded_payload["args"] == {"data_in": "seeded/dataset"}
+    assert seeded_payload["cluster"] == {
+        "cluster_enabled": False,
+        "workers": 3,
+    }
+    assert "cluster_enabled = true" in source_settings.read_text(encoding="utf-8")
 
     disabled_settings = (
         tmp_path / ".agilab/apps/flight_telemetry_project/app_settings.toml"
@@ -1905,11 +2080,13 @@ def test_bootstrap_cluster_share_recovery_handles_disabled_missing_and_write_err
         args=bootstrap.parse_startup_args([]),
         ports=ports,
     )
-    assert (
-        "info",
-        f"Cluster mode was already disabled or missing in `{disabled_settings}`.",
-    ) in fake_st.events
-    assert ("rerun", "") in fake_st.events
+    assert any(
+        "Cluster mode was already disabled" in body
+        for kind, body in fake_st.events
+        if kind == "error"
+    )
+    assert ("rerun", "") not in fake_st.events
+    assert fake_st.stopped is True
 
     broken_settings = tmp_path / ".agilab/apps/broken_project/app_settings.toml"
     broken_settings.parent.mkdir(parents=True)
@@ -1917,7 +2094,7 @@ def test_bootstrap_cluster_share_recovery_handles_disabled_missing_and_write_err
     broken_st = ClickStreamlit()
     broken_st.query_params["active_app"] = "broken_project"
 
-    def raise_disable(_settings_path):
+    def raise_disable(_settings_path, **_kwargs):
         raise OSError("locked")
 
     monkeypatch.setattr(bootstrap, "disable_cluster_in_app_settings", raise_disable)
@@ -1936,46 +2113,325 @@ def test_bootstrap_cluster_share_recovery_handles_disabled_missing_and_write_err
     assert broken_st.stopped is True
 
 
-def test_bootstrap_sync_active_app_from_query_updates_query_and_store(tmp_path):
+def test_bootstrap_cluster_share_recovery_does_not_publish_seed_on_write_failure(
+    tmp_path, monkeypatch
+):
     bootstrap = about_agilab._about_bootstrap
-    apps_path = tmp_path / "apps"
-    apps_path.mkdir()
-    env = SimpleNamespace(apps_path=apps_path, app="default")
-    fake_st = SimpleNamespace(query_params={"active_app": "target"})
-    stored_paths: list[Path] = []
+    source_settings = tmp_path / "source/atomic_project/src/app_settings.toml"
+    source_settings.parent.mkdir(parents=True)
+    source_settings.write_text(
+        '[args]\ndata_in = "atomic/dataset"\n\n[cluster]\ncluster_enabled = true\n',
+        encoding="utf-8",
+    )
+    workspace_settings = tmp_path / ".agilab/apps/atomic_project/app_settings.toml"
 
-    def fake_apply_request(target_env, request_value):
-        assert target_env is env
-        assert request_value == "target"
-        target_env.app = "target"
-        return True
+    def fail_dump(_payload, _handle):
+        raise OSError("publication failed")
 
-    bootstrap.sync_active_app_from_query(
-        env,
-        streamlit=fake_st,
-        store_last_active_app=stored_paths.append,
-        apply_request=fake_apply_request,
+    monkeypatch.setattr(
+        bootstrap,
+        "_tomli_writer",
+        SimpleNamespace(dump=fail_dump),
     )
 
-    assert fake_st.query_params["active_app"] == "target"
-    assert stored_paths == [apps_path / "target"]
+    with pytest.raises(OSError, match="publication failed"):
+        bootstrap.disable_cluster_in_app_settings(
+            workspace_settings,
+            source_settings_path=source_settings,
+        )
+
+    assert workspace_settings.exists() is False
+    assert "cluster_enabled = true" in source_settings.read_text(encoding="utf-8")
+
+
+def test_bootstrap_cluster_share_recovery_fails_closed_if_selected_source_disappears(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    source_settings = tmp_path / "source/vanished_project/src/app_settings.toml"
+    workspace_settings = tmp_path / ".agilab/apps/vanished_project/app_settings.toml"
+    fake_st = _FakeStreamlit(button_values={"Disable cluster mode and reload": True})
+    ports, _calls = _make_bootstrap_ports(object())
+
+    bootstrap.handle_cluster_share_startup_error(
+        streamlit=fake_st,
+        exc=RuntimeError("Cluster mode requires AGI_CLUSTER_SHARE"),
+        env_file_path=tmp_path / ".agilab/.env",
+        args=bootstrap.parse_startup_args([]),
+        ports=ports,
+        app_name="vanished_project",
+        source_settings_path=source_settings,
+        source_settings_resolved=True,
+    )
+
+    assert workspace_settings.exists() is False
+    assert any(
+        "selected source settings" in body and "no longer exist" in body
+        for kind, body in fake_st.events
+        if kind == "error"
+    )
+    assert ("rerun", "") not in fake_st.events
+    assert fake_st.stopped is True
+
+
+def test_bootstrap_cluster_share_recovery_rejects_workspace_app_symlink(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    workspace_apps = tmp_path / ".agilab/apps"
+    workspace_apps.mkdir(parents=True)
+    outside_app = tmp_path / "outside/flight_telemetry_project"
+    outside_app.mkdir(parents=True)
+    outside_settings = outside_app / "app_settings.toml"
+    outside_settings.write_text("[cluster]\ncluster_enabled = true\n", encoding="utf-8")
+    redirected_app = workspace_apps / "flight_telemetry_project"
+    try:
+        redirected_app.symlink_to(outside_app, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    fake_st = _FakeStreamlit(button_values={"Disable cluster mode and reload": True})
+    fake_st.query_params["active_app"] = "flight_telemetry_project"
+    ports, _calls = _make_bootstrap_ports(object())
+
+    bootstrap.handle_cluster_share_startup_error(
+        streamlit=fake_st,
+        exc=RuntimeError("Cluster mode requires AGI_CLUSTER_SHARE"),
+        env_file_path=tmp_path / ".agilab/.env",
+        args=bootstrap.parse_startup_args([]),
+        ports=ports,
+    )
+
+    assert outside_settings.read_text(encoding="utf-8") == (
+        "[cluster]\ncluster_enabled = true\n"
+    )
+    assert any(
+        "Automatic local recovery is unavailable" in body
+        for kind, body in fake_st.events
+        if kind == "error"
+    )
+    assert not [body for kind, body in fake_st.events if kind == "button"]
+    assert fake_st.stopped is True
+
+
+def test_bootstrap_sync_active_app_from_query_schedules_cold_transition(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    target_path = apps_path / "target_project"
+    target_path.mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=apps_path,
+        app="default",
+        active_app=apps_path / "default",
+        _agilab_initialized=True,
+        init_done=True,
+        _agilab_authorized_app_container_roots=(apps_path,),
+    )
+    env_snapshot = dict(vars(env))
+    fake_st = _FakeStreamlit()
+    fake_st.query_params["active_app"] = "target_project"
+
+    assert bootstrap.sync_active_app_from_query(
+        env,
+        streamlit=fake_st,
+    ) is True
+
+    assert vars(env) == env_snapshot
+    assert fake_st.session_state["first_run"] is True
+    assert fake_st.query_params["active_app"] == str(target_path.resolve())
+    assert ("rerun", "") in fake_st.events
+
+
+def test_bootstrap_sync_active_app_from_query_rejects_warm_out_of_root_path(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    safe_project = apps_path / "safe_project"
+    outside_project = tmp_path / "outside/evil_project"
+    safe_project.mkdir(parents=True)
+    outside_project.mkdir(parents=True)
+    monkeypatch.setattr(bootstrap, "discover_installed_app_projects", lambda: ())
+    env = SimpleNamespace(
+        apps_path=apps_path,
+        builtin_apps_path=apps_path / "builtin",
+        apps_repository_root=None,
+        projects={"safe_project"},
+        app="safe_project",
+        active_app=safe_project,
+        _agilab_authorized_app_container_roots=(
+            apps_path,
+            apps_path / "builtin",
+        ),
+    )
+    fake_st = _FakeStreamlit()
+    fake_st.query_params["active_app"] = str(outside_project)
+
+    assert bootstrap.sync_active_app_from_query(
+        env,
+        streamlit=fake_st,
+    ) is False
+
+    assert env.app == "safe_project"
+    assert env.active_app == safe_project
+    assert fake_st.query_params == {"active_app": "safe_project"}
+    assert ("rerun", "") not in fake_st.events
+
+
+def test_bootstrap_sync_active_app_from_query_does_not_promote_provider_parent(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    safe_project = apps_path / "safe_project"
+    provider_project = tmp_path / "providers/canonical_project"
+    unadvertised_project = provider_project.parent / "unadvertised_project"
+    for project in (safe_project, provider_project, unadvertised_project):
+        project.mkdir(parents=True)
+    installed_projects = (
+        SimpleNamespace(
+            name="canonical_project",
+            project_root=provider_project,
+            provider="advertised_project",
+        ),
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "discover_installed_app_projects",
+        lambda: installed_projects,
+    )
+
+    class FakeEnv:
+        def __init__(self):
+            self.apps_path = apps_path
+            self.builtin_apps_path = apps_path / "builtin"
+            self.apps_repository_root = None
+            self.projects = {"safe_project", "canonical_project"}
+            self.app = "safe_project"
+            self.active_app = safe_project
+            self.verbose = 1
+            self.init_done = True
+            self._agilab_authorized_app_container_roots = (
+                apps_path,
+                apps_path / "builtin",
+            )
+
+    env = FakeEnv()
+    fake_st = _FakeStreamlit()
+    fake_st.query_params["active_app"] = "advertised_project"
+
+    assert bootstrap.sync_active_app_from_query(
+        env,
+        streamlit=fake_st,
+    ) is True
+
+    assert env.app == "safe_project"
+    assert env.apps_path == apps_path
+    assert env._agilab_authorized_app_container_roots == (
+        apps_path,
+        apps_path / "builtin",
+    )
+    assert fake_st.query_params["active_app"] == str(provider_project.resolve())
+    assert fake_st.session_state["first_run"] is True
+
+    env.apps_path = provider_project.parent.resolve()
+    env.app = "canonical_project"
+    env.active_app = provider_project.resolve()
+    fake_st.session_state["first_run"] = False
+    fake_st.events.clear()
+
+    fake_st.query_params["active_app"] = str(unadvertised_project)
+    assert bootstrap.sync_active_app_from_query(
+        env,
+        streamlit=fake_st,
+    ) is False
+
+    assert env.app == "canonical_project"
+    assert env.active_app == provider_project.resolve()
+    assert fake_st.query_params["active_app"] == "canonical_project"
+    assert fake_st.session_state["first_run"] is False
+    assert ("rerun", "") not in fake_st.events
 
 
 def test_bootstrap_sync_active_app_from_query_keeps_matching_query(tmp_path):
     bootstrap = about_agilab._about_bootstrap
     env = SimpleNamespace(apps_path=tmp_path / "apps", app="target")
     fake_st = SimpleNamespace(query_params={"active_app": "target"})
-    stored_paths: list[Path] = []
-
-    bootstrap.sync_active_app_from_query(
+    assert bootstrap.sync_active_app_from_query(
         env,
         streamlit=fake_st,
-        store_last_active_app=stored_paths.append,
-        apply_request=lambda _env, _request_value: False,
-    )
+    ) is False
 
     assert fake_st.query_params == {"active_app": "target"}
-    assert stored_paths == []
+
+
+def test_bootstrap_page_environment_ignores_commented_app_default_for_construction(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    (apps_path / "flight_telemetry_project").mkdir(parents=True)
+    constructed_apps: list[str] = []
+    load_modes: list[bool] = []
+    requested_apps: list[str | None] = []
+
+    class FakeAgiEnv:
+        @classmethod
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            app = Path(active_app).name
+            constructed_apps.append(app)
+            return SimpleNamespace(
+                apps_path=apps_path,
+                active_app=Path(active_app),
+                app=app,
+                projects={app},
+                verbose=verbose,
+                is_source_env=False,
+                is_worker_env=False,
+                OPENAI_API_KEY="",
+                CLUSTER_CREDENTIALS="",
+                envars={},
+                init_done=False,
+                _agilab_session_scoped=True,
+            )
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    def load_env_file_map(_path, *, include_commented=True):
+        load_modes.append(include_commented)
+        if include_commented:
+            return {"APP_DEFAULT": "commented_project"}
+        return {}
+
+    fake_st = _FakeStreamlit()
+    ports, _port_calls = _make_bootstrap_ports(
+        FakeAgiEnv,
+        last_app=None,
+        environ={},
+    )
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=load_env_file_map,
+        logger=None,
+        apply_active_app_request=lambda _env, requested: (
+            requested_apps.append(requested) or False
+        ),
+        handle_data_root_failure=lambda _exc, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    assert result.handled_recovery is False
+    assert constructed_apps == ["flight_telemetry_project"]
+    assert requested_apps == []
+    assert load_modes[0] is False
 
 
 def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
@@ -1993,10 +2449,10 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
         def set_env_var(key: str, value: str) -> None:
             set_env_calls.append((key, value))
 
-        def __init__(self, *, apps_path: Path, verbose: int):
+        def __init__(self, *, apps_path: Path, app: str, verbose: int):
             self.apps_path = apps_path
             self.verbose = verbose
-            self.app = "default"
+            self.app = app
             self.projects = {"flight_telemetry_project"}
             self.is_source_env = True
             self.is_worker_env = False
@@ -2040,7 +2496,7 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
         logger=None,
         apply_active_app_request=fake_apply_active_app_request,
         handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2071,6 +2527,7 @@ def test_bootstrap_page_environment_replaces_legacy_warm_env_without_borrowing_s
     apps_path = tmp_path / "apps"
     app_path = apps_path / "sb3_trainer_project"
     app_path.mkdir(parents=True)
+    (apps_path / "flight_telemetry_project").mkdir()
     requested_apps: list[str | None] = []
     set_env_calls: list[tuple[str, str]] = []
     refreshed_envs: list[object] = []
@@ -2099,13 +2556,14 @@ def test_bootstrap_page_environment_replaces_legacy_warm_env_without_borrowing_s
             return existing_env
 
         @classmethod
-        def session(cls, *, apps_path: Path, verbose: int):
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            app = Path(active_app).name
             cls.session_calls += 1
             return SimpleNamespace(
                 apps_path=apps_path,
-                app="sb3_trainer_project",
-                active_app=apps_path / "sb3_trainer_project",
-                projects={"sb3_trainer_project"},
+                app=app,
+                active_app=Path(active_app),
+                projects={app},
                 is_source_env=True,
                 is_worker_env=False,
                 OPENAI_API_KEY="",
@@ -2136,7 +2594,7 @@ def test_bootstrap_page_environment_replaces_legacy_warm_env_without_borrowing_s
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
         logger=None,
         apply_active_app_request=apply_request,
         handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2151,7 +2609,7 @@ def test_bootstrap_page_environment_replaces_legacy_warm_env_without_borrowing_s
     assert result.env._agilab_session_scoped is True
     assert fake_st.session_state["first_run"] is False
     assert result.env.init_done is True
-    assert requested_apps == [None]
+    assert requested_apps == []
     assert refreshed_envs == [result.env]
     assert port_calls.activated == []
     assert WarmAgiEnv.current_calls == 0
@@ -2164,6 +2622,7 @@ def test_bootstrap_session_factory_failure_never_borrows_cli_singleton(
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
     apps_path.mkdir()
+    (apps_path / "flight_telemetry_project").mkdir()
     current_calls: list[str] = []
 
     class SessionAgiEnv:
@@ -2172,8 +2631,9 @@ def test_bootstrap_session_factory_failure_never_borrows_cli_singleton(
             return None
 
         @classmethod
-        def session(cls, *, apps_path: Path, verbose: int):
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
             assert apps_path == tmp_path / "apps"
+            assert Path(active_app).name == "flight_telemetry_project"
             assert verbose == 1
             raise RuntimeError(
                 "AgiEnv is already initialised with a different configuration; "
@@ -2197,7 +2657,7 @@ def test_bootstrap_session_factory_failure_never_borrows_cli_singleton(
         bootstrap.bootstrap_page_environment(
             streamlit=fake_st,
             env_file_path=tmp_path / ".env",
-            load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+            load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
             logger=None,
             apply_active_app_request=lambda *_args: False,
             handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2211,12 +2671,41 @@ def test_bootstrap_session_factory_failure_never_borrows_cli_singleton(
     assert "env" not in fake_st.session_state
 
 
+def test_bootstrap_session_factory_rejects_wrong_same_named_target(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    target_path = apps_path / "target_project"
+    wrong_path = tmp_path / "other/target_project"
+    target_path.mkdir(parents=True)
+    wrong_path.mkdir(parents=True)
+
+    class WrongTargetAgiEnv:
+        @classmethod
+        def session(cls, **_kwargs):
+            return SimpleNamespace(
+                app="target_project",
+                active_app=wrong_path,
+                _agilab_session_scoped=True,
+            )
+
+    with pytest.raises(RuntimeError, match="initialized a different project"):
+        bootstrap._create_streamlit_session_env(
+            WrongTargetAgiEnv,
+            apps_path=apps_path,
+            startup_app=bootstrap.StartupAppRequest(
+                "target_project", target_path, "query"
+            ),
+            verbose=1,
+        )
+
+
 def test_bootstrap_requires_session_factory_with_actionable_upgrade_error(
     tmp_path, monkeypatch
 ):
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
     apps_path.mkdir()
+    (apps_path / "flight_telemetry_project").mkdir()
 
     class LegacyAgiEnv:
         init_calls = 0
@@ -2247,7 +2736,7 @@ def test_bootstrap_requires_session_factory_with_actionable_upgrade_error(
         bootstrap.bootstrap_page_environment(
             streamlit=fake_st,
             env_file_path=tmp_path / ".env",
-            load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+            load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
             logger=None,
             apply_active_app_request=lambda *_args: False,
             handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2306,7 +2795,7 @@ def test_bootstrap_page_environment_reuses_matching_session_scoped_warm_env(
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
         logger=None,
         apply_active_app_request=lambda _env, _requested: False,
         handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2322,6 +2811,192 @@ def test_bootstrap_page_environment_reuses_matching_session_scoped_warm_env(
     assert refreshed_envs == [existing_env]
 
 
+def test_bootstrap_matching_warm_env_ignores_irrelevant_invalid_app_default(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    app_path = apps_path / "builtin/flight_telemetry_project"
+    app_path.mkdir(parents=True)
+    existing_env = SimpleNamespace(
+        apps_path=apps_path,
+        app="flight_telemetry_project",
+        active_app=app_path,
+        projects={"flight_telemetry_project"},
+        is_source_env=True,
+        is_worker_env=False,
+        OPENAI_API_KEY="",
+        CLUSTER_CREDENTIALS="",
+        envars={},
+        init_done=True,
+        _agilab_session_scoped=True,
+    )
+
+    class WarmAgiEnv:
+        @classmethod
+        def session(cls, **_kwargs):
+            raise AssertionError("the healthy matching warm environment must be reused")
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
+    ports, _calls = _make_bootstrap_ports(WarmAgiEnv, last_app=None, environ={})
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path, **_kwargs: {"APP_DEFAULT": "invalid"},
+        logger=None,
+        apply_active_app_request=lambda *_args: False,
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    assert result.env is existing_env
+    assert result.handled_recovery is False
+
+
+def test_bootstrap_warm_env_external_query_cluster_failure_uses_safe_recovery(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "public-apps"
+    warm_app = apps_path / "warm_project"
+    external_repo = tmp_path / "external-repo"
+    external_app = external_repo / "apps/external_project"
+    external_settings = external_app / "src/app_settings.toml"
+    warm_app.mkdir(parents=True)
+    external_settings.parent.mkdir(parents=True)
+    external_settings.write_text(
+        "[cluster]\ncluster_enabled = true\n", encoding="utf-8"
+    )
+    existing_env = SimpleNamespace(
+        apps_path=apps_path,
+        app="warm_project",
+        active_app=warm_app,
+        projects={"warm_project"},
+        is_source_env=True,
+        is_worker_env=False,
+        OPENAI_API_KEY="",
+        CLUSTER_CREDENTIALS="",
+        envars={},
+        init_done=True,
+        _agilab_session_scoped=True,
+    )
+    construction_targets: list[Path] = []
+
+    class FailingAgiEnv:
+        @classmethod
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            assert apps_path == tmp_path / "public-apps"
+            assert verbose == 1
+            construction_targets.append(Path(active_app))
+            raise RuntimeError(
+                "Cluster mode requires AGI_CLUSTER_SHARE to be mounted and writable. "
+                "Configured AGI_CLUSTER_SHARE='/missing/share' is not usable"
+            )
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
+    fake_st.query_params["active_app"] = str(external_app)
+    ports, _calls = _make_bootstrap_ports(
+        FailingAgiEnv,
+        last_app=warm_app,
+        environ={},
+    )
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".agilab/.env",
+        load_env_file_map=lambda _path, **_kwargs: {
+            "APPS_REPOSITORY": str(external_repo)
+        },
+        logger=None,
+        apply_active_app_request=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("startup switching must happen inside session construction")
+        ),
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    assert result.handled_recovery is True
+    assert construction_targets == [external_app.resolve()]
+    assert fake_st.session_state["env"] is existing_env
+    assert existing_env.app == "warm_project"
+    assert existing_env.active_app == warm_app
+    assert existing_env.init_done is True
+    assert fake_st.query_params["active_app"] == str(external_app)
+    workspace_settings = tmp_path / ".agilab/apps/external_project/app_settings.toml"
+    assert any(
+        f"Workspace settings: `{workspace_settings}`" in body
+        for kind, body in fake_st.events
+        if kind == "error"
+    )
+
+
+def test_bootstrap_rejects_nonexistent_query_project_before_session_construction(
+    tmp_path,
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    (apps_path / "builtin/flight_telemetry_project").mkdir(parents=True)
+    missing_project = apps_path / "builtin/ghost_unavailable_project"
+    set_env_calls: list[tuple[str, str]] = []
+
+    class CountingAgiEnv:
+        session_calls = 0
+
+        @classmethod
+        def session(cls, **_kwargs):
+            cls.session_calls += 1
+            raise AssertionError("an invalid project must not reach construction")
+
+        @staticmethod
+        def set_env_var(key: str, value: str) -> None:
+            set_env_calls.append((key, value))
+
+    fake_st = _FakeStreamlit()
+    fake_st.query_params["active_app"] = str(missing_project)
+    ports, _calls = _make_bootstrap_ports(CountingAgiEnv, last_app=None, environ={})
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path, **_kwargs: {},
+        logger=None,
+        apply_active_app_request=lambda *_args: False,
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(apps_path)],
+        ports=ports,
+    )
+
+    assert result.handled_recovery is True
+    assert CountingAgiEnv.session_calls == 0
+    assert set_env_calls == []
+    assert missing_project.exists() is False
+    assert any(
+        "does not resolve to an existing app" in body
+        for kind, body in fake_st.events
+        if kind == "error"
+    )
+
+
 def test_bootstrap_page_environment_replaces_warm_env_with_different_apps_path(
     tmp_path, monkeypatch
 ):
@@ -2330,6 +3005,7 @@ def test_bootstrap_page_environment_replaces_warm_env_with_different_apps_path(
     app_path = apps_path / "sb3_trainer_project"
     stale_apps_path = tmp_path / "agi-space" / "apps"
     app_path.mkdir(parents=True)
+    (apps_path / "flight_telemetry_project").mkdir()
     stale_apps_path.mkdir(parents=True)
 
     existing_env = SimpleNamespace(
@@ -2355,12 +3031,13 @@ def test_bootstrap_page_environment_replaces_warm_env_with_different_apps_path(
             return existing_env
 
         @classmethod
-        def session(cls, *, apps_path: Path, verbose: int):
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            app = Path(active_app).name
             return SimpleNamespace(
                 apps_path=apps_path,
-                app="sb3_trainer_project",
-                active_app=apps_path / "sb3_trainer_project",
-                projects={"sb3_trainer_project"},
+                app=app,
+                active_app=Path(active_app),
+                projects={app},
                 is_source_env=True,
                 is_worker_env=False,
                 OPENAI_API_KEY="",
@@ -2387,7 +3064,7 @@ def test_bootstrap_page_environment_replaces_warm_env_with_different_apps_path(
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
         logger=None,
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2448,12 +3125,13 @@ def test_bootstrap_page_environment_never_resets_or_borrows_unusable_warm_single
             set_env_calls.append((key, value))
 
         @classmethod
-        def session(cls, *, apps_path: Path, verbose: int):
+        def session(cls, *, apps_path: Path, active_app: Path, verbose: int):
+            app = Path(active_app).name
             return SimpleNamespace(
                 apps_path=apps_path,
-                app="flight_telemetry_project",
-                active_app=apps_path / "flight_telemetry_project",
-                projects={"flight_telemetry_project"},
+                app=app,
+                active_app=Path(active_app),
+                projects={app},
                 is_source_env=True,
                 is_worker_env=False,
                 OPENAI_API_KEY="",
@@ -2476,7 +3154,7 @@ def test_bootstrap_page_environment_never_resets_or_borrows_unusable_warm_single
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        load_env_file_map=lambda _path, **_kwargs: {"APPS_PATH": str(apps_path)},
         logger=None,
         apply_active_app_request=lambda _env, _requested: False,
         handle_data_root_failure=lambda _exc, **_kwargs: False,
@@ -2942,17 +3620,255 @@ def test_bootstrap_sync_active_app_from_query_handles_missing_query_api(tmp_path
         def query_params(self):
             raise RuntimeError("query unavailable")
 
-    stored_paths: list[Path] = []
     env = SimpleNamespace(apps_path=tmp_path, app="default")
 
-    bootstrap.sync_active_app_from_query(
+    assert bootstrap.sync_active_app_from_query(
         env,
         streamlit=BrokenQueryStreamlit(),
-        store_last_active_app=stored_paths.append,
-        apply_request=lambda *_args: True,
+    ) is False
+
+
+def test_bootstrap_resolve_startup_app_request_precedence_and_stale_last_fallback(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    builtin_apps = apps_path / "builtin"
+    query_project = builtin_apps / "query_project"
+    cli_project = builtin_apps / "cli_project"
+    current_remembered = builtin_apps / "remembered_project"
+    default_project = builtin_apps / "default_project"
+    built_in_default = builtin_apps / "flight_telemetry_project"
+    for project in (
+        query_project,
+        cli_project,
+        current_remembered,
+        default_project,
+        built_in_default,
+    ):
+        project.mkdir(parents=True)
+    remembered_raw = tmp_path / "stale-install" / "remembered_project"
+    monkeypatch.setattr(bootstrap, "discover_installed_app_projects", lambda: ())
+
+    def make_ports(last_app):
+        return bootstrap.BootstrapPorts(
+            agi_env_cls=object(),
+            activate_mlflow=lambda _env: None,
+            background_services_enabled=lambda: False,
+            load_last_active_app=lambda: last_app,
+            store_last_active_app=lambda _path: None,
+            environ={},
+        )
+
+    query_raw = str(query_project)
+    streamlit = SimpleNamespace(query_params={"active_app": query_raw})
+    cli_args = bootstrap.parse_startup_args(["--active-app", str(cli_project)])
+    saved_env = {"APP_DEFAULT": str(default_project)}
+
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=cli_args,
+        ports=make_ports(remembered_raw),
+        apps_path=apps_path,
+        saved_env=saved_env,
+    ) == bootstrap.StartupAppRequest("query_project", query_project.resolve(), "query")
+
+    streamlit.query_params = {}
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=cli_args,
+        ports=make_ports(remembered_raw),
+        apps_path=apps_path,
+        saved_env=saved_env,
+    ) == bootstrap.StartupAppRequest("cli_project", cli_project.resolve(), "cli")
+
+    no_cli_args = bootstrap.parse_startup_args([])
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=no_cli_args,
+        ports=make_ports(remembered_raw),
+        apps_path=apps_path,
+        saved_env=saved_env,
+    ) == bootstrap.StartupAppRequest(
+        "remembered_project", current_remembered.resolve(), "last"
     )
 
-    assert stored_paths == []
+    stale_absent = tmp_path / "stale-install" / "absent_project"
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=no_cli_args,
+        ports=make_ports(stale_absent),
+        apps_path=apps_path,
+        saved_env=saved_env,
+    ) == bootstrap.StartupAppRequest(
+        "default_project", default_project.resolve(), "default"
+    )
+
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=no_cli_args,
+        ports=make_ports(stale_absent),
+        apps_path=apps_path,
+        saved_env={},
+    ) == bootstrap.StartupAppRequest(
+        "flight_telemetry_project", built_in_default.resolve(), "default"
+    )
+
+    stale_warm = SimpleNamespace(
+        apps_path=apps_path,
+        app="deleted_project",
+        active_app=builtin_apps / "deleted_project",
+        _agilab_session_scoped=True,
+    )
+    assert bootstrap.resolve_startup_app_request(
+        streamlit=streamlit,
+        args=no_cli_args,
+        ports=make_ports(stale_absent),
+        apps_path=apps_path,
+        saved_env=saved_env,
+        warm_env=stale_warm,
+    ) == bootstrap.StartupAppRequest(
+        "default_project", default_project.resolve(), "default"
+    )
+
+    with pytest.raises(ValueError, match="APP_DEFAULT startup project"):
+        bootstrap.resolve_startup_app_request(
+            streamlit=streamlit,
+            args=no_cli_args,
+            ports=make_ports(stale_absent),
+            apps_path=apps_path,
+            saved_env={"APP_DEFAULT": "invalid"},
+        )
+
+    missing_query = builtin_apps / "missing_project"
+    streamlit.query_params = {"active_app": str(missing_query)}
+    with pytest.raises(ValueError, match="does not resolve to an existing app"):
+        bootstrap.resolve_startup_app_request(
+            streamlit=streamlit,
+            args=no_cli_args,
+            ports=make_ports(None),
+            apps_path=apps_path,
+            saved_env={},
+        )
+    assert missing_query.exists() is False
+
+
+def test_bootstrap_resolve_startup_app_request_keeps_configured_external_last_app(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "public-apps"
+    external_repo = tmp_path / "private-apps-repo"
+    external_project = external_repo / "apps/external_project"
+    external_project.mkdir(parents=True)
+    monkeypatch.setattr(bootstrap, "discover_installed_app_projects", lambda: ())
+    ports = bootstrap.BootstrapPorts(
+        agi_env_cls=object(),
+        activate_mlflow=lambda _env: None,
+        background_services_enabled=lambda: False,
+        load_last_active_app=lambda: external_project,
+        store_last_active_app=lambda _path: None,
+        environ={},
+    )
+
+    request = bootstrap.resolve_startup_app_request(
+        streamlit=SimpleNamespace(query_params={}),
+        args=bootstrap.parse_startup_args([]),
+        ports=ports,
+        apps_path=apps_path,
+        saved_env={"APPS_REPOSITORY": str(external_repo)},
+    )
+
+    assert request == bootstrap.StartupAppRequest(
+        "external_project", external_project.resolve(), "last"
+    )
+
+
+def test_bootstrap_startup_rejects_nested_path_inside_installed_provider(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    provider_project = tmp_path / "providers/canonical_project"
+    nested_project = provider_project / "nested_project"
+    nested_project.mkdir(parents=True)
+    monkeypatch.setattr(
+        bootstrap,
+        "discover_installed_app_projects",
+        lambda: (
+            SimpleNamespace(
+                name="canonical_project",
+                project_root=provider_project,
+                provider="advertised_project",
+            ),
+        ),
+    )
+    ports = bootstrap.BootstrapPorts(
+        agi_env_cls=object(),
+        activate_mlflow=lambda _env: None,
+        background_services_enabled=lambda: False,
+        load_last_active_app=lambda: None,
+        store_last_active_app=lambda _path: None,
+        environ={},
+    )
+
+    request = bootstrap.resolve_startup_app_request(
+        streamlit=SimpleNamespace(query_params={"active_app": "advertised_project"}),
+        args=bootstrap.parse_startup_args([]),
+        ports=ports,
+        apps_path=tmp_path / "apps",
+        saved_env={},
+    )
+    assert request == bootstrap.StartupAppRequest(
+        "canonical_project", provider_project.resolve(), "query"
+    )
+
+    with pytest.raises(ValueError, match="does not resolve to an existing app"):
+        bootstrap.resolve_startup_app_request(
+            streamlit=SimpleNamespace(query_params={"active_app": str(nested_project)}),
+            args=bootstrap.parse_startup_args([]),
+            ports=ports,
+            apps_path=tmp_path / "apps",
+            saved_env={},
+        )
+
+
+@pytest.mark.parametrize("request_source", ["query", "cli"])
+def test_bootstrap_startup_rejects_nested_project_inside_configured_apps_root(
+    request_source, tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    nested_worker = apps_path / "builtin/container_project/src/container_worker"
+    nested_worker.mkdir(parents=True)
+    monkeypatch.setattr(bootstrap, "discover_installed_app_projects", lambda: ())
+    ports = bootstrap.BootstrapPorts(
+        agi_env_cls=object(),
+        activate_mlflow=lambda _env: None,
+        background_services_enabled=lambda: False,
+        load_last_active_app=lambda: None,
+        store_last_active_app=lambda _path: None,
+        environ={},
+    )
+    streamlit = SimpleNamespace(
+        query_params={
+            "active_app": str(nested_worker) if request_source == "query" else ""
+        }
+    )
+    args = bootstrap.parse_startup_args(
+        ["--active-app", str(nested_worker)] if request_source == "cli" else []
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"The {request_source} startup project .* does not resolve",
+    ):
+        bootstrap.resolve_startup_app_request(
+            streamlit=streamlit,
+            args=args,
+            ports=ports,
+            apps_path=apps_path,
+            saved_env={},
+        )
 
 
 def test_bootstrap_startup_active_app_name_handles_query_lists_loader_errors_and_empty_values():
@@ -3011,39 +3927,39 @@ def test_bootstrap_startup_active_app_name_handles_query_lists_loader_errors_and
     )
 
 
-def test_bootstrap_sync_active_app_from_query_handles_empty_list_and_store_error(
+def test_bootstrap_sync_active_app_from_query_handles_empty_list_and_rerun(
     tmp_path,
 ):
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
-    env = SimpleNamespace(apps_path=apps_path, app="default")
-    empty_query_st = SimpleNamespace(query_params={"active_app": []})
-
-    bootstrap.sync_active_app_from_query(
-        env,
-        streamlit=empty_query_st,
-        store_last_active_app=lambda _path: None,
-        apply_request=lambda *_args: False,
+    (apps_path / "target_project").mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=apps_path,
+        app="default",
+        _agilab_authorized_app_container_roots=(apps_path,),
     )
+    fake_st = _FakeStreamlit()
+    fake_st.query_params["active_app"] = []
 
-    assert empty_query_st.query_params["active_app"] == "default"
-
-    requested_query_st = SimpleNamespace(query_params={"active_app": ["target"]})
-
-    def apply_request(target_env, requested):
-        target_env.app = requested
-        return True
-
-    bootstrap.sync_active_app_from_query(
+    assert bootstrap.sync_active_app_from_query(
         env,
-        streamlit=requested_query_st,
-        store_last_active_app=lambda _path: (_ for _ in ()).throw(
-            RuntimeError("store failed")
-        ),
-        apply_request=apply_request,
-    )
+        streamlit=fake_st,
+    ) is False
 
-    assert requested_query_st.query_params["active_app"] == "target"
+    assert fake_st.query_params["active_app"] == "default"
+
+    fake_st.query_params["active_app"] = ["target_project"]
+
+    assert bootstrap.sync_active_app_from_query(
+        env,
+        streamlit=fake_st,
+    ) is True
+
+    assert fake_st.query_params["active_app"] == str(
+        (apps_path / "target_project").resolve()
+    )
+    assert fake_st.session_state["first_run"] is True
+    assert ("rerun", "") in fake_st.events
 
 
 def test_bootstrap_remember_active_app_ignores_store_errors(tmp_path):
@@ -3057,15 +3973,17 @@ def test_bootstrap_remember_active_app_ignores_store_errors(tmp_path):
 def test_bootstrap_page_environment_uses_injected_ports_and_services(tmp_path):
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
+    remembered_app = apps_path / "remembered_project"
+    remembered_app.mkdir(parents=True)
     requested_apps: list[str | None] = []
     saved_values: list[tuple[str, str]] = []
     stored_credentials: list[str] = []
 
     class FakeAgiEnv:
-        def __init__(self, *, apps_path: Path, verbose: int):
+        def __init__(self, *, apps_path: Path, app: str, verbose: int):
             self.apps_path = apps_path
             self.verbose = verbose
-            self.app = "default"
+            self.app = app
             self.is_source_env = True
             self.is_worker_env = False
             self.OPENAI_API_KEY = ""
@@ -3088,14 +4006,14 @@ def test_bootstrap_page_environment_uses_injected_ports_and_services(tmp_path):
     ports, port_calls = _make_bootstrap_ports(
         FakeAgiEnv,
         services_enabled=True,
-        last_app=apps_path / "remembered",
+        last_app=remembered_app,
         environ={},
     )
 
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=apply_request,
         handle_data_root_failure=lambda *_args, **_kwargs: False,
@@ -3117,10 +4035,10 @@ def test_bootstrap_page_environment_uses_injected_ports_and_services(tmp_path):
     assert result.env.init_done is True
     assert fake_st.session_state["apps_path"] == str(apps_path)
     assert fake_st.session_state["first_run"] is False
-    assert fake_st.query_params["active_app"] == "remembered"
-    assert requested_apps == [str(apps_path / "remembered")]
+    assert fake_st.query_params["active_app"] == "remembered_project"
+    assert requested_apps == []
     assert port_calls.activated == [result.env]
-    assert port_calls.stored == [apps_path / "remembered"]
+    assert port_calls.stored == [remembered_app]
     assert ("APPS_PATH", str(apps_path)) in saved_values
     assert not [message for event, message in fake_st.events if event == "warning"]
 
@@ -3128,13 +4046,15 @@ def test_bootstrap_page_environment_uses_injected_ports_and_services(tmp_path):
 def test_bootstrap_page_environment_cli_active_app_overrides_last_app(tmp_path):
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
+    cli_app = apps_path / "cli_app_project"
+    cli_app.mkdir(parents=True)
     requested_apps: list[str | None] = []
 
     class FakeAgiEnv:
-        def __init__(self, *, apps_path: Path, verbose: int):
+        def __init__(self, *, apps_path: Path, app: str, verbose: int):
             self.apps_path = apps_path
             self.verbose = verbose
-            self.app = "default"
+            self.app = app
             self.is_source_env = False
             self.is_worker_env = False
             self.OPENAI_API_KEY = "sk-" + "b" * 16
@@ -3152,26 +4072,29 @@ def test_bootstrap_page_environment_cli_active_app_overrides_last_app(tmp_path):
 
     fake_st = _FakeStreamlit()
     ports, port_calls = _make_bootstrap_ports(
-        FakeAgiEnv, services_enabled=False, last_app="remembered"
+        FakeAgiEnv, services_enabled=False, last_app="remembered_project"
     )
 
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"OPENAI_API_KEY": "already-saved"},
+        load_env_file_map=lambda _path, **_kwargs: {"OPENAI_API_KEY": "already-saved"},
         logger=object(),
         apply_active_app_request=apply_request,
         handle_data_root_failure=lambda *_args, **_kwargs: False,
         refresh_env_from_file=lambda _env: None,
         clean_openai_key=lambda value: value,
         store_cluster_credentials=lambda *_args, **_kwargs: True,
-        argv=["--apps-path", str(apps_path), "--active-app", "cli-app"],
+        argv=["--apps-path", str(apps_path), "--active-app", "cli_app_project"],
         ports=ports,
     )
 
     assert result.should_rerun is False
-    assert requested_apps == ["cli-app"]
-    assert fake_st.query_params["active_app"] == "cli-app"
+    assert result.handled_recovery is False
+    assert result.env.app == "cli_app_project"
+    assert result.env.active_app == cli_app.resolve()
+    assert requested_apps == []
+    assert fake_st.query_params["active_app"] == "cli_app_project"
     assert port_calls.activated == []
 
 
@@ -3188,7 +4111,7 @@ def test_bootstrap_page_environment_handles_missing_apps_path(monkeypatch, tmp_p
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=lambda *_args, **_kwargs: False,
@@ -3227,7 +4150,7 @@ def test_bootstrap_page_environment_handles_resolution_and_data_root_recovery(
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=lambda *_args, **_kwargs: False,
@@ -3250,7 +4173,7 @@ def test_bootstrap_page_environment_handles_resolution_and_data_root_recovery(
     recovered = bootstrap.bootstrap_page_environment(
         streamlit=_FakeStreamlit(),
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {},
+        load_env_file_map=lambda _path, **_kwargs: {},
         logger=object(),
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=lambda exc, **_kwargs: "bad data root" in str(exc),
@@ -3269,6 +4192,7 @@ def test_bootstrap_page_environment_reraises_unrecovered_data_root_error(
     tmp_path,
 ):
     bootstrap = about_agilab._about_bootstrap
+    (tmp_path / "apps/flight_telemetry_project").mkdir(parents=True)
 
     class FailingAgiEnv:
         def __init__(self, *_args, **_kwargs):
@@ -3283,7 +4207,7 @@ def test_bootstrap_page_environment_reraises_unrecovered_data_root_error(
         bootstrap.bootstrap_page_environment(
             streamlit=_FakeStreamlit(),
             env_file_path=tmp_path / ".env",
-            load_env_file_map=lambda _path: {},
+            load_env_file_map=lambda _path, **_kwargs: {},
             logger=object(),
             apply_active_app_request=lambda *_args: False,
             handle_data_root_failure=lambda *_args, **_kwargs: False,
@@ -3299,10 +4223,10 @@ def test_bootstrap_page_environment_ignores_query_param_write_errors(tmp_path):
     bootstrap = about_agilab._about_bootstrap
 
     class FakeAgiEnv:
-        def __init__(self, *, apps_path: Path, verbose: int):
+        def __init__(self, *, apps_path: Path, app: str, verbose: int):
             self.apps_path = apps_path
             self.verbose = verbose
-            self.app = "default"
+            self.app = app
             self.is_source_env = True
             self.is_worker_env = False
             self.OPENAI_API_KEY = "sk-" + "c" * 16
@@ -3324,7 +4248,9 @@ def test_bootstrap_page_environment_ignores_query_param_write_errors(tmp_path):
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
         env_file_path=tmp_path / ".env",
-        load_env_file_map=lambda _path: {"APPS_PATH": str(tmp_path / "apps")},
+        load_env_file_map=lambda _path, **_kwargs: {
+            "APPS_PATH": str(tmp_path / "apps")
+        },
         logger=object(),
         apply_active_app_request=lambda *_args: False,
         handle_data_root_failure=lambda *_args, **_kwargs: False,

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -869,6 +869,167 @@ def test_agilab_main_page_env_editor(mock_ui_env):
     assert any("Environment variables updated" in msg for msg in success_msgs)
 
 
+def test_agilab_main_page_recovers_from_unmounted_cluster_share(mock_ui_env):
+    home_root = mock_ui_env["apps_dir"].parent
+    project_dir = mock_ui_env["project_dir"]
+    source_settings = project_dir / "src/app_settings.toml"
+    source_settings.write_text(
+        '[args]\ndata_in = "flight_telemetry/dataset"\n\n'
+        "[cluster]\ncluster_enabled = true\nworkers = 3\n",
+        encoding="utf-8",
+    )
+    worker_source = (
+        project_dir / "src/flight_telemetry_worker/flight_telemetry_worker.py"
+    )
+    worker_source.parent.mkdir(parents=True)
+    worker_source.write_text("", encoding="utf-8")
+    missing_share = home_root / "missing-cluster-share"
+    workspace_settings = (
+        home_root / ".agilab/apps/flight_telemetry_project/app_settings.toml"
+    )
+    at = _app_test("src/agilab/main_page.py")
+
+    with patch.dict(
+        os.environ,
+        {
+            "HOME": str(home_root),
+            "AGI_CLUSTER_SHARE": str(missing_share),
+        },
+        clear=False,
+    ):
+        at.run()
+        assert not at.exception
+        assert "env" not in at.session_state
+        assert any(
+            "Cluster mode is enabled for the active project" in str(item.value)
+            for item in at.error
+        )
+        recovery_button = next(
+            button
+            for button in at.button
+            if button.label == "Disable cluster mode and reload"
+        )
+        recovery_button.click().run()
+
+    assert not at.exception
+    payload = tomllib.loads(workspace_settings.read_text(encoding="utf-8"))
+    assert payload["args"] == {"data_in": "flight_telemetry/dataset"}
+    assert payload["cluster"] == {"cluster_enabled": False, "workers": 3}
+    assert tomllib.loads(source_settings.read_text(encoding="utf-8"))["cluster"] == {
+        "cluster_enabled": True,
+        "workers": 3,
+    }
+    assert "env" in at.session_state
+    assert at.session_state["first_run"] is False
+    rendered_markdown = "\n".join(str(item.value) for item in at.markdown)
+    assert "Turn experiments into evidence-backed apps" in rendered_markdown
+    assert not [
+        button
+        for button in at.button
+        if button.label == "Disable cluster mode and reload"
+    ]
+    assert not [
+        item
+        for item in at.error
+        if "Cluster mode is enabled for the active project" in str(item.value)
+    ]
+
+
+def test_agilab_warm_query_cluster_failure_keeps_old_env_until_recovery(
+    mock_ui_env, monkeypatch
+):
+    home_root = mock_ui_env["apps_dir"].parent
+    target_project = mock_ui_env["apps_dir"] / "cluster_target_project"
+    target_source = target_project / "src/app_settings.toml"
+    target_source.parent.mkdir(parents=True)
+    target_source.write_text(
+        '[args]\ndata_in = "cluster_target/dataset"\n\n'
+        "[cluster]\ncluster_enabled = true\nworkers = 2\n",
+        encoding="utf-8",
+    )
+    target_worker = (
+        target_project
+        / "src/cluster_target_worker/cluster_target_worker.py"
+    )
+    target_worker.parent.mkdir(parents=True)
+    target_worker.write_text("", encoding="utf-8")
+    (target_project / "src/cluster_target.py").write_text("", encoding="utf-8")
+
+    missing_share = home_root / "missing-cluster-share"
+    workspace_settings = (
+        home_root / ".agilab/apps/cluster_target_project/app_settings.toml"
+    )
+    remembered_apps: list[Path] = []
+    ui_support = importlib.import_module("agi_gui.ui_support")
+    monkeypatch.setattr(
+        ui_support,
+        "store_last_active_app",
+        lambda path: remembered_apps.append(Path(path).resolve()),
+    )
+    at = _app_test("src/agilab/main_page.py")
+
+    with patch.dict(
+        os.environ,
+        {
+            "HOME": str(home_root),
+            "AGI_CLUSTER_SHARE": str(missing_share),
+        },
+        clear=False,
+    ):
+        at.run()
+        assert not at.exception
+        old_env = at.session_state["env"]
+        old_snapshot = {
+            name: getattr(old_env, name)
+            for name in (
+                "app",
+                "active_app",
+                "apps_path",
+                "_agilab_initialized",
+                "init_done",
+                "_agilab_authorized_app_container_roots",
+            )
+        }
+        remembered_before = list(remembered_apps)
+
+        at.query_params["active_app"] = "cluster_target_project"
+        at.run()
+
+        assert not at.exception
+        assert at.session_state["env"] is old_env
+        assert {
+            name: getattr(old_env, name) for name in old_snapshot
+        } == old_snapshot
+        assert at.session_state["first_run"] is True
+        assert remembered_apps == remembered_before
+        assert workspace_settings.exists() is False
+        assert any(
+            "Cluster mode is enabled for the active project" in str(item.value)
+            for item in at.error
+        )
+        recovery_button = next(
+            button
+            for button in at.button
+            if button.label == "Disable cluster mode and reload"
+        )
+        recovery_button.click().run()
+
+    assert not at.exception
+    assert at.session_state["env"] is not old_env
+    assert at.session_state["env"].app == "cluster_target_project"
+    assert at.session_state["env"]._agilab_initialized is True
+    assert at.session_state["first_run"] is False
+    assert {name: getattr(old_env, name) for name in old_snapshot} == old_snapshot
+    payload = tomllib.loads(workspace_settings.read_text(encoding="utf-8"))
+    assert payload["args"] == {"data_in": "cluster_target/dataset"}
+    assert payload["cluster"] == {"cluster_enabled": False, "workers": 2}
+    assert tomllib.loads(target_source.read_text(encoding="utf-8"))["cluster"] == {
+        "cluster_enabled": True,
+        "workers": 2,
+    }
+    assert remembered_apps[-1] == target_project.resolve()
+
+
 def test_agilab_main_page_refuses_unprotected_public_bind(mock_ui_env):
     home_root = mock_ui_env["apps_dir"].parent
     at = _app_test("src/agilab/main_page.py")


### PR DESCRIPTION
## Summary

- resolve the requested app before constructing its runtime environment, then offer an in-page local recovery when persisted cluster mode points at an unavailable share
- copy settings into the user workspace and disable only `cluster.cluster_enabled` in one locked transaction, while preserving source files and rejecting symlink escapes
- make query-driven app switches cold and atomic so a failed target bootstrap cannot corrupt the healthy session environment or remembered active app
- add polluted-environment, trust-boundary, atomicity, cold-start, warm-switch, and real-rerun regressions

## Repro

1. Enable cluster mode in an active project settings file.
2. Configure `AGI_CLUSTER_SHARE` to a missing or unwritable path.
3. Launch AGILAB.
4. Startup stops before a usable environment exists and tells the operator to mount the share or manually change stale settings.

## Root Cause

The ABOUT bootstrap constructed `AgiEnv` before resolving and retaining a safely authorized requested app. The error path could therefore describe the failure but could not safely repair the selected project settings. Query-driven warm app changes also reinitialized the existing environment in place, allowing a failed target bootstrap to leave partial state behind.

## Regression Test

- polluted-HOME tests cover missing shares, settings preservation, source immutability, source disappearance, source-less apps, serialization failure, and symlink escapes
- trust-boundary tests reject nested and out-of-root query/CLI targets while preserving the confined built-in same-name fallback
- real Streamlit AppTests cover first-load recovery and a warm query switch that preserves the old environment and last-active store until the successful recovery rerun
- a live Chromium journey clicks **Disable cluster mode and reload**, reaches the normal ABOUT page, and reports no console, page, request, or HTTP errors

## Validation

- current rebased HEAD: 202 helper/core tests passed; the two cold/warm AppTests passed; live Chromium recovery passed with zero browser issues
- full feature validation before the clean rebase: 90 UI-page tests passed; `agi-gui` workflow parity passed with 3,775 passed and 4 skipped
- Ruff passed on all changed files with the existing `E402` exception; the unscoped check still reports the pre-existing intentional import placement at `src/agilab/main_page.py:88`
- `./dev scope`, impact validation, provenance guard, and diff checks passed
- GitHub required checks passed: root tests, Windows core, Python 3.12/3.14 compatibility, clean installs on Ubuntu/macOS/Windows, policy guard, and GitGuardian; public demo smoke was skipped by workflow policy

## Review Evidence

- `strong_review` / Russell — GPT-5 Codex inherited runtime, read-only final review, no file edits; result: CLEAN with no merge blockers
- `final_integration_review` / Ampere — GPT-5 Codex inherited runtime, read-only integration review, no file edits; initial findings were addressed and the final code had no blocker

## Agent Metadata

- Tokki version: 1.0.35
- Agent/runtime: Codex; runtime version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
