### PR TITLE
fix(ui): tolerate concurrent page import renders

### DIFF
--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -83,6 +83,14 @@ except ModuleNotFoundError:
 
 logger = AgiLogger.get_logger(__name__)
 
+# A page runner may import a sizeable app bundle and render its initial UI while
+# temporarily owning process-global import state.  Five seconds is sufficient
+# for small pages but is too short for normal first renders of app-backed
+# project pages, causing a concurrent Streamlit rerun to surface a traceback.
+# Keep the guard bounded so a real deadlock remains diagnosable, while allowing
+# a normal interactive render to finish.
+_INTERACTIVE_PAGE_IMPORT_LEASE_TIMEOUT_SECONDS = 30.0
+
 apply_streamlit_theme_environment(packaged_streamlit_config_path(__file__))
 
 import streamlit as st
@@ -1475,7 +1483,9 @@ def _page_file_runner(page_file: Path) -> Callable[[], None]:
         _record_ui_timing_span(
             f"{page_label}:bootstrap", bootstrap_started_at, category="bootstrap"
         )
-        with isolated_import_process_state():
+        with isolated_import_process_state(
+            timeout=_INTERACTIVE_PAGE_IMPORT_LEASE_TIMEOUT_SECONDS
+        ):
             import_started_at = time.perf_counter()
             module = _load_page_module(resolved_page)
             _record_ui_timing_span(

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1432,6 +1432,46 @@ def test_page_file_runner_serializes_and_restores_main_process_state(
     assert sys.path == original_path
 
 
+def test_page_file_runner_allows_a_normal_interactive_import_wait(
+    tmp_path, monkeypatch
+):
+    """Interactive page reruns receive a practical bounded import wait."""
+
+    from contextlib import contextmanager
+
+    main_page = _import_agilab_module("agilab.main_page")
+    main_page._PAGE_RUNNER_CACHE.clear()
+    main_page._RESOLVED_PAGE_PATH_CACHE.clear()
+    monkeypatch.setattr(
+        main_page, "_about_resources_path", lambda: tmp_path / "resources"
+    )
+    monkeypatch.setattr(
+        main_page, "_ensure_navigation_environment", lambda *_args, **_kwargs: object()
+    )
+    monkeypatch.setattr(main_page, "_record_ui_timing_span", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main_page, "_render_page_load_timing", lambda *_args, **_kwargs: None)
+
+    received_timeouts: list[float] = []
+
+    @contextmanager
+    def _capture_import_scope(*, timeout: float, **_kwargs):
+        received_timeouts.append(timeout)
+        yield
+
+    page_file = tmp_path / "page.py"
+    page_file.write_text("def main():\n    pass\n", encoding="utf-8")
+    module = SimpleNamespace(main=lambda: None)
+    monkeypatch.setattr(main_page, "isolated_import_process_state", _capture_import_scope)
+    monkeypatch.setattr(main_page, "_load_page_module", lambda _path: module)
+
+    main_page._page_file_runner(page_file)()
+
+    assert received_timeouts == [
+        main_page._INTERACTIVE_PAGE_IMPORT_LEASE_TIMEOUT_SECONDS
+    ]
+    assert received_timeouts[0] > 5.0
+
+
 def test_all_page_caches_disable_does_not_store_runner_or_module_name(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Extend the main interactive page runner import-state lease from 5 to 30 seconds so a normal slow first render does not fail a concurrent Streamlit rerun.

## Repro

Open another AGILAB page while a project-backed page is still rendering. The second request could time out after five seconds with `SidecarRegistryBusyError`.

## Root Cause

The page runner correctly serializes temporary process-global import state, but used the generic five-second bound while it held that state through an entire page render.

## Change

Use a documented 30-second bounded wait for interactive page runs; preserve global serialization and eventual bounded failure for a true deadlock.

## Regression Test

Added a page-runner test that verifies the explicit interactive import lease is longer than the generic five-second default.

## Validation

- `pytest test/test_ui_pages.py -k page_file_runner` — 4 passed
- `pytest -q -o addopts='' test/test_ui_pages.py` — passed
- `workflow_parity.py --profile agi-gui` — passed

## Agent Metadata

- Tokki: 1.0.38
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used

## Review Evidence

- No sub-agent or separate model review was used.
- Focused regression and UI/runtime parity validation passed.