### PR TITLE
fix(ui): report a busy inline render lease as recoverable startup

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -21,7 +21,10 @@ from agi_env.project.app_provider_registry import (
 )
 from agi_env.runtime.process_support import fix_windows_drive
 from agi_env.runtime.repository_support import get_apps_repository_root
-from agi_env.ui.sidecar_registry import hosted_inline_render_guard
+from agi_env.ui.sidecar_registry import (
+    SidecarRegistryBusyError,
+    hosted_inline_render_guard,
+)
 
 try:  # pragma: no cover - optional import fallback is exercised through behavior tests
     import tomli_w as _tomli_writer
@@ -1255,7 +1258,21 @@ def bootstrap_page_environment(
 ) -> BootstrapResult:
     """Create and persist the AGILAB environment for a cold Streamlit session."""
     ports = ports or default_bootstrap_ports()
-    args = parse_startup_args(argv)
+    # Reading startup arguments waits on the process-global inline render
+    # lease, which a peer page render holds for the whole of that render.  The
+    # wait is bounded, so a cold session starting behind a busy peer can
+    # legitimately fail to acquire it.  That is a transient condition, not a
+    # broken installation, so report it as a recoverable startup state instead
+    # of letting it escape as a traceback.
+    try:
+        args = parse_startup_args(argv)
+    except SidecarRegistryBusyError:
+        stop_startup_with_error(
+            streamlit,
+            "Another AGILAB view is still initializing. Reload this page to "
+            "finish starting up.",
+        )
+        return BootstrapResult(env=None, handled_recovery=True)
     try:
         apps_path = resolve_apps_path(
             args,

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -1170,6 +1170,55 @@ def test_bootstrap_resolve_apps_path_prefers_cli_then_env(tmp_path):
     )
 
 
+def test_bootstrap_reports_a_busy_peer_render_as_recoverable_startup(monkeypatch):
+    """A busy inline render lease stops startup cleanly instead of raising.
+
+    ``parse_startup_args`` waits on the process-global inline render lease, and
+    a peer page render holds that lease for the whole of its render -- an
+    unbounded hold that no acquisition timeout can outlast.  Cold startup must
+    therefore treat a busy lease as a recoverable state, the way every other
+    cold-start failure in ``bootstrap_page_environment`` already is.
+    """
+
+    bootstrap = about_agilab._about_bootstrap
+    fake_st = _FakeStreamlit()
+    resolve_calls: list[object] = []
+
+    def _busy(_argv=None):
+        raise sidecar_registry_module.SidecarRegistryBusyError(
+            "Timed out waiting for hosted inline render lease; "
+            "another AGILAB session is still using it"
+        )
+
+    monkeypatch.setattr(bootstrap, "parse_startup_args", _busy)
+    monkeypatch.setattr(
+        bootstrap,
+        "resolve_apps_path",
+        lambda *_args, **_kwargs: resolve_calls.append(_args),
+    )
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=Path("/nonexistent/.env"),
+        load_env_file_map=lambda *_args, **_kwargs: {},
+        logger=object(),
+        apply_active_app_request=lambda *_args, **_kwargs: None,
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+    )
+
+    assert result.env is None
+    assert result.handled_recovery is True
+    assert fake_st.stopped is True
+    assert resolve_calls == []
+    errors = [payload for kind, payload in fake_st.events if kind == "error"]
+    assert len(errors) == 1
+    assert "still initializing" in errors[0]
+    assert "Traceback" not in errors[0]
+
+
 def test_parse_startup_args_times_out_behind_peer_hosted_render(monkeypatch):
     bootstrap = about_agilab._about_bootstrap
     outcomes: list[BaseException | object] = []


### PR DESCRIPTION
## Problem

Commit 2e02266 gave an interactive page render a 30s budget on the process-global
inline render lease. That timeout bounds **acquisition**, not **holding** —
`_page_file_runner` holds the lease across `_load_page_module()` *and* the whole
`main_fn()` render (`main_page.py:1486-1503`), so a holder can occupy it for minutes.

Cold startup reads `sys.argv` under that same lease (`parse_startup_args`, needed
because `isolated_import_process_state` temporarily swaps `sys.argv`). A session
starting behind a peer render therefore raised `SidecarRegistryBusyError` as a raw
traceback — and it sat one line above a `try:` whose `except` tuple already contains
`RuntimeError`, which `SidecarRegistryBusyError` inherits. Every *other* cold-start
failure in `bootstrap_page_environment` is converted into `stop_startup_with_error`;
this was the only one that escaped.

## Why not just raise the timeout

That was the first thing I tried, and it is wrong. No acquisition bound can outlast
an unbounded hold, so a bigger number only trades a fast bounded failure for a long
**uninterruptible** wait inside `st.spinner("Initializing environment...")` that ends
in the identical traceback. The lease is held across a render that can legitimately
include a `uv sync` (`_ANALYSIS_PREPARATION_PROCESS_TIMEOUT_SECONDS = 300.0`).

## Fix

Catch the busy lease at the startup call site and report it as a transient state,
mirroring how `HostedAnalysisBusyError` is already handled on the ANALYSIS page.

## Test

`test_bootstrap_reports_a_busy_peer_render_as_recoverable_startup` asserts the
session stops cleanly, shows one actionable error, and never reaches
`resolve_apps_path`. It fails on `main` (raw `SidecarRegistryBusyError`) and needs
no sleeps.

`test/test_about_agilab_helpers.py test/test_ui_pages.py` → **272 passed**.

## Follow-ups (not in this PR)

- `sidecar_registry.py:233` `lock_timeout = max(timeout, 5.0)` gives a waiter exactly
  the budget the holder may consume.
- The real durable fix is to bound the **hold** (release the lease before the render
  body, or snapshot `sys.argv` at process start so startup needs no lease at all).
- `SidecarRegistryBusyError` is silently absorbed by broad `RuntimeError` tuples at
  `2_ORCHESTRATE.py:2256/2294` and has no handler at `4_ANALYSIS.py:3813/3821`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)