### PR TITLE
fix(analysis): recover notebook sidecars from stale Python ABIs

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 7920028debd1a4f37e405380d5c448f218762b0f28345234d8d2df950d9d344e
+source_sha256: 36792f9db9cb26858aebdd794ac7bae096c2c7d26ae6ba98c05c63e428bb4763
 title: ANALYSIS page session environment and sidecar ownership contract
-verified_commit: c14c94d2a0adba4b3effe2890b25e07b4b6b469f
+verified_commit: 844b0c05447aacdd999592aaa1f43d1e3373f8ed
 ---
 
 # ANALYSIS page session environment and sidecar ownership contract
@@ -58,3 +58,10 @@ the isolated PyTorch Playground ANALYSIS browser scenario passed.
 2026-07-28 re-verification: user-facing empty-evidence guidance now names the
 current ORCHESTRATE `RUN` action; session environment and sidecar ownership
 behavior is unchanged.
+
+2026-07-29 re-verification: project notebook sidecars now pass the configured
+AGILAB Python selector explicitly to `uv run`, so an ignored project `.venv`
+with a stale free-threaded ABI is replaced instead of silently reused. Analysis
+view sidecars retain their per-project interpreter selection. The polluted-venv
+regression, focused ANALYSIS/UI tests, AGI GUI parity profile, and an isolated
+browser launch of `lab_stages.ipynb` passed.

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -937,6 +937,11 @@ def _local_uv_command(
     ], process_env
 
 
+def _notebook_python_uv_spec(env: Any) -> str:
+    """Select AGILAB's configured runtime for project notebook environments."""
+    return str(getattr(env, "python_uv_spec", "") or sys.executable)
+
+
 def _format_bg_command(cmd: BgCommand) -> str:
     if isinstance(cmd, str):
         return cmd
@@ -3627,7 +3632,9 @@ def _ensure_notebook_sidecar(
     project_home = str(project_root.resolve())
     sidecar_token = token or _notebook_sidecar_token(notebook_key)
     tornado_settings = _notebook_iframe_tornado_settings_arg()
+    notebook_python = _notebook_python_uv_spec(env)
     attempts.append(f"Trying JupyterLab sidecar rooted at: {project_home}")
+    attempts.append(f"Using notebook Python selector: {notebook_python}")
 
     def _launch_notebook(allocated_port: int, registered_token: str):
         run_cmd = [
@@ -3635,6 +3642,8 @@ def _ensure_notebook_sidecar(
             "--preview-features",
             "extra-build-dependencies",
             "run",
+            "--python",
+            notebook_python,
             "--project",
             project_home,
             "--with",

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1286,6 +1286,12 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     notebook_path = project_root / "notebooks" / "lab_stages.ipynb"
     notebook_path.parent.mkdir(parents=True)
     notebook_path.write_text("{}", encoding="utf-8")
+    polluted_venv = project_root / ".venv"
+    polluted_venv.mkdir()
+    (polluted_venv / "pyvenv.cfg").write_text(
+        "home = /uv/python/cpython-3.14+freethreaded/bin\nversion_info = 3.14\n",
+        encoding="utf-8",
+    )
     commands: list[tuple[object, str, dict[str, str] | None]] = []
 
     class _FakeProcess:
@@ -1304,6 +1310,7 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     fake_env = SimpleNamespace(
         envars={"127.0.0.1_CMD_PREFIX": 'export PATH="$HOME/.local/bin:$PATH";'},
         uv="uv --quiet",
+        python_uv_spec="3.14.6+gil",
         AGILAB_LOG_ABS=tmp_path,
         logger=fake_logger,
     )
@@ -1329,6 +1336,7 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "DEFAULT_SIDECAR_REGISTRY", FakeRegistry())
     monkeypatch.setattr(module, "_notebook_sidecar_token", lambda _key: "sidecar-token")
+    monkeypatch.setenv("UV_PYTHON", "3.14t")
 
     def _fake_exec_bg(_env, cmd, cwd: str, process_env=None):
         commands.append((cmd, cwd, process_env))
@@ -1346,6 +1354,7 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     assert "export" not in command
     assert process_env is not None
     assert process_env["PATH"].startswith(f"{Path.home()}/.local/bin:")
+    assert command[command.index("--python") + 1] == "3.14.6+gil"
     assert command[command.index("--project") + 1] == str(project_root.resolve())
     assert f"--ServerApp.root_dir={project_root.resolve()}" in command
     assert "jupyter" in command
@@ -1367,6 +1376,14 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     assert registry_calls[0]["key"] == str(project_root.resolve())
     assert all("sidecar-token" not in message for message in log_messages)
     assert any("<redacted>" in message for message in log_messages)
+
+
+def test_notebook_python_uv_spec_falls_back_to_running_interpreter(monkeypatch):
+    module = _load_analysis_module()
+    controller_python = "/controller-venv/bin/python"
+    monkeypatch.setattr(module, "sys", SimpleNamespace(executable=controller_python))
+
+    assert module._notebook_python_uv_spec(SimpleNamespace()) == controller_python
 
 
 def test_exec_bg_clears_parent_python_environment(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- pin project notebook sidecars to AGILAB's configured Python selector
- fall back to the controller interpreter when no selector is configured
- surface the selected runtime in sidecar startup diagnostics
- refresh the path-scoped ANALYSIS maintenance invariant

## Repro

Opening the Flight Telemetry notebook from ANALYSIS reused the ignored project `.venv`, which had been created with CPython 3.14 free-threaded. The sidecar then attempted to build `polars-runtime-32` from source and exited before binding its port, producing “The notebook sidecar did not start correctly.”

## Root Cause

The notebook launch used `uv run --project ...` without `--python`. That let a stale project-local ABI environment override AGILAB's canonical `python_uv_spec=3.14.6+gil`.

The fix is intentionally notebook-specific. The shared ANALYSIS uv helper also launches apps-page sidecars with their own Python constraints (including a `<3.13` page), so globally forcing the manager selector would be a regression.

## Regression Test

The focused launch test now creates a polluted 3.14t `pyvenv.cfg`, sets an ambient `UV_PYTHON=3.14t`, and proves the notebook command still passes the configured `3.14.6+gil` selector explicitly. A separate test covers the `sys.executable` fallback.

## Validation

- 185 focused ANALYSIS/UI tests passed
- local `agi-gui` workflow parity profile passed
- maintenance-memory check passed
- isolated real-runtime proof replaced a 3.14t project venv with CPython 3.14.6 GIL, imported Polars 1.43.1, started JupyterLab, loaded `lab_stages.ipynb` in the iframe, and started its kernel
- direct Playwright inspection confirmed the sidecar error text is absent and the Jupyter iframe is live
- scoped Ruff check and diff checks passed

The generic widget robot watchdog timed out while walking notebook/expander content; direct Playwright browser and network inspection was used for the browser-only proof. Full-file Ruff/format was not used as a gate because `4_ANALYSIS.py` already has unrelated pre-existing findings outside this diff.

## Review Evidence

A read-only Codex sub-agent reviewed the live logs, sidecar registry, interpreter selection, and sibling sidecar blast radius. It caught and prevented an over-broad first approach that would have forced the manager Python onto incompatible apps-page projects. The reviewer did not edit files; all findings were addressed.

## Agent Metadata

- Tokki: 1.0.39
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used
