### PR TITLE
docs(agi-core): sync the meta-package rewrite into the public mirror

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "5e41d32e28f68119894f52b92a00175c017e59b4baa333da7cbdff0feefd0edd",
+  "source_digest_sha256": "57d79139be5f7e2ecba192943188e6c07e9484b1e513e21655019e1fa58a3b97",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "5e41d32e28f68119894f52b92a00175c017e59b4baa333da7cbdff0feefd0edd"
+  "target_digest_sha256": "57d79139be5f7e2ecba192943188e6c07e9484b1e513e21655019e1fa58a3b97"
 }

--- a/docs/source/agi-core-architecture.rst
+++ b/docs/source/agi-core-architecture.rst
@@ -1,13 +1,13 @@
 AGI Core Architecture
 =====================
 
-``agi_core`` is the shared framework-helper layer used by AGILAB pages, CLI
-mirrors, telemetry, and app-loading code. It is not the worker runtime and it
-does not own environment resolution or distributed execution. Those
-responsibilities live in ``agi_env``, ``agi_node``, and ``agi_cluster``.
+``agi-core`` is the meta-package that installs and wires ``agi-env``,
+``agi-node``, and ``agi-cluster`` together. It carries no framework logic of its
+own: environment resolution lives in ``agi_env``, the worker runtime in
+``agi_node``, and distributed execution in ``agi_cluster``.
 
-Use this page when you need to decide whether a change belongs in shared
-page/app helpers or should stay inside an app, page, or worker package.
+Use this page when you need to decide which of those three packages a change
+belongs in, or whether it should stay inside an app, page, or worker package.
 
 .. contents::
    :local:
@@ -17,36 +17,40 @@ Modules at a glance
 -------------------
 
 .. figure:: diagrams/agi-core-overview.svg
-   :alt: Visual summary of agi_core modules
+   :alt: Visual summary of the AGILAB runtime packages
    :class: diagram-panel diagram-standard
 
-   Web interface and CLI entry points call into ``agi_core`` helpers before
-   handing environment resolution to ``agi_env`` and execution to
-   ``agi_cluster``.
+   Web interface and CLI entry points resolve the environment through
+   ``agi_env`` and hand execution to ``agi_cluster``; ``agi-core`` is the
+   distribution that installs those packages together.
 
-``src/agilab/core/agi-core`` ships the following higher-level domains:
+``src/agilab/core/agi-core`` declares the three runtime packages as pinned
+dependencies and exposes no public API of its own. Installing ``agi-core``
+installs the set; importing ``agi_core`` gives you nothing to call:
 
-``agi_core.apps``
-    Helper mixins for app metadata, dataset manifests, and path helpers that
-    app managers can import from their project root. If you add a new manager or
-    need an app to opt in to common validation, start here.
-``agi_core.streamlit``
-    Shared web interface widgets (status panels, history view, deploy dialogs) used
-    by PROJECT/ORCHESTRATE/WORKFLOW/ANALYSIS. Keeping them here avoids circular imports from the
-    page packages.
-``agi_core.telemetry``
-    Structured logging, run-history helpers, and wrappers used by ``AGI.run`` to
-    emit consistent events back to the web interface and the CLI mirrors.
-``agi_core.services``
-    Small utility services (encryption, local cache, dataset registry) designed
-    to be reused by both the GUI and the app installers.
+.. code-block:: python
+
+   >>> import agi_core
+   >>> agi_core.__all__
+   ()
+
+The distribution contains a single module, ``agi_core.agi_env_runtime``, which
+holds the ``RUNTIME_PACKAGE_SPEC`` metadata dictionary that ``agi-env`` reads to
+order package resolution. It is framework plumbing, not an entry point.
+
+.. note::
+
+   Earlier revisions of this page described ``agi_core.apps``,
+   ``agi_core.streamlit``, ``agi_core.telemetry``, and ``agi_core.services``.
+   Those subpackages were never released. Import the shared helpers from
+   ``agi_env``, ``agi_node``, or ``agi_cluster`` instead.
 
 What belongs here
 -----------------
 
-Put code in ``agi_core`` only when it is shared by multiple pages, CLI mirrors,
-or app managers and does not require worker-runtime imports. Keep these outside
-``agi_core``:
+Nothing new belongs in ``agi_core``: it is a dependency aggregator, and adding a
+module there would give it a public surface it is not meant to have. Route
+shared code to the package that owns the responsibility:
 
 - active-project path and environment resolution: use ``agi_env``
 - worker base classes, package bootstrap, and worker install hooks: use
@@ -59,43 +63,42 @@ Execution flow
 --------------
 
 .. figure:: Agilab-Overview.svg
-   :alt: High-level flow linking the web interface to agi-core
+   :alt: High-level flow from the web interface to the runtime packages
    :class: diagram-panel diagram-hero
 
-   Web interface pages talk to ``agi_core`` services before dispatching work to
-   ``agi_env``/``agi_cluster``.
+   Web interface pages resolve an ``AgiEnv`` and dispatch work through the
+   public ``AGI`` facade in ``agi_cluster``.
 
 .. figure:: diagrams/packages_agi_env.svg
-   :alt: Package-level view highlighting agi_core dependencies
+   :alt: Package-level view of the runtime package dependencies
    :class: diagram-panel diagram-wide
 
-   Generated from ``pyreverse`` to show how ``agi_core`` orchestrates calls to
+   Generated from ``pyreverse`` to show how the page and CLI layers depend on
    ``agi_env`` helpers and dispatcher facades.
 
 Typical call stack when a user clicks **RUN** on the ORCHESTRATE page:
 
 1. ``src/agilab/pages/2_ORCHESTRATE.py`` collects form values and calls
    shared app/page helpers.
-2. ``agi_core`` builds app metadata, page state, telemetry context, or
-   ``WorkDispatcher`` inputs without importing worker-only dependencies.
+2. The page builds app metadata, page state, and ``WorkDispatcher`` inputs
+   from helpers it owns, without importing worker-only dependencies.
 3. The page resolves an ``AgiEnv`` and calls the public ``AGI`` facade.
 4. ``AGI.run`` hands execution to ``agi_cluster.agi_distributor`` and the
    worker package built by ``agi_node``.
-5. Results propagate back through ``agi_core`` helpers such as history,
-   downloads, telemetry, and status widgets before the UI renders the finished
-   run.
+5. Results propagate back to the page, which renders history, downloads, and
+   status from the run manifest.
 
 Repository pointers
 -------------------
 
-=============  =============================================================
-Directory      Purpose
-=============  =============================================================
-``apps``       Metadata helpers shared by ``src/agilab/apps`` managers.
-``streamlit``  Widgets, layout templates, and modal logic for ORCHESTRATE/ANALYSIS.
-``telemetry``  Structured logging, status persistence, and run history APIs.
-``services``   Standalone service objects (encryption, caching, dataset registry).
-=============  =============================================================
+===============  ===========================================================
+Package          Purpose
+===============  ===========================================================
+``agi-env``      Paths, configs, logging, credentials, and share roots.
+``agi-node``     Worker base classes, package bootstrap, and install hooks.
+``agi-cluster``  Run dispatch, Dask, SSH, service lifecycle, and ``AGI.run``.
+``agi-core``     Meta-package: installs the three above at a pinned version.
+===============  ===========================================================
 
 Tips for contributions
 ----------------------
@@ -103,17 +106,19 @@ Tips for contributions
 - Keep business logic for a specific app inside its app project root: source
   built-ins use ``src/agilab/apps/builtin/<project>``, packaged payloads use
   ``src/agilab/lib/agi-app-*``, and external apps stay in their app repository.
-  Only move code into ``agi_core`` when *multiple* apps/pages need the
+  Only move code into a runtime package when *multiple* apps/pages need the
   abstraction.
-- When adding a new web widget, place it under ``agi_core/streamlit`` and
-  export it through a small ``__all__``. That keeps import graphs manageable.
-- ``agi_core`` has no hard dependency on ``agi_env`` or ``agi_cluster``. If your
-  change requires environment or dispatcher behaviour, extract a thin interface
-  and inject the dependency so unit tests stay fast.
+- Web widgets shared across pages belong to the page bundle that owns them, or
+  to ``agi_env.ui`` when the whole UI layer needs them. There is no
+  ``agi_core`` widget namespace.
+- ``agi-core`` pins ``agi-env``, ``agi-node``, and ``agi-cluster`` with ``==``
+  constraints, so the four versions move together. A change that needs a new
+  runtime capability must ship in the package that owns it, and the pins must
+  be bumped in the same release.
 
 See also
 --------
 
 - :doc:`framework-api` for the high-level ``AGI.*`` orchestration entry points.
-- :doc:`agilab` for the user-facing web pages built on top of ``agi_core``.
-- :doc:`architecture` for the full-stack overview (pages → agi_core → agi_env/cluster).
+- :doc:`agilab` for the user-facing web pages built on the runtime packages.
+- :doc:`architecture` for the full-stack overview (pages → agi_env → agi_cluster).

--- a/docs/source/diagrams/agi-core-overview.svg
+++ b/docs/source/diagrams/agi-core-overview.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1240" height="640" viewBox="0 0 1240 640" role="img" aria-labelledby="title desc">
   <title id="title">AGI core orchestration</title>
-  <desc id="desc">Diagram showing web and CLI entrypoints feeding agi_core, then agi_env, agi_cluster, agi_node workers, and artifacts with a clear orchestration flow.</desc>
+  <desc id="desc">Diagram showing web and CLI entrypoints running in an agi-core install, then agi_env, agi_cluster, agi_node workers, and artifacts with a clear orchestration flow.</desc>
   <defs>
     <style>
       text {
@@ -81,7 +81,7 @@
 
   <g transform="translate(62,48)">
     <text class="title" x="0" y="0">AGI core orchestration</text>
-    <text class="subtitle" x="0" y="30">How entry points feed agi_core, then environment resolution, cluster dispatch, worker execution, and artifacts.</text>
+    <text class="subtitle" x="0" y="30">How entry points reach environment resolution, cluster dispatch, worker execution, and artifacts.</text>
   </g>
 
   <g transform="translate(60,120)">
@@ -111,12 +111,12 @@
 
   <g transform="translate(484,170)">
     <rect class="card" width="308" height="154" fill="#e3dcff" />
-    <text class="card-title" x="154" y="38" text-anchor="middle">agi_core</text>
-    <text class="card-body" x="24" y="72">Resolve app and args; build run plans</text>
-    <text class="card-body" x="24" y="96">Drive lab_stages and telemetry</text>
+    <text class="card-title" x="154" y="38" text-anchor="middle">agi-core</text>
+    <text class="card-body" x="24" y="72">Meta-package; no public API</text>
+    <text class="card-body" x="24" y="96">Pins the three runtime packages</text>
     <text class="card-note" x="24" y="128">
-      <tspan x="24" dy="0">Reusable widgets, services, history,</tspan>
-      <tspan x="24" dy="18">and orchestration helpers</tspan>
+      <tspan x="24" dy="0">Installs agi-env, agi-node and</tspan>
+      <tspan x="24" dy="18">agi-cluster at one version</tspan>
     </text>
   </g>
 
@@ -164,8 +164,8 @@
     <rect class="callout" width="520" height="66" fill="#ffffff" />
     <text class="callout-title" x="20" y="33">Reading guide</text>
     <text class="callout-body" x="136" y="30">
-      <tspan x="136" dy="0">Inputs converge into agi_core, then flow through</tspan>
-      <tspan x="136" dy="18">environment setup to cluster and worker execution.</tspan>
+      <tspan x="136" dy="0">Entry points run in an agi-core install, then flow</tspan>
+      <tspan x="136" dy="18">through environment setup to cluster and workers.</tspan>
     </text>
   </g>
 


### PR DESCRIPTION
Public mirror of the canonical change. This is the PR that changes the published page.

## Problem

`docs/source/agi-core-architecture.rst` — the advertised architecture page for the
released `agi-core` PyPI package — documented four subpackages in the present tense:
`agi_core.apps`, `agi_core.streamlit`, `agi_core.telemetry`, `agi_core.services`. It gave
each a purpose, listed them again in a "Repository pointers" directory table, and told
contributors to place new widgets under `agi_core/streamlit`.

**None of them has ever existed in any commit.** What ships:

```python
>>> import agi_core
>>> agi_core.__all__
()
```

One module, `agi_env_runtime.py`, holding a `RUNTIME_PACKAGE_SPEC` metadata dict.
`pyproject.toml:4` calls it a *"Meta-package that installs and wires agi-env, agi-node,
and agi-cluster together"*; `:32` pins all three with `==`. The page also asserted
`agi_core` "has no hard dependency on `agi_env` or `agi_cluster`" — contradicted by
those pins.

## Fix

Rewritten against the shipped package. The routing guidance ("what belongs where") was
the page's real value and is kept, corrected to name the package that owns each
responsibility. A note records the removed subpackages so a reader who followed the old
page can find where the helpers actually live.

The overview diagram carried the same claim in four places — card body, subtitle,
reading guide, and `<desc>` accessibility text. Two were invisible to grep and only
showed up in the rendered preview. All four corrected; every replacement line is shorter
than the one it replaces, so the layout is unchanged.

## Mirror mechanics

Synced with `tools/sync_docs_source.py`; the stamp is regenerated by that run.
`--delete` dry run now reports `create: 0  update: 0  delete: 0` — the trees are fully
aligned for the first time in this session. Clearing the release-proof drift that was
blocking it needed a separate canonical change (jpmorard/thales_agilab#203).

## Validation

- `tools/sync_docs_source.py --delete`: 0/0/0 · `--verify-stamp`: ok
- `tools/release_proof_report.py`: **12/12 pass**
- `tools/docs_diagram_wording_check.py`: rc=0 · SVG parses as valid XML
- 129 docs tests pass
- `tools/workflow_parity.py --profile docs`: **PASS**, Sphinx build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)