### PR TITLE
fix(cache): allow apps to replace inferred distribution inputs

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -158,9 +158,13 @@ class BaseWorker(ArtifactContract, abc.ABC):
         fields such as ``data_in`` and ``submission_inbox``. Applications whose
         planner reads other filesystem locations can expose those roots here
         without changing the stable ``build_distribution(workers)`` signature.
+        Set ``distribution_cache_inputs_mode`` to ``"replace"`` when these
+        declared paths are the complete planner input set.
         """
 
         return ()
+
+    distribution_cache_inputs_mode: ClassVar[str] = "augment"
 
     def _actual_work_pool(self, x: Any = None) -> Any:
         """Process one work item; dataframe families must override this."""

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/distribution_cache_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/distribution_cache_support.py
@@ -88,9 +88,21 @@ def _discover_input_paths(target_inst: Any) -> list[Path]:
             if isinstance(field_value, Mapping):
                 _visit(field_value)
 
-    _visit(_args_payload(getattr(target_inst, "args", None)))
-
     declared_inputs = getattr(target_inst, "distribution_cache_inputs", None)
+    input_mode = getattr(target_inst, "distribution_cache_inputs_mode", "augment")
+    if input_mode not in {"augment", "replace"}:
+        raise ValueError(
+            "distribution_cache_inputs_mode must be 'augment' or 'replace', "
+            f"got {input_mode!r}"
+        )
+    if input_mode == "augment":
+        _visit(_args_payload(getattr(target_inst, "args", None)))
+    elif declared_inputs is None:
+        raise TypeError(
+            "distribution_cache_inputs must be defined when "
+            "distribution_cache_inputs_mode is 'replace'"
+        )
+
     if declared_inputs is not None:
         if not callable(declared_inputs):
             raise TypeError("distribution_cache_inputs must be callable when defined")

--- a/src/agilab/core/test/test_work_dispatcher.py
+++ b/src/agilab/core/test/test_work_dispatcher.py
@@ -15,6 +15,7 @@ from agi_node.agi_dispatcher import WorkDispatcher
 from agi_node.agi_dispatcher.agi_dispatcher import RUN_STAGES_KEY
 from agi_node.agi_dispatcher.distribution_cache_support import (
     DISTRIBUTION_CACHE_SCHEMA,
+    build_cache_context,
 )
 
 
@@ -43,6 +44,45 @@ def test_dispatcher_init_sets_instance_args_without_class_state():
     assert first.args == payload
     assert second.args == {"x": 2}
     assert "args" not in WorkDispatcher.__dict__
+
+
+def test_distribution_cache_declared_inputs_augment_inferred_paths(tmp_path):
+    data_in = tmp_path / "data"
+    planner_state = tmp_path / "planner.state"
+    data_in.mkdir()
+    planner_state.write_text("state", encoding="utf-8")
+    target = SimpleNamespace(
+        args=SimpleNamespace(data_in=data_in),
+        distribution_cache_inputs=lambda: [planner_state],
+        build_distribution=lambda _workers: None,
+    )
+
+    context = build_cache_context(target, capacities=None)
+
+    assert context["inputs"]["roots"] == sorted(
+        [data_in.resolve().as_posix(), planner_state.resolve().as_posix()]
+    )
+
+
+def test_distribution_cache_declared_inputs_can_replace_inferred_paths(tmp_path):
+    broad_data_in = tmp_path / "workflow"
+    planner_input = broad_data_in / "upstream"
+    unrelated_output = broad_data_in / "downstream" / "huge.json"
+    planner_input.mkdir(parents=True)
+    unrelated_output.parent.mkdir(parents=True)
+    (planner_input / "input.csv").write_text("value\n1\n", encoding="utf-8")
+    unrelated_output.write_text("must not be fingerprinted", encoding="utf-8")
+    target = SimpleNamespace(
+        args=SimpleNamespace(data_in=broad_data_in),
+        distribution_cache_inputs_mode="replace",
+        distribution_cache_inputs=lambda: [planner_input],
+        build_distribution=lambda _workers: None,
+    )
+
+    context = build_cache_context(target, capacities=None)
+
+    assert context["inputs"]["roots"] == [planner_input.resolve().as_posix()]
+    assert unrelated_output.as_posix() not in json.dumps(context)
 
 
 def test_dispatcher_run_stage_contract_rejects_legacy_and_invalid_payloads():


### PR DESCRIPTION
## Summary
- add an explicit replace mode for application-declared distribution cache inputs
- retain the existing augment behavior as the default
- validate invalid or incomplete cache-input declarations

## Repro
LinkSim declares the trajectory directories used by its planner, but the shared cache layer also inferred the broad workflow root from `data_in="."`. Fingerprinting that root included large downstream artifacts such as topology evidence and delayed LinkSim startup before any outputs appeared.

## Root Cause
Application-declared cache inputs could only augment automatically inferred path arguments. There was no contract for an app to state that its declared inputs are the complete planner dependency set.

## Regression Test
The dispatcher tests now verify both default augmentation and explicit replacement, including that unrelated files under a broad workflow root are excluded.

## Validation
- `test_work_dispatcher.py`: passed
- staged scope and impact checks: passed

## Review Evidence
- Reviewer: Codex, GPT-5
- Result: reviewed against the latest upstream main; no unresolved findings
- Sub-agents: not used

## Agent Metadata
- Tokki: 1.0.39
- Agent/runtime: Codex (version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used