### PR TITLE
fix(workflow): key multi_app_dag stages so its WORKFLOW page renders

### DIFF
--- a/src/agilab/apps/builtin/multi_app_dag_project/lab_stages.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/lab_stages.toml
@@ -1,13 +1,4 @@
-[[steps]]
-D = "Inspect the multi-app DAG contract"
-Q = "Open the bundled flight-to-meteo DAG and identify stages, artifacts, and handoffs."
-M = ""
-C = "from pathlib import Path\nimport json\npath = Path('dag_templates/flight_to_weather_legacy_multi_app_dag.json')\npayload = json.loads(path.read_text(encoding='utf-8'))\n[(node['id'], node['app']) for node in payload['nodes']]"
-R = "runpy"
-
-[[steps]]
-D = "Preview runner state"
-Q = "Build a read-only runner-state preview without executing either app."
-M = ""
-C = "from pathlib import Path\nfrom multi_app_dag.preview_multi_app_dag import build_preview, planning_repo_root\nsummary = build_preview(repo_root=planning_repo_root(None), output_path=Path.home() / 'log/execute/multi_app_dag/runner_state.json')\nsummary['runner_state']['summary']"
-R = "runpy"
+multi_app_dag = [
+  { D = "Inspect the multi-app DAG contract", Q = "Open the bundled flight-to-meteo DAG and identify stages, artifacts, and handoffs.", M = "", C = "from pathlib import Path\nimport json\npath = Path('dag_templates/flight_to_weather_legacy_multi_app_dag.json')\npayload = json.loads(path.read_text(encoding='utf-8'))\n[(node['id'], node['app']) for node in payload['nodes']]", R = "runpy" },
+  { D = "Preview runner state", Q = "Build a read-only runner-state preview without executing either app.", M = "", C = "from pathlib import Path\nfrom multi_app_dag.preview_multi_app_dag import build_preview, planning_repo_root\nsummary = build_preview(repo_root=planning_repo_root(None), output_path=Path.home() / 'log/execute/multi_app_dag/runner_state.json')\nsummary['runner_state']['summary']", R = "runpy" }
+]

--- a/test/test_builtin_lab_stages_contract.py
+++ b/test/test_builtin_lab_stages_contract.py
@@ -1,0 +1,118 @@
+"""Guard the one lab_stages.toml property the app contract matrix never checks.
+
+``tools/app_contract_matrix.py`` asserts that a built-in app's ``lab_stages.toml``
+parses and is non-empty. It never checks the property that decides whether the
+WORKFLOW page shows anything: the top-level table key must equal the app's module
+key, because ``3_WORKFLOW.py::_read_stages`` is a strict ``data.get(module_key, [])``
+with no fallback. A file keyed ``[[stages]]`` or ``[[steps]]`` yields ``[]`` and the
+page renders empty, silently -- no error, no warning, no log line.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+BUILTIN_ROOT = Path(__file__).resolve().parents[1] / "src" / "agilab" / "apps" / "builtin"
+META_KEY = "__meta__"
+
+# Apps whose stage file predates this contract and does not satisfy it yet.
+# Each entry is a documented debt, not a permitted shape: the file is a design
+# manifest (``id``/``label``/``kind``/``depends_on``/``produces``) that was written
+# into the executable contract's filename, so no entry is even displayable and a
+# key rename alone would not fix it. Removing an app from this list is the fix;
+# adding one is not allowed -- author the stages, or ship the decomposition as
+# ``pipeline_view.dot`` instead.
+KNOWN_UNRENDERABLE = {
+    "data_quality_gate_project",
+    "r_runtime_bridge_project",
+    "sklearn_pipeline_project",
+    "tescia_diagnostic_project",
+}
+
+
+def _module_key(project_dir: Path) -> str:
+    name = project_dir.name
+    return name[: -len("_project")] if name.endswith("_project") else name
+
+
+def _stage_files() -> list[Path]:
+    return sorted(BUILTIN_ROOT.glob("*/lab_stages.toml"))
+
+
+def test_builtin_stage_files_are_discoverable() -> None:
+    """The glob must find files, otherwise every test below passes vacuously."""
+
+    assert _stage_files(), f"no built-in lab_stages.toml found under {BUILTIN_ROOT}"
+
+
+@pytest.mark.parametrize(
+    "stage_file", _stage_files(), ids=lambda path: path.parent.name
+)
+def test_builtin_lab_stages_use_the_module_key(stage_file: Path) -> None:
+    """The WORKFLOW page looks the payload up by module key and nothing else."""
+
+    project = stage_file.parent.name
+    module_key = _module_key(stage_file.parent)
+    payload = tomllib.loads(stage_file.read_text(encoding="utf-8"))
+    entries = payload.get(module_key)
+
+    if project in KNOWN_UNRENDERABLE:
+        pytest.xfail(f"{project} ships a design manifest, not a stage contract")
+
+    assert isinstance(entries, list) and entries, (
+        f"{project}/lab_stages.toml must expose its stages under the module key "
+        f"{module_key!r}; found top-level keys "
+        f"{sorted(k for k in payload if k != META_KEY)!r}. "
+        "The WORKFLOW page reads data.get(module_key, []) with no fallback, so any "
+        "other key renders an empty page."
+    )
+
+
+@pytest.mark.parametrize(
+    "stage_file", _stage_files(), ids=lambda path: path.parent.name
+)
+def test_builtin_lab_stages_entries_are_displayable(stage_file: Path) -> None:
+    """Every entry needs a non-empty Q or C or prune_invalid_entries drops it."""
+
+    project = stage_file.parent.name
+    if project in KNOWN_UNRENDERABLE:
+        pytest.xfail(f"{project} ships a design manifest, not a stage contract")
+
+    module_key = _module_key(stage_file.parent)
+    payload = tomllib.loads(stage_file.read_text(encoding="utf-8"))
+    entries = payload.get(module_key)
+    assert isinstance(entries, list), (
+        f"{project}/lab_stages.toml has no {module_key!r} table; "
+        "test_builtin_lab_stages_use_the_module_key explains why."
+    )
+
+    undisplayable = [
+        index
+        for index, entry in enumerate(entries)
+        if not str(entry.get("Q") or "").strip() and not str(entry.get("C") or "").strip()
+    ]
+    assert not undisplayable, (
+        f"{project}/lab_stages.toml entries {undisplayable} have neither Q nor C; "
+        "prune_invalid_entries drops them and the WORKFLOW editor deletes them "
+        "permanently on the next save."
+    )
+
+
+def test_known_unrenderable_list_stays_closed() -> None:
+    """The debt list may shrink, never grow, and must not name a missing app."""
+
+    present = {path.parent.name for path in _stage_files()}
+    stale = KNOWN_UNRENDERABLE - present
+    assert not stale, (
+        f"KNOWN_UNRENDERABLE names apps with no lab_stages.toml: {sorted(stale)}. "
+        "Drop them from the list."
+    )
+    assert len(KNOWN_UNRENDERABLE) <= 4, (
+        "KNOWN_UNRENDERABLE grew. A new built-in app must ship a renderable "
+        "lab_stages.toml, or ship its decomposition as pipeline_view.dot and no "
+        "lab_stages.toml at all."
+    )


### PR DESCRIPTION
## Problem

`3_WORKFLOW.py:596-605` reads a built-in app's stages with a strict lookup:

```python
return list(data.get(module_key, []))   # the entire selection logic
```

No fallback. `multi_app_dag_project` shipped its two stages under `[[steps]]`, so the
lookup returned `[]` and the WORKFLOW page rendered **empty** — silently. No error, no
warning, no log line: a `FileNotFoundError` gives `[]` and a `TOMLDecodeError` gives
`st.error`, but a key mismatch produces neither.

Measured on that exact read path:

| | key | raw entries | displayable |
|---|---|---|---|
| before | `multi_app_dag` | **0** | **0** |
| after | `multi_app_dag` | 2 | 2 |
| `weather_forecast_project` (control) | `weather_forecast` | 4 | 4 |

Both stage bodies already `ast.parse` as valid Python, so this changes the table key
and nothing else.

## The guard

`tools/app_contract_matrix.py` (152 checks, all green) asserts `lab_stages.toml` parses
and is non-empty. It records `top_level_keys` in its own evidence *while passing the
check* — it has the information and does not use it. That is why this shipped.

The new test asserts the two properties the page actually depends on:

1. the payload sits under the module key (app slug without `_project`);
2. every entry has a non-empty `Q` or `C`, so `prune_invalid_entries` keeps it.

Verified it catches the defect: against the pre-fix file it fails with
`multi_app_dag_project` on both assertions.

## Known debt, xfailed with the reason

Four apps cannot satisfy this yet — `data_quality_gate`, `sklearn_pipeline`,
`r_runtime_bridge`, `tescia_diagnostic`. Their files are **design manifests**
(`id`/`label`/`kind`/`depends_on`/`produces`) written into the executable contract's
filename. No entry has `Q` or `C`, so none is even displayable, and a key rename alone
would make things worse: `pipeline_editor.py:1357` rewrites the pruned list on save, so
renamed-but-undisplayable entries would be **permanently deleted** the first time an
operator touches the pipeline.

Those four need a per-app decision (author real stages, or ship the decomposition as
`pipeline_view.dot` and drop the file) and are out of scope here. The list is asserted
closed so a fifth cannot appear.

## Validation

- `test_builtin_lab_stages_contract.py`: 14 passed, 8 xfailed
- `test_app_contract_matrix.py test_builtin_app_tests.py test_workflow_validation.py`: 24 passed
- `tools/app_contract_matrix.py`: still 152/152

🤖 Generated with [Claude Code](https://claude.com/claude-code)