### PR TITLE
fix(contract): check lab_stages renderability, not parseability

### DIFF
--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -476,3 +476,68 @@ def test_app_contract_matrix_quiet_mode_suppresses_stdout(capsys):
     assert module.main(["--quiet"]) == 0
 
     assert capsys.readouterr().out == ""
+
+
+def test_app_contract_matrix_detects_unrenderable_lab_stages(tmp_path: Path):
+    """A stage file keyed anything but the module key renders an empty page."""
+
+    module = _load_module()
+    project = _seed_builtin_project(tmp_path, "demo_project")
+    (project / "lab_stages.toml").write_text(
+        '[[steps]]\nD = "Demo"\nQ = "Do the thing."\nC = "x = 1"\nR = "runpy"\n',
+        encoding="utf-8",
+    )
+
+    checks = {check.id: check for check in module._project_checks(tmp_path, project)}
+    lab_stages = checks["demo_project:lab_stages"]
+
+    assert lab_stages.status == "fail"
+    assert lab_stages.details["module_key"] == "demo"
+    assert lab_stages.details["keyed_under_module_key"] is False
+    assert lab_stages.details["renders_in_workflow"] is False
+    assert lab_stages.details["top_level_keys"] == ["steps"]
+
+
+def test_app_contract_matrix_detects_undisplayable_lab_stages(tmp_path: Path):
+    """Correct key, but entries without Q or C are pruned before rendering."""
+
+    module = _load_module()
+    project = _seed_builtin_project(tmp_path, "demo_project")
+    (project / "lab_stages.toml").write_text(
+        '[[demo]]\nid = "phase_one"\nlabel = "Phase one"\nkind = "data"\n',
+        encoding="utf-8",
+    )
+
+    checks = {check.id: check for check in module._project_checks(tmp_path, project)}
+    lab_stages = checks["demo_project:lab_stages"]
+
+    assert lab_stages.status == "fail"
+    assert lab_stages.details["keyed_under_module_key"] is True
+    assert lab_stages.details["entry_count"] == 1
+    assert lab_stages.details["displayable_count"] == 0
+
+
+def test_app_contract_matrix_accepts_a_renderable_lab_stages(tmp_path: Path):
+    module = _load_module()
+    project = _seed_builtin_project(tmp_path, "demo_project")
+    (project / "lab_stages.toml").write_text(
+        '[[demo]]\nD = "Demo"\nQ = "Do the thing."\nC = "x = 1"\nR = "runpy"\n'
+        "\n[__meta__]\nschema = \"agilab.lab_stages.v1\"\n",
+        encoding="utf-8",
+    )
+
+    checks = {check.id: check for check in module._project_checks(tmp_path, project)}
+    lab_stages = checks["demo_project:lab_stages"]
+
+    assert lab_stages.status == "pass"
+    assert lab_stages.details["displayable_count"] == 1
+    assert lab_stages.details["top_level_keys"] == ["demo"]
+
+
+def test_unrenderable_lab_stages_debt_list_stays_closed():
+    """The documented debt may shrink, never grow."""
+
+    module = _load_module()
+    assert len(module.UNRENDERABLE_LAB_STAGES_PROJECTS) <= 4
+    overlap = module.UNRENDERABLE_LAB_STAGES_PROJECTS & module.OPTIONAL_LAB_STAGES_EXEMPT_PROJECTS
+    assert not overlap, f"an app cannot be both exempt and in debt: {sorted(overlap)}"

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -41,6 +41,23 @@ OPTIONAL_LAB_STAGES_EXEMPT_PROJECTS = frozenset(
         "pytorch_playground_project",
     }
 )
+# Apps that ship a lab_stages.toml the WORKFLOW page cannot render. Their files are
+# design manifests (id/label/kind/depends_on/produces) written into the executable
+# contract's filename: no entry carries Q or C, so none is displayable, and renaming
+# the table key alone would make things worse -- pipeline_editor rewrites the pruned
+# list on save, so renamed-but-undisplayable entries are deleted permanently the first
+# time an operator touches the pipeline. Each needs a per-app decision: author real
+# stages, or ship the decomposition as pipeline_view.dot and drop the file.
+# The list may shrink, never grow.
+UNRENDERABLE_LAB_STAGES_PROJECTS = frozenset(
+    {
+        "data_quality_gate_project",
+        "r_runtime_bridge_project",
+        "sklearn_pipeline_project",
+        "tescia_diagnostic_project",
+    }
+)
+LAB_STAGES_META_KEY = "__meta__"
 PAYLOAD_EXCLUDED_DIRS = frozenset(
     {
         ".mypy_cache",
@@ -146,6 +163,36 @@ def _load_module(repo_root: Path, relative_path: Path, module_name: str):
 def _read_toml(path: Path) -> dict[str, Any]:
     with path.open("rb") as stream:
         return tomllib.load(stream)
+
+
+def _lab_stages_module_key(project_name: str) -> str:
+    """Return the key the WORKFLOW page looks the stage payload up under.
+
+    Mirrors the app-slug derivation in ``agilab.pipeline.pipeline_stages.module_keys``:
+    the export directory name, i.e. the project name without its ``_project`` suffix.
+    Reimplemented here so this contract tool stays importable without pulling in the
+    Streamlit UI stack.
+    """
+
+    suffix = "_project"
+    return project_name[: -len(suffix)] if project_name.endswith(suffix) else project_name
+
+
+def _lab_stage_is_displayable(entry: Any) -> bool:
+    """Mirror ``agilab.pipeline.pipeline_stages.is_displayable_stage``.
+
+    An entry survives ``prune_invalid_entries`` only when ``Q`` or ``C`` is a
+    non-empty string; everything else is dropped, and the WORKFLOW editor deletes
+    the dropped entries permanently on the next save.
+    """
+
+    if not isinstance(entry, dict):
+        return False
+    for field in ("Q", "C"):
+        value = entry.get(field, "")
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
 
 
 def _relative(repo_root: Path, path: Path) -> str:
@@ -730,9 +777,46 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
     else:
         try:
             lab_stages = _read_toml(lab_stages_path)
-            lab_stage_ok = bool(lab_stages)
-            lab_stage_summary = "lab_stages.toml is parseable"
-            lab_stage_details = {"required": True, "top_level_keys": sorted(lab_stages)}
+            module_key = _lab_stages_module_key(project_name)
+            entries = lab_stages.get(module_key)
+            keyed = isinstance(entries, list) and bool(entries)
+            displayable = (
+                [entry for entry in entries if _lab_stage_is_displayable(entry)]
+                if keyed
+                else []
+            )
+            renders = bool(displayable)
+            known_debt = project_name in UNRENDERABLE_LAB_STAGES_PROJECTS
+            # A known-debt app still passes so the gate stays actionable, but the
+            # evidence records that its WORKFLOW page is empty.
+            lab_stage_ok = renders or known_debt
+            if renders:
+                lab_stage_summary = (
+                    f"lab_stages.toml exposes {len(displayable)} displayable "
+                    f"stage(s) under the module key {module_key!r}"
+                )
+            elif known_debt:
+                lab_stage_summary = (
+                    "lab_stages.toml is a known-unrenderable design manifest; the "
+                    "WORKFLOW page shows no stage for this app"
+                )
+            else:
+                lab_stage_summary = (
+                    f"lab_stages.toml exposes no displayable stage under the module "
+                    f"key {module_key!r}; the WORKFLOW page renders empty"
+                )
+            lab_stage_details = {
+                "required": True,
+                "module_key": module_key,
+                "keyed_under_module_key": keyed,
+                "entry_count": len(entries) if keyed else 0,
+                "displayable_count": len(displayable),
+                "renders_in_workflow": renders,
+                "known_debt": known_debt,
+                "top_level_keys": sorted(
+                    key for key in lab_stages if key != LAB_STAGES_META_KEY
+                ),
+            }
         except Exception as exc:
             lab_stage_ok = False
             lab_stage_summary = f"lab_stages.toml is required and could not be parsed: {exc}"


### PR DESCRIPTION
Closes the hole that let four unrenderable stage files ship. Follow-up to #904.

## The hole

`tools/app_contract_matrix.py` asserted:

```python
lab_stage_ok = bool(lab_stages)
lab_stage_summary = "lab_stages.toml is parseable"
lab_stage_details = {"required": True, "top_level_keys": sorted(lab_stages)}
```

It recorded `top_level_keys` in its own evidence **while passing the check**. The
information was there and unused. That is how four built-in apps shipped a stage file
the WORKFLOW page cannot render, and it would not have caught `multi_app_dag`'s
`[[steps]]` key either.

## What the check now verifies

The two properties the page actually depends on:

1. **the payload sits under the module key** — `3_WORKFLOW.py:596-605` is a strict
   `data.get(module_key, [])` with no fallback, so any other key yields `[]` and the
   page renders empty with no error, warning, or log line;
2. **at least one entry carries a non-empty `Q` or `C`** — `prune_invalid_entries`
   drops the rest, and `pipeline_editor.py:1357` rewrites the pruned list on save, so
   dropped entries are deleted permanently the first time an operator touches the
   pipeline.

Evidence now reports `module_key`, `keyed_under_module_key`, `entry_count`,
`displayable_count`, `renders_in_workflow` and `known_debt`.

| app | renders | displayable | keys |
|---|---|---|---|
| mission_decision, multi_app_dag, uav_queue, uav_relay_queue, weather_forecast, weather_forecast_legacy | ✅ | 6/2/4/2/4/4 | module key |
| data_quality_gate, r_runtime_bridge, sklearn_pipeline | ❌ debt | 0 | `['stages']` |
| tescia_diagnostic | ❌ debt | 0 | `['steps']` |

## On duplicating the predicates

Both helpers reimplement `agilab.pipeline.pipeline_stages` logic rather than importing
it, so this contract tool stays runnable without the Streamlit UI stack. Each docstring
names the function it mirrors. I'd rather not add a second contract silently — that is
the exact failure mode elsewhere in this area — so if you prefer the import, say so and
I'll switch it.

## Debt handling

The four apps pass as documented debt so the gate stays actionable, while the evidence
records that their WORKFLOW page is empty. The list is asserted closed and asserted
disjoint from `OPTIONAL_LAB_STAGES_EXEMPT_PROJECTS`, so an app cannot be both optional
and in debt.

## Validation

- Three new detection tests: wrong key → fail, right key but no `Q`/`C` → fail, valid → pass
- `test_app_contract_matrix.py`: 18 passed
- 52 passed / 8 xfailed across the contract, builtin-stage, module-layout and core-guard suites
- `tools/app_contract_matrix.py` on the real repo: **still 152/152**

🤖 Generated with [Claude Code](https://claude.com/claude-code)