### PR TITLE
fix(docs): enforce mirror evidence ownership

### DIFF
--- a/.claude/skills/agilab-docs/SKILL.md
+++ b/.claude/skills/agilab-docs/SKILL.md
@@ -16,6 +16,12 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
 - The public Pages workflow in `agilab` currently builds from the mirrored
   `docs/source` tree in this repo, so that mirror must be kept in sync with the
   canonical source for published pages to stay correct.
+- Three exact paths form a public-owned release-evidence enclave and are not
+  copied from the private source: `data/release_proof.toml`,
+  `release-proof.rst`, and `data/ui_robot_evidence.json`. Generate and validate
+  those files only in the public `agilab` repository. The private page at the
+  same `release-proof.rst` path is an intentionally excluded pointer, not the
+  source for the public proof.
 - Refresh the public mirror with
   `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`.
   The generated stamp `docs/.docs_source_mirror_stamp.json` is part of the mirror
@@ -28,6 +34,8 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
 ## Required Workflow (No Direct `docs/html` Edits)
 
 1. Edit the canonical source file under `../thales_agilab/docs/source`.
+   For one of the three public-owned release-evidence paths above, edit or
+   regenerate the public file instead and run its dedicated proof validator.
 2. Sync the public mirror from the AGILAB repo root:
    `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
 3. If the change touches an SVG diagram, validate the SVG as XML, render a local
@@ -45,6 +53,11 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
    `docs/html/_images` or copied Sphinx outputs.
 5. Validate the mirror stamp before committing:
    `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
+   A verified stamp proves canonical equality only when the canonical source is
+   available. Public CI may validate target integrity with
+   `--skip-missing-source`, but its mandatory warning means canonical drift was
+   not checked. A release refresh may write an explicit target-only stamp; it
+   must use `source_status = unavailable` and must never claim canonical sync.
 6. Rebuild or run the docs profile when the rendered page matters:
    `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
 7. Verify the change exists in both:
@@ -65,6 +78,9 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - That means updating only `../thales_agilab/docs/source` is not sufficient for
   public publication; refresh `agilab/docs/source` with `tools/sync_docs_source.py`
   so the mirror stamp stays valid.
+- The public release-evidence enclave is deliberately different: private mirror
+  sync must preserve it, and `tools/release_proof_report.py --check` remains its
+  independent public owner guard.
 - Figures referenced by Sphinx may be copied to `_images/` in the built site, so a
   raw URL such as `/diagrams/foo.svg` can legitimately return `404` even when the
   published page is correct.
@@ -83,6 +99,9 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - Do stage/commit mirrored `docs/source/**` updates and
   `docs/.docs_source_mirror_stamp.json` in `agilab` when a public page depends on
   the change.
+- For the three public-owned proof paths, stage the regenerated public files and
+  an explicit target-only stamp when the canonical checkout is unavailable;
+  never copy the private pointer or private snapshots over them.
 - Do not stage or commit `docs/html/**`; it is generated local output and should
   remain outside commits.
 - If `docs/html/**` was modified by a local build, leave it unstaged or clean the
@@ -195,6 +214,10 @@ the referenced artifact exists and is current.
 - Public mirror sync (from `agilab` repo root):
   - `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
   - `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
+  - The stamp lists the public-owned exclusions. Use
+    `--write-target-only-stamp` only for a public release refresh that cannot
+    access the canonical checkout; the resulting proof is target integrity,
+    not canonical alignment.
 - SVG docs figure preview:
   - Parse the canonical and mirrored SVG with `xml.etree.ElementTree`.
   - Prefer `rsvg-convert -w 1600 -o /tmp/<name>.png <figure>.svg` when available

--- a/.codex/skills/agilab-docs/SKILL.md
+++ b/.codex/skills/agilab-docs/SKILL.md
@@ -16,6 +16,12 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
 - The public Pages workflow in `agilab` currently builds from the mirrored
   `docs/source` tree in this repo, so that mirror must be kept in sync with the
   canonical source for published pages to stay correct.
+- Three exact paths form a public-owned release-evidence enclave and are not
+  copied from the private source: `data/release_proof.toml`,
+  `release-proof.rst`, and `data/ui_robot_evidence.json`. Generate and validate
+  those files only in the public `agilab` repository. The private page at the
+  same `release-proof.rst` path is an intentionally excluded pointer, not the
+  source for the public proof.
 - Refresh the public mirror with
   `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`.
   The generated stamp `docs/.docs_source_mirror_stamp.json` is part of the mirror
@@ -28,6 +34,8 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
 ## Required Workflow (No Direct `docs/html` Edits)
 
 1. Edit the canonical source file under `../thales_agilab/docs/source`.
+   For one of the three public-owned release-evidence paths above, edit or
+   regenerate the public file instead and run its dedicated proof validator.
 2. Sync the public mirror from the AGILAB repo root:
    `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
 3. If the change touches an SVG diagram, validate the SVG as XML, render a local
@@ -45,6 +53,11 @@ Use this skill when editing docs content or docs build tooling for AGILAB.
    `docs/html/_images` or copied Sphinx outputs.
 5. Validate the mirror stamp before committing:
    `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
+   A verified stamp proves canonical equality only when the canonical source is
+   available. Public CI may validate target integrity with
+   `--skip-missing-source`, but its mandatory warning means canonical drift was
+   not checked. A release refresh may write an explicit target-only stamp; it
+   must use `source_status = unavailable` and must never claim canonical sync.
 6. Rebuild or run the docs profile when the rendered page matters:
    `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
 7. Verify the change exists in both:
@@ -65,6 +78,9 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - That means updating only `../thales_agilab/docs/source` is not sufficient for
   public publication; refresh `agilab/docs/source` with `tools/sync_docs_source.py`
   so the mirror stamp stays valid.
+- The public release-evidence enclave is deliberately different: private mirror
+  sync must preserve it, and `tools/release_proof_report.py --check` remains its
+  independent public owner guard.
 - Figures referenced by Sphinx may be copied to `_images/` in the built site, so a
   raw URL such as `/diagrams/foo.svg` can legitimately return `404` even when the
   published page is correct.
@@ -83,6 +99,9 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - Do stage/commit mirrored `docs/source/**` updates and
   `docs/.docs_source_mirror_stamp.json` in `agilab` when a public page depends on
   the change.
+- For the three public-owned proof paths, stage the regenerated public files and
+  an explicit target-only stamp when the canonical checkout is unavailable;
+  never copy the private pointer or private snapshots over them.
 - Do not stage or commit `docs/html/**`; it is generated local output and should
   remain outside commits.
 - If `docs/html/**` was modified by a local build, leave it unstaged or clean the
@@ -195,6 +214,10 @@ the referenced artifact exists and is current.
 - Public mirror sync (from `agilab` repo root):
   - `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
   - `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
+  - The stamp lists the public-owned exclusions. Use
+    `--write-target-only-stamp` only for a public release refresh that cannot
+    access the canonical checkout; the resulting proof is target integrity,
+    not canonical alignment.
 - SVG docs figure preview:
   - Parse the canonical and mirrored SVG with `xml.etree.ElementTree`.
   - Prefer `rsvg-convert -w 1600 -o /tmp/<name>.png <figure>.svg` when available

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -80,6 +80,7 @@ if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
   fi
   run_guard_python tools/sync_docs_source.py \
     --verify-stamp \
+    "${docs_source_args[@]}" \
     --quiet
   run_guard_python tools/sync_docs_source.py \
     "${docs_source_args[@]}" \

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -50,12 +50,12 @@ jobs:
           cache-dependency-glob: |
             uv.lock
             pyproject.toml
-      - name: Verify managed docs/source mirror stamp
+      - name: Verify checked-in docs mirror integrity
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --quiet
+          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --skip-missing-source --quiet
           uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact
       - name: Install Graphviz
         run: |

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -55,13 +55,12 @@ jobs:
           enable-cache: true
           prune-cache: true
 
-      - name: Verify managed docs/source mirror stamp
+      - name: Verify checked-in docs mirror integrity
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --quiet
-          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --quiet --skip-missing-source
+          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --skip-missing-source --quiet
           uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact
 
       - name: Test docs/source guard tools

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1061,10 +1061,8 @@ jobs:
             --check-github-runs \
             --compact
           python tools/sync_docs_source.py \
-            --source docs/source \
             --target docs/source \
-            --apply \
-            --delete \
+            --write-target-only-stamp \
             --quiet
 
           release_metadata_paths=(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,8 +541,14 @@ Use this runbook whenever you:
   `../thales_agilab/docs/source`; `docs/source` is the managed public mirror and
   `docs/html` is generated local output. After canonical docs edits, refresh the
   mirror and stamp with `uv --preview-features extra-build-dependencies run
-  python tools/sync_docs_source.py --apply --delete`. Never hand-edit, stage, or
-  commit `docs/html/**`.
+  python tools/sync_docs_source.py --apply --delete`. The exact public release
+  evidence paths `data/release_proof.toml`, `release-proof.rst`, and
+  `data/ui_robot_evidence.json` are intentionally excluded from that mirror:
+  they are generated and verified in this public repository, while the private
+  source keeps only its own excluded pointer page. A verified mirror stamp
+  proves canonical equality only when the canonical source was actually
+  supplied; target-only release stamps must record that canonical drift was not
+  checked. Never hand-edit, stage, or commit `docs/html/**`.
 - **VIRTUAL_ENV warning**: AGILAB-managed PyCharm configs and launch wrappers clear
   `VIRTUAL_ENV` before invoking `uv`, because AGILAB intentionally selects the target
   project `.venv` instead of a stale activated shell. If a direct `uv` command still

--- a/agent-context-rules.json
+++ b/agent-context-rules.json
@@ -106,9 +106,9 @@
             "tools/sync_docs_source.py"
           ],
           "commands": [
-            "uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check"
+            "uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --skip-missing-source"
           ],
-          "why": "Route public wording through docs source discipline and evidence-boundary checks."
+          "why": "Route public wording through docs source discipline and evidence-boundary checks. In public-only clones this command checks target integrity and reports that canonical drift was not checked; when the canonical source is configured it also enforces source-to-mirror equality."
         },
         "release-publication": {
           "token_budget": 2600,

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,15 @@
 {
-  "file_count": 276,
-  "format_version": 1,
+  "file_count": 273,
+  "format_version": 2,
   "managed_target": "docs/source",
-  "source_digest_sha256": "1526a18c4fafb82e590e27631b6fa985b42d23ff1b5a453f12ce576bb79fbf03",
+  "public_owned_exclusions": [
+    "data/release_proof.toml",
+    "data/ui_robot_evidence.json",
+    "release-proof.rst"
+  ],
+  "source_digest_sha256": "2a9f314bc386459c9cf1b4232e8c656a8e2129a740a5f321a9f0c5b9d4d77692",
   "source_hint": "../thales_agilab/docs/source",
+  "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "1526a18c4fafb82e590e27631b6fa985b42d23ff1b5a453f12ce576bb79fbf03"
+  "target_digest_sha256": "2a9f314bc386459c9cf1b4232e8c656a8e2129a740a5f321a9f0c5b9d4d77692"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -110,7 +110,9 @@ check:
 - **Source/mirror parity**: contributors can edit public docs in their pull
   request. Maintainers keep the canonical ``../thales_agilab/docs/source`` tree
   and this repository's ``docs/source`` mirror aligned, verify the mirror stamp,
-  and build the page when layout or links matter. Never hand-edit
+  and build the page when layout or links matter. The public release-proof
+  manifest, generated release-proof page, and UI robot evidence are explicitly
+  public-owned and excluded from private-to-public sync. Never hand-edit
   ``docs/html``.
 - **Screenshots and diagrams**: update source screenshots, SVG diagrams,
   captions, alt text, and references together. Inspect the rendered page so old

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -57,7 +57,7 @@ workflow = "docs-source-guard"
 run_id = "30244336406"
 url = "https://github.com/ThalesGroup/agilab/actions/runs/30244336406"
 head_sha = "411267613c11109af85d6139a180bf72e9e999a8"
-summary = "passed docs mirror and release-proof consistency checks"
+summary = "passed checked-in docs mirror integrity and release-proof consistency checks; canonical private-source drift is not checked by public CI"
 
 [[ci_runs]]
 id = "docs-publish"

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -475,6 +475,11 @@ from GitHub. Maintainers who work with a separate canonical documentation
 checkout should edit that canonical source first, then sync the public mirror in
 ``agilab/docs/source`` before opening or updating the public PR.
 
+The release-proof manifest, its generated page, and the UI robot evidence are
+the exception. They are generated from the public AGILAB checkout and remain
+owned by that repository; private-to-public mirror sync preserves them. The
+canonical documentation source keeps only a pointer to the public release proof.
+
 For maintainer mirror syncs, run:
 
 .. code-block:: bash

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -28,7 +28,7 @@ Current public release
    * - Public guardrails
      - `repo-guardrails run 30244336462 <https://github.com/ThalesGroup/agilab/actions/runs/30244336462>`__ at commit ``411267613c11`` passed repository guardrails at the recorded post-release main commit; clean-install jobs were skipped and are not claimed as release proof
    * - Docs source guard
-     - `docs-source-guard run 30244336406 <https://github.com/ThalesGroup/agilab/actions/runs/30244336406>`__ at commit ``411267613c11`` passed docs mirror and release-proof consistency checks
+     - `docs-source-guard run 30244336406 <https://github.com/ThalesGroup/agilab/actions/runs/30244336406>`__ at commit ``411267613c11`` passed checked-in docs mirror integrity and release-proof consistency checks; canonical private-source drift is not checked by public CI
    * - Docs publish
      - `docs-publish run 30244336436 <https://github.com/ThalesGroup/agilab/actions/runs/30244336436>`__ at commit ``411267613c11`` built the public documentation from the managed docs mirror
    * - Coverage

--- a/src/agilab/resources/help/troubleshooting.html
+++ b/src/agilab/resources/help/troubleshooting.html
@@ -53,6 +53,14 @@
   <h2 id="c-example-of-tests-sequence">C - Example Test Sequence</h2>
   <pre><code>./dev impact
 ./dev bugfix
+uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --skip-missing-source</code></pre>
+  <p>
+    In a public-only clone, <code>--skip-missing-source</code> validates the
+    checked-in mirror target and reports that canonical drift was not checked.
+    Maintainers with the canonical docs checkout must instead configure its
+    source path and omit that option so source-to-mirror drift is mandatory:
+  </p>
+  <pre><code>AGILAB_DOCS_SOURCE=/path/to/canonical/docs/source \
 uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp</code></pre>
 
   <h1 id="known-limitations-and-deprecations">Known Limitations and Deprecations</h1>

--- a/test/test_agent_context_router.py
+++ b/test/test_agent_context_router.py
@@ -60,6 +60,20 @@ def test_recommend_context_matches_docs_and_evidence_rules() -> None:
     assert "agilab-evidence-contracts" in skill_names
 
 
+def test_docs_context_command_is_honest_without_canonical_checkout() -> None:
+    rules = json.loads(agent_context_router.DEFAULT_RULES.read_text(encoding="utf-8"))
+    docs_pack = rules["context_profiles"]["tokki"]["rule_packs"][
+        "docs-public-claims"
+    ]
+
+    assert docs_pack["commands"] == [
+        "uv --preview-features extra-build-dependencies run python "
+        "tools/sync_docs_source.py --check --skip-missing-source"
+    ]
+    assert "target integrity" in docs_pack["why"]
+    assert "canonical drift was not checked" in docs_pack["why"]
+
+
 def test_recommend_context_matches_release_prompt_without_files() -> None:
     payload = agent_context_router.recommend_context(
         prompt="ready for release, check PyPI and Hugging Face sync",

--- a/test/test_agilab_audit.py
+++ b/test/test_agilab_audit.py
@@ -122,3 +122,40 @@ def test_audit_preflight_accepts_selected_first_publish_project(monkeypatch) -> 
             ],
         }
     ]
+
+
+def test_release_audit_uses_explicit_target_only_docs_verification(monkeypatch) -> None:
+    commands: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(agilab_audit, "_worktrees", lambda: [])
+
+    def fake_command_check(name, command, timeout=120):
+        del timeout
+        commands.append((name, command))
+        return {
+            "name": name,
+            "status": "pass",
+            "returncode": 0,
+            "summary": (
+                "canonical docs source unavailable; target integrity only; "
+                "canonical drift NOT CHECKED"
+                if name == "docs-mirror-target-integrity"
+                else "ok"
+            ),
+        }
+
+    monkeypatch.setattr(agilab_audit, "_command_check", fake_command_check)
+
+    report = agilab_audit.build_report(fetch=False, network=False)
+
+    assert report["status"] == "pass"
+    assert commands[0] == (
+        "docs-mirror-target-integrity",
+        [
+            sys.executable,
+            "tools/sync_docs_source.py",
+            "--verify-stamp",
+            "--skip-missing-source",
+            "--quiet",
+        ],
+    )
+    assert "canonical drift NOT CHECKED" in report["checks"][0]["summary"]

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -9,6 +9,7 @@ WORKFLOW_PATH = Path(".github/workflows/ci.yml")
 COVERAGE_WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 DOCS_SOURCE_GUARD_WORKFLOW_PATH = Path(".github/workflows/docs-source-guard.yaml")
 DOCS_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/docs-publish.yaml")
+PYPI_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/pypi-publish.yaml")
 ENSURE_ROADMAP_LABEL_WORKFLOW_PATH = Path(".github/workflows/ensure-roadmap-label.yaml")
 UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
 WINDOWS_CORE_TESTS_WORKFLOW_PATH = Path(".github/workflows/windows-core-tests.yml")
@@ -362,6 +363,29 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
         "-o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py"
     ) in guard_text
     assert "run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py" not in guard_text
+
+
+def test_docs_workflows_label_target_only_verification_honestly() -> None:
+    for path in (DOCS_SOURCE_GUARD_WORKFLOW_PATH, DOCS_PUBLISH_WORKFLOW_PATH):
+        text = path.read_text(encoding="utf-8")
+        assert "Verify checked-in docs mirror integrity" in text
+        assert (
+            "tools/sync_docs_source.py --verify-stamp --skip-missing-source --quiet"
+            in text
+        )
+
+    guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "--check --delete --quiet --skip-missing-source" not in guard_text
+
+
+def test_release_workflow_writes_an_explicit_target_only_mirror_stamp() -> None:
+    text = PYPI_PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
+    stamp_block = text.split("python tools/sync_docs_source.py", 1)[1].split(
+        "release_metadata_paths=", 1
+    )[0]
+
+    assert "--write-target-only-stamp" in stamp_block
+    assert "--source docs/source" not in stamp_block
 
 
 def test_docs_source_guard_fetches_release_tags_for_exact_proof() -> None:

--- a/test/test_deprecation_hygiene.py
+++ b/test/test_deprecation_hygiene.py
@@ -101,3 +101,11 @@ def test_packaged_help_uses_current_troubleshooting_page() -> None:
 
     assert typo_hits == []
     assert stale_heading_hits == []
+
+    troubleshooting = (help_root / "troubleshooting.html").read_text(encoding="utf-8")
+    assert (
+        "tools/sync_docs_source.py --verify-stamp --skip-missing-source"
+        in troubleshooting
+    )
+    assert "canonical drift was not checked" in troubleshooting
+    assert "AGILAB_DOCS_SOURCE=/path/to/canonical/docs/source" in troubleshooting

--- a/test/test_kpi_evidence_bundle.py
+++ b/test/test_kpi_evidence_bundle.py
@@ -82,8 +82,26 @@ def test_build_bundle_passes_static_public_evidence_contracts() -> None:
         "web_ui_robot_contract",
         "production_readiness_report_contract",
         "docs_mirror_stamp",
+        "docs_canonical_alignment",
         "public_docs_evidence_links",
     }
+
+
+def test_missing_canonical_docs_is_skipped_not_passed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    monkeypatch.setenv("AGILAB_DOCS_SOURCE", str(tmp_path / "missing-canonical"))
+
+    target_check = module._check_docs_mirror_stamp(Path.cwd())
+    canonical_check = module._check_docs_canonical_alignment(Path.cwd())
+
+    assert target_check["status"] == "pass"
+    assert "target integrity" in target_check["summary"]
+    assert canonical_check["status"] == "skipped"
+    assert canonical_check["details"]["canonical_alignment_checked"] is False
+    assert "canonical drift NOT CHECKED" in canonical_check["summary"]
 
 
 def test_render_readme_summary_uses_kpi_bundle_scores() -> None:

--- a/test/test_maintenance_dashboard.py
+++ b/test/test_maintenance_dashboard.py
@@ -44,6 +44,23 @@ def test_maintenance_dashboard_exposes_long_term_contract_checks() -> None:
     } <= check_ids
 
 
+def test_docs_mirror_honors_configured_canonical_source(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    configured_source = tmp_path / "canonical-docs" / "source"
+    monkeypatch.setenv("AGILAB_DOCS_SOURCE", str(configured_source))
+
+    check = module.check_docs_mirror(ROOT).as_dict()
+
+    assert check["status"] == "warn"
+    assert check["summary"] == (
+        "canonical docs source is unavailable; mirror drift was not checked"
+    )
+    assert check["details"]["source"] == configured_source.resolve().as_posix()
+
+
 def test_extension_contract_kit_declares_required_extension_types() -> None:
     module = _load_module()
 

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -35,11 +35,16 @@ def test_classify_docs_source_change_runs_docs_guard_only():
 
 
 def test_classify_release_proof_change_runs_both_doc_related_guards():
-    state = pre_push_changed_files.classify_changed_files(["docs/source/release-proof.rst"])
+    for path in (
+        "docs/source/data/release_proof.toml",
+        "docs/source/release-proof.rst",
+        "docs/source/data/ui_robot_evidence.json",
+    ):
+        state = pre_push_changed_files.classify_changed_files([path])
 
-    assert state.docs_changed
-    assert state.release_proof_changed
-    assert not state.app_contracts_changed
+        assert state.docs_changed, path
+        assert state.release_proof_changed, path
+        assert not state.app_contracts_changed, path
 
 
 def test_classify_release_tool_change_runs_release_proof_guard_only():
@@ -94,10 +99,13 @@ def test_classify_infra_scopes_do_not_count_as_mixed_push_scope():
 
 def test_pre_push_docs_guard_accepts_an_isolated_canonical_source():
     hook = (ROOT / ".githooks" / "pre-push").read_text(encoding="utf-8")
+    verify_block = hook.split("--verify-stamp", 1)[1].split(
+        "run_guard_python tools/sync_docs_source.py", 1
+    )[0]
 
     assert 'if [[ -n "${AGILAB_DOCS_SOURCE:-}" ]]' in hook
     assert 'docs_source_args=(--source "$AGILAB_DOCS_SOURCE")' in hook
-    assert '"${docs_source_args[@]}" \\' in hook
+    assert '"${docs_source_args[@]}" \\' in verify_block
 
 
 def test_pre_push_docs_source_override_fails_closed_when_missing(

--- a/test/test_production_readiness_report.py
+++ b/test/test_production_readiness_report.py
@@ -33,6 +33,7 @@ def test_build_report_passes_static_production_readiness_contracts() -> None:
     check_ids = {check["id"] for check in report["checks"]}
     assert check_ids == {
         "docs_mirror_stamp",
+        "docs_canonical_alignment",
         "docs_workflow_parity_profile",
         "production_readiness_workflow_profile",
         "architecture_scorecard",
@@ -49,6 +50,23 @@ def test_build_report_passes_static_production_readiness_contracts() -> None:
         "cluster_share_fail_fast",
         "production_boundary_docs",
     }
+
+
+def test_missing_canonical_docs_is_skipped_not_passed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    monkeypatch.setenv("AGILAB_DOCS_SOURCE", str(tmp_path / "missing-canonical"))
+
+    target_check = module._check_docs_mirror_stamp(Path.cwd())
+    canonical_check = module._check_docs_canonical_alignment(Path.cwd())
+
+    assert target_check["status"] == "pass"
+    assert "target integrity" in target_check["summary"]
+    assert canonical_check["status"] == "skipped"
+    assert canonical_check["details"]["canonical_alignment_checked"] is False
+    assert "canonical drift NOT CHECKED" in canonical_check["summary"]
 
 
 def test_build_report_includes_shared_adoption_hardening_controls() -> None:

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -1270,33 +1270,61 @@ def test_update_public_demo_release_test_skips_manifest_backed_constant(tmp_path
     assert public_test.read_text(encoding="utf-8") == text
 
 
-def test_update_release_proof_references_refreshes_canonical_docs_and_syncs(tmp_path, monkeypatch) -> None:
+def test_update_release_proof_references_refreshes_public_owned_proof_only(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_pypi_publish()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
     script = tmp_path / "tools" / "release_proof_report.py"
     script.parent.mkdir(parents=True)
     script.write_text("print('ok')\n", encoding="utf-8")
-    docs_repo = tmp_path / "thales_agilab"
-    canonical_source = docs_repo / "docs" / "source"
-    manifest = canonical_source / "data" / "release_proof.toml"
+    public_source = tmp_path / "docs" / "source"
+    manifest = public_source / "data" / "release_proof.toml"
     manifest.parent.mkdir(parents=True)
     manifest.write_text("[release]\n", encoding="utf-8")
     commands: list[list[str]] = []
-    synced: list[Path] = []
-    monkeypatch.setattr(module, "find_docs_repository", lambda: (docs_repo, "default"))
-    monkeypatch.setattr(module, "run", lambda cmd, cwd=None, **_kwargs: commands.append([str(part) for part in cmd]))
-    monkeypatch.setattr(module, "sync_docs_source_mirror", synced.append)
+    monkeypatch.setattr(
+        module,
+        "run",
+        lambda cmd, cwd=None, **_kwargs: commands.append(
+            [str(part) for part in cmd]
+        ),
+    )
 
     module.update_release_proof_references("2026.04.24")
 
-    assert synced == [canonical_source]
     command = commands[0]
     assert "--docs-source" in command
-    assert str(canonical_source) in command
+    assert str(public_source) in command
     assert "--github-release-tag" in command
     assert "v2026.04.24" in command
     assert "--github-release-url" in command
     assert "https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.24" in command
+
+
+def test_update_public_docs_mirror_stamp_marks_canonical_source_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    script = tmp_path / "tools" / "sync_docs_source.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    public_source = tmp_path / "docs" / "source"
+    public_source.mkdir(parents=True)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        module,
+        "run",
+        lambda cmd, cwd=None, **_kwargs: commands.append([str(part) for part in cmd]),
+    )
+
+    module.update_public_docs_mirror_stamp_from_current_tree()
+
+    command = commands[0]
+    assert "--write-target-only-stamp" in command
+    assert "--source" not in command
+    assert command[command.index("--target") + 1] == str(public_source)
 
 
 def test_update_docs_index_release_link_requires_canonical_docs_repo(tmp_path, monkeypatch) -> None:

--- a/test/test_sync_docs_source.py
+++ b/test/test_sync_docs_source.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 
 MODULE_PATH = Path("tools/sync_docs_source.py").resolve()
 
@@ -30,6 +31,32 @@ def test_build_manifest_ignores_junk_files(tmp_path: Path) -> None:
     manifest = module.build_manifest(source)
 
     assert manifest == {"guide.rst": source / "guide.rst"}
+
+
+def test_configured_canonical_source_honors_environment(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    configured = tmp_path / "isolated-canonical"
+    monkeypatch.setenv(module.DOCS_SOURCE_ENV, str(configured))
+
+    assert module.configured_canonical_source() == configured
+
+
+def test_build_manifest_excludes_only_public_owned_docs_artifacts(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    root = tmp_path / "source"
+    managed = root / "data" / "managed.json"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("managed\n", encoding="utf-8")
+    for rel_path in module.PUBLIC_OWNED_EXCLUSIONS:
+        path = root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("public-owned\n", encoding="utf-8")
+
+    manifest = module.build_manifest(root)
+
+    assert manifest == {"data/managed.json": managed}
 
 
 def test_make_sync_plan_reports_create_update_and_delete(tmp_path: Path) -> None:
@@ -68,6 +95,56 @@ def test_apply_sync_plan_copies_and_deletes(tmp_path: Path) -> None:
 
     assert (target / "nested" / "guide.rst").read_text(encoding="utf-8") == "guide\n"
     assert not (target / "stale.rst").exists()
+
+
+def test_apply_delete_preserves_public_owned_artifacts_and_manages_adjacent_data(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    for rel_path in module.PUBLIC_OWNED_EXCLUSIONS:
+        source_path = source / rel_path
+        target_path = target / rel_path
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text("canonical-copy\n", encoding="utf-8")
+        target_path.write_text("public-generated\n", encoding="utf-8")
+    (source / "data" / "managed.json").write_text("new\n", encoding="utf-8")
+    (target / "data" / "managed.json").write_text("old\n", encoding="utf-8")
+    (target / "data" / "stale.json").write_text("stale\n", encoding="utf-8")
+
+    plan = module.make_sync_plan(source, target, delete_extra=True)
+    module.apply_sync_plan(source, target, plan)
+
+    assert plan.updated == ["data/managed.json"]
+    assert plan.deleted == ["data/stale.json"]
+    for rel_path in module.PUBLIC_OWNED_EXCLUSIONS:
+        assert (target / rel_path).read_text(encoding="utf-8") == "public-generated\n"
+    assert (target / "data" / "managed.json").read_text(encoding="utf-8") == "new\n"
+    assert not (target / "data" / "stale.json").exists()
+
+
+def test_public_owned_artifact_changes_do_not_change_managed_digest(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    before = module._manifest_state(target)
+    for rel_path in module.PUBLIC_OWNED_EXCLUSIONS:
+        path = target / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("generated version one\n", encoding="utf-8")
+    after_create = module._manifest_state(target)
+    for rel_path in module.PUBLIC_OWNED_EXCLUSIONS:
+        (target / rel_path).write_text("generated version two\n", encoding="utf-8")
+
+    assert after_create == before
+    assert module._manifest_state(target) == before
 
 
 def test_make_sync_plan_normalizes_unicode_relative_paths(tmp_path: Path) -> None:
@@ -109,12 +186,55 @@ def test_main_check_and_apply_modes(tmp_path: Path, capsys) -> None:
     payload = json.loads(stamp.read_text(encoding="utf-8"))
     assert payload["file_count"] == 1
     assert payload["managed_target"] == "docs/source"
+    assert payload["format_version"] == 2
+    assert payload["source_status"] == "verified"
+    assert payload["source_digest_sha256"] == payload["target_digest_sha256"]
+    assert payload["public_owned_exclusions"] == sorted(
+        module.PUBLIC_OWNED_EXCLUSIONS
+    )
 
 
-def test_main_can_skip_missing_canonical_source_for_local_guards(tmp_path: Path, capsys) -> None:
+def test_main_missing_canonical_source_requires_explicit_degraded_mode(
+    tmp_path: Path,
+    capsys,
+) -> None:
     module = _load_module()
     target = tmp_path / "target"
     target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    assert module.main(["--target", str(target), "--write-target-only-stamp"]) == 0
+    capsys.readouterr()
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(tmp_path / "missing-source"),
+            "--target",
+            str(target),
+            "--verify-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "canonical docs source not found" in capsys.readouterr().out
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(tmp_path / "missing-source"),
+            "--target",
+            str(target),
+            "--verify-stamp",
+            "--skip-missing-source",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "target integrity only" in output
+    assert "canonical drift NOT CHECKED" in output
 
     exit_code = module.main(
         [
@@ -124,11 +244,14 @@ def test_main_can_skip_missing_canonical_source_for_local_guards(tmp_path: Path,
             str(target),
             "--check",
             "--skip-missing-source",
+            "--quiet",
         ]
     )
 
     assert exit_code == 0
-    assert "skipped mirror drift check" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "target integrity only" in output
+    assert "canonical drift NOT CHECKED" in output
 
 
 def test_verify_stamp_passes_after_apply(tmp_path: Path, capsys) -> None:
@@ -141,10 +264,135 @@ def test_verify_stamp_passes_after_apply(tmp_path: Path, capsys) -> None:
 
     assert module.main(["--source", str(source), "--target", str(target), "--apply"]) == 0
 
-    exit_code = module.main(["--target", str(target), "--verify-stamp"])
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--verify-stamp",
+        ]
+    )
 
     assert exit_code == 0
     assert "mirror stamp ok:" in capsys.readouterr().out
+
+
+def test_verify_stamp_detects_canonical_source_drift(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    assert module.main(["--source", str(source), "--target", str(target), "--apply"]) == 0
+    capsys.readouterr()
+    (source / "guide.rst").write_text("canonical changed\n", encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--verify-stamp",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "canonical source drift" in capsys.readouterr().out
+
+
+def test_verified_stamp_rejects_self_source_and_unsynced_trees(tmp_path: Path) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("source\n", encoding="utf-8")
+    (target / "guide.rst").write_text("target\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="same directory"):
+        module.build_mirror_stamp(target, target)
+    with pytest.raises(ValueError, match="differ"):
+        module.build_mirror_stamp(source, target)
+
+
+def test_target_only_stamp_is_explicitly_noncanonical(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+
+    exit_code = module.main(
+        ["--target", str(target), "--write-target-only-stamp", "--quiet"]
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(
+        module.stamp_path_for_target(target).read_text(encoding="utf-8")
+    )
+    assert payload["source_status"] == "unavailable"
+    assert payload["source_digest_sha256"] is None
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--verify-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+
+    (source / "guide.rst").write_text("canonical changed\n", encoding="utf-8")
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--verify-stamp",
+            "--quiet",
+        ]
+    )
+    assert exit_code == 1
+    assert "canonical source drift" in capsys.readouterr().out
+
+
+def test_target_only_stamp_still_detects_target_mutation(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    assert module.main(["--target", str(target), "--write-target-only-stamp"]) == 0
+    capsys.readouterr()
+    (target / "guide.rst").write_text("changed\n", encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(tmp_path / "missing-source"),
+            "--target",
+            str(target),
+            "--verify-stamp",
+            "--skip-missing-source",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "mirror stamp mismatch" in capsys.readouterr().out
 
 
 def test_verify_stamp_detects_unmanaged_edit(tmp_path: Path, capsys) -> None:
@@ -158,7 +406,15 @@ def test_verify_stamp_detects_unmanaged_edit(tmp_path: Path, capsys) -> None:
     assert module.main(["--source", str(source), "--target", str(target), "--apply"]) == 0
     (target / "guide.rst").write_text("changed\n", encoding="utf-8")
 
-    exit_code = module.main(["--target", str(target), "--verify-stamp"])
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--verify-stamp",
+        ]
+    )
 
     assert exit_code == 1
     assert "mirror stamp mismatch" in capsys.readouterr().out
@@ -170,7 +426,105 @@ def test_verify_stamp_reports_missing_stamp(tmp_path: Path, capsys) -> None:
     target.mkdir()
     (target / "guide.rst").write_text("guide\n", encoding="utf-8")
 
-    exit_code = module.main(["--target", str(target), "--verify-stamp"])
+    exit_code = module.main(
+        [
+            "--source",
+            str(tmp_path / "source"),
+            "--target",
+            str(target),
+            "--verify-stamp",
+        ]
+    )
 
     assert exit_code == 1
     assert "missing mirror stamp" in capsys.readouterr().out
+
+
+def test_verify_stamp_rejects_non_object_json(tmp_path: Path) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    module.stamp_path_for_target(target).write_text("[]\n", encoding="utf-8")
+
+    ok, message = module.verify_mirror_stamp(
+        target,
+        source=None,
+        skip_missing_source=True,
+    )
+
+    assert ok is False
+    assert "expected a JSON object" in message
+
+
+def test_v1_stamp_rejection_names_both_regeneration_modes(tmp_path: Path) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    module.stamp_path_for_target(target).write_text(
+        json.dumps({"format_version": 1}) + "\n",
+        encoding="utf-8",
+    )
+
+    ok, message = module.verify_mirror_stamp(
+        target,
+        source=None,
+        skip_missing_source=True,
+    )
+
+    assert ok is False
+    assert "unsupported mirror stamp format" in message
+    assert "--apply --delete" in message
+    assert "--write-target-only-stamp" in message
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("managed_target", "other/source"),
+        ("source_hint", "untrusted/source"),
+        ("sync_tool", "tools/other_sync.py"),
+    ],
+)
+def test_verify_stamp_rejects_false_identity_metadata(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    stamp_path = module.write_target_only_mirror_stamp(target)
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    payload[field] = replacement
+    stamp_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    ok, message = module.verify_mirror_stamp(
+        target,
+        source=None,
+        skip_missing_source=True,
+    )
+
+    assert ok is False
+    assert f"{field} mismatch" in message
+
+
+def test_structured_target_and_canonical_checks_do_not_call_missing_source_pass(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    module.write_target_only_mirror_stamp(target)
+
+    target_ok, target_message = module.verify_target_mirror_integrity(target)
+    canonical_status, canonical_message = module.verify_canonical_mirror_alignment(
+        target,
+        tmp_path / "missing-canonical",
+    )
+
+    assert target_ok is True
+    assert "target integrity verified" in target_message
+    assert canonical_status == "skipped"
+    assert "canonical drift NOT CHECKED" in canonical_message

--- a/tools/agilab_audit.py
+++ b/tools/agilab_audit.py
@@ -158,8 +158,14 @@ def build_report(
     ]
     checks = [
         _command_check(
-            "docs-mirror-stamp",
-            [sys.executable, "tools/sync_docs_source.py", "--verify-stamp"],
+            "docs-mirror-target-integrity",
+            [
+                sys.executable,
+                "tools/sync_docs_source.py",
+                "--verify-stamp",
+                "--skip-missing-source",
+                "--quiet",
+            ],
         ),
         _command_check(
             "release-proof",

--- a/tools/kpi_evidence_bundle.py
+++ b/tools/kpi_evidence_bundle.py
@@ -72,11 +72,15 @@ def _check_result(
     evidence: Sequence[str] = (),
     details: dict[str, Any] | None = None,
     executed: bool = False,
+    status_override: str | None = None,
 ) -> dict[str, Any]:
+    status = status_override or ("pass" if passed else "fail")
+    if status not in {"pass", "fail", "skipped"}:
+        raise ValueError(f"unsupported check status: {status}")
     return {
         "id": check_id,
         "label": label,
-        "status": "pass" if passed else "fail",
+        "status": status,
         "summary": summary,
         "executed": executed,
         "evidence": list(evidence),
@@ -2333,15 +2337,42 @@ def _check_production_readiness_report(repo_root: Path) -> dict[str, Any]:
 def _check_docs_mirror_stamp(repo_root: Path) -> dict[str, Any]:
     try:
         sync_docs_source = _load_tool_module(repo_root, "sync_docs_source")
-        ok, message = sync_docs_source.verify_mirror_stamp(repo_root / "docs" / "source")
+        ok, message = sync_docs_source.verify_target_mirror_integrity(
+            repo_root / "docs" / "source"
+        )
     except Exception as exc:
         ok, message = False, str(exc)
     return _check_result(
         "docs_mirror_stamp",
-        "Docs mirror stamp",
+        "Checked-in docs mirror target integrity",
         ok,
         message,
         evidence=["docs/.docs_source_mirror_stamp.json", "tools/sync_docs_source.py"],
+    )
+
+
+def _check_docs_canonical_alignment(repo_root: Path) -> dict[str, Any]:
+    source = None
+    try:
+        sync_docs_source = _load_tool_module(repo_root, "sync_docs_source")
+        source = sync_docs_source.configured_canonical_source()
+        status, message = sync_docs_source.verify_canonical_mirror_alignment(
+            repo_root / "docs" / "source",
+            source,
+        )
+    except Exception as exc:
+        status, message = "fail", str(exc)
+    return _check_result(
+        "docs_canonical_alignment",
+        "Canonical-to-public docs alignment",
+        status == "pass",
+        message,
+        evidence=["docs/.docs_source_mirror_stamp.json", "tools/sync_docs_source.py"],
+        details={
+            "canonical_source": str(source) if source is not None else None,
+            "canonical_alignment_checked": status != "skipped",
+        },
+        status_override=status,
     )
 
 
@@ -2568,6 +2599,7 @@ def build_bundle(
         _check_web_robot_contract(repo_root),
         _check_production_readiness_report(repo_root),
         _check_docs_mirror_stamp(repo_root),
+        _check_docs_canonical_alignment(repo_root),
         _check_public_docs_links(repo_root),
     ]
     if run_hf_smoke:
@@ -2575,6 +2607,7 @@ def build_bundle(
 
     passed = sum(1 for check in checks if check["status"] == "pass")
     failed = sum(1 for check in checks if check["status"] == "fail")
+    skipped = sum(1 for check in checks if check["status"] == "skipped")
     return {
         "kpi": "Overall public evaluation",
         "supported_score": SUPPORTED_OVERALL_SCORE,
@@ -2583,6 +2616,7 @@ def build_bundle(
         "summary": {
             "passed": passed,
             "failed": failed,
+            "skipped": skipped,
             "total": len(checks),
             "hf_smoke_executed": run_hf_smoke,
             "score_components": {

--- a/tools/maintenance_dashboard.py
+++ b/tools/maintenance_dashboard.py
@@ -182,7 +182,7 @@ def check_adrs(repo_root: Path) -> Check:
 
 def check_docs_mirror(repo_root: Path) -> Check:
     sync_docs = _load_tool(repo_root, "tools/sync_docs_source.py", "maintenance_sync_docs_source")
-    source = (repo_root.parent / "thales_agilab" / "docs" / "source").resolve()
+    source = sync_docs.configured_canonical_source().expanduser().resolve()
     target = repo_root / "docs/source"
     if not source.is_dir():
         return _check(
@@ -195,7 +195,7 @@ def check_docs_mirror(repo_root: Path) -> Check:
             details={"source": source.as_posix()},
         )
     plan = sync_docs.make_sync_plan(source, target, delete_extra=True)
-    stamp_ok, stamp_message = sync_docs.verify_mirror_stamp(target)
+    stamp_ok, stamp_message = sync_docs.verify_mirror_stamp(target, source)
     ok = not plan.has_changes() and stamp_ok
     return _check(
         "docs_mirror",

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -34,6 +34,7 @@ RELEASE_PROOF_GUARD_FILES = {
     "README.md",
     "badges/pypi-version-agilab.svg",
     "docs/source/release-proof.rst",
+    "docs/source/data/ui_robot_evidence.json",
     "pyproject.toml",
     "test/test_release_proof_report.py",
     "tools/release_proof_report.py",

--- a/tools/production_readiness_report.py
+++ b/tools/production_readiness_report.py
@@ -48,11 +48,15 @@ def _check_result(
     *,
     evidence: Sequence[str] = (),
     details: dict[str, Any] | None = None,
+    status_override: str | None = None,
 ) -> dict[str, Any]:
+    status = status_override or ("pass" if passed else "fail")
+    if status not in {"pass", "fail", "skipped"}:
+        raise ValueError(f"unsupported check status: {status}")
     return {
         "id": check_id,
         "label": label,
-        "status": "pass" if passed else "fail",
+        "status": status,
         "summary": summary,
         "evidence": list(evidence),
         "details": details or {},
@@ -80,15 +84,42 @@ def _missing_required_tokens(
 def _check_docs_mirror_stamp(repo_root: Path) -> dict[str, Any]:
     try:
         sync_docs_source = _load_tool_module("sync_docs_source")
-        ok, message = sync_docs_source.verify_mirror_stamp(repo_root / "docs" / "source")
+        ok, message = sync_docs_source.verify_target_mirror_integrity(
+            repo_root / "docs" / "source"
+        )
     except Exception as exc:
         ok, message = False, str(exc)
     return _check_result(
         "docs_mirror_stamp",
-        "Docs mirror stamp",
+        "Checked-in docs mirror target integrity",
         ok,
         message,
         evidence=["docs/.docs_source_mirror_stamp.json", "tools/sync_docs_source.py"],
+    )
+
+
+def _check_docs_canonical_alignment(repo_root: Path) -> dict[str, Any]:
+    source = None
+    try:
+        sync_docs_source = _load_tool_module("sync_docs_source")
+        source = sync_docs_source.configured_canonical_source()
+        status, message = sync_docs_source.verify_canonical_mirror_alignment(
+            repo_root / "docs" / "source",
+            source,
+        )
+    except Exception as exc:
+        status, message = "fail", str(exc)
+    return _check_result(
+        "docs_canonical_alignment",
+        "Canonical-to-public docs alignment",
+        status == "pass",
+        message,
+        evidence=["docs/.docs_source_mirror_stamp.json", "tools/sync_docs_source.py"],
+        details={
+            "canonical_source": str(source) if source is not None else None,
+            "canonical_alignment_checked": status != "skipped",
+        },
+        status_override=status,
     )
 
 
@@ -924,6 +955,7 @@ def build_report(*, repo_root: Path = REPO_ROOT, run_docs_profile: bool = False)
     repo_root = repo_root.resolve()
     checks = [
         _check_docs_mirror_stamp(repo_root),
+        _check_docs_canonical_alignment(repo_root),
         _check_docs_workflow_profile(repo_root),
         _check_production_readiness_workflow_profile(repo_root),
         _check_architecture_scorecard(repo_root),
@@ -945,6 +977,7 @@ def build_report(*, repo_root: Path = REPO_ROOT, run_docs_profile: bool = False)
 
     passed = sum(1 for check in checks if check["status"] == "pass")
     failed = sum(1 for check in checks if check["status"] == "fail")
+    skipped = sum(1 for check in checks if check["status"] == "skipped")
     return {
         "kpi": "Production readiness",
         "supported_score": SUPPORTED_SCORE,
@@ -952,6 +985,7 @@ def build_report(*, repo_root: Path = REPO_ROOT, run_docs_profile: bool = False)
         "summary": {
             "passed": passed,
             "failed": failed,
+            "skipped": skipped,
             "total": len(checks),
             "docs_profile_executed": run_docs_profile,
         },

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -2330,19 +2330,10 @@ def update_release_proof_references_in_source(tag: str, docs_source: pathlib.Pat
 
 def update_release_proof_references(tag: str) -> None:
     public_source = REPO_ROOT / "docs/source"
-
-    docs_repo, source = find_docs_repository()
-    if docs_repo:
-        canonical_source = docs_repo / "docs/source"
-        manifest = canonical_source / "data/release_proof.toml"
-        if not manifest.exists():
-            raise SystemExit(f"ERROR: canonical release proof manifest not found: {manifest}")
-        update_release_proof_references_in_source(tag, canonical_source)
-        sync_docs_source_mirror(canonical_source)
-        return
-
-    if public_source.exists():
-        update_release_proof_references_in_source(tag, public_source)
+    manifest = public_source / "data/release_proof.toml"
+    if not manifest.exists():
+        raise SystemExit(f"ERROR: public release proof manifest not found: {manifest}")
+    update_release_proof_references_in_source(tag, public_source)
 
 
 def update_public_docs_mirror_stamp_from_current_tree() -> None:
@@ -2354,11 +2345,9 @@ def update_public_docs_mirror_stamp_from_current_tree() -> None:
         [
             sys.executable,
             str(script),
-            "--source",
-            str(public_source),
             "--target",
             str(public_source),
-            "--apply",
+            "--write-target-only-stamp",
             "--quiet",
         ],
         cwd=REPO_ROOT,

--- a/tools/sync_docs_source.py
+++ b/tools/sync_docs_source.py
@@ -3,20 +3,35 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import sys
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-import unicodedata
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SOURCE = REPO_ROOT.parent / "thales_agilab" / "docs" / "source"
 DEFAULT_TARGET = REPO_ROOT / "docs" / "source"
+DOCS_SOURCE_ENV = "AGILAB_DOCS_SOURCE"
 STAMP_FILE_NAME = ".docs_source_mirror_stamp.json"
-STAMP_FORMAT_VERSION = 1
+STAMP_FORMAT_VERSION = 2
+STAMP_MANAGED_TARGET = "docs/source"
+STAMP_SOURCE_HINT = "../thales_agilab/docs/source"
+STAMP_SYNC_TOOL = "tools/sync_docs_source.py"
 IGNORED_FILE_NAMES = {".DS_Store"}
 IGNORED_DIR_NAMES = {"__pycache__", ".ipynb_checkpoints"}
+PUBLIC_OWNED_EXCLUSIONS = frozenset(
+    {
+        "data/release_proof.toml",
+        "data/ui_robot_evidence.json",
+        "release-proof.rst",
+    }
+)
+CANONICAL_DRIFT_NOT_CHECKED = (
+    "canonical docs source unavailable; target integrity only; "
+    "canonical drift NOT CHECKED"
+)
 
 
 @dataclass(frozen=True)
@@ -30,6 +45,8 @@ class SyncPlan:
 
 
 def _should_include(rel_path: Path) -> bool:
+    if _normalized_rel_path(rel_path) in PUBLIC_OWNED_EXCLUSIONS:
+        return False
     return not any(
         part in IGNORED_DIR_NAMES or part in IGNORED_FILE_NAMES
         for part in rel_path.parts
@@ -81,18 +98,64 @@ def stamp_path_for_target(target: Path) -> Path:
     return target.parent / STAMP_FILE_NAME
 
 
-def build_mirror_stamp(source: Path, target: Path) -> dict[str, int | str]:
-    source_state = _manifest_state(source)
+def configured_canonical_source() -> Path:
+    configured = os.environ.get(DOCS_SOURCE_ENV)
+    return Path(configured).expanduser() if configured else DEFAULT_SOURCE
+
+
+def _stamp_payload(
+    target: Path,
+    *,
+    source_status: str,
+    source_digest_sha256: str | None,
+) -> dict[str, object]:
     target_state = _manifest_state(target)
     return {
         "format_version": STAMP_FORMAT_VERSION,
-        "managed_target": "docs/source",
-        "source_hint": "../thales_agilab/docs/source",
-        "source_digest_sha256": source_state["digest_sha256"],
+        "managed_target": STAMP_MANAGED_TARGET,
+        "public_owned_exclusions": sorted(PUBLIC_OWNED_EXCLUSIONS),
+        "source_hint": STAMP_SOURCE_HINT,
+        "source_status": source_status,
+        "source_digest_sha256": source_digest_sha256,
         "target_digest_sha256": target_state["digest_sha256"],
         "file_count": target_state["file_count"],
-        "sync_tool": "tools/sync_docs_source.py",
+        "sync_tool": STAMP_SYNC_TOOL,
     }
+
+
+def build_mirror_stamp(source: Path, target: Path) -> dict[str, object]:
+    if not source.is_dir():
+        raise ValueError(f"canonical source is not a directory: {source}")
+    if not target.is_dir():
+        raise ValueError(f"mirror target is not a directory: {target}")
+    if source.resolve() == target.resolve():
+        raise ValueError(
+            "canonical source and mirror target resolve to the same directory; "
+            "refusing to manufacture canonical mirror evidence"
+        )
+
+    source_state = _manifest_state(source)
+    target_state = _manifest_state(target)
+    if source_state != target_state:
+        raise ValueError(
+            "canonical source and managed mirror target differ; apply the complete "
+            "sync plan before writing verified mirror evidence"
+        )
+    return _stamp_payload(
+        target,
+        source_status="verified",
+        source_digest_sha256=str(source_state["digest_sha256"]),
+    )
+
+
+def build_target_only_mirror_stamp(target: Path) -> dict[str, object]:
+    if not target.is_dir():
+        raise ValueError(f"mirror target is not a directory: {target}")
+    return _stamp_payload(
+        target,
+        source_status="unavailable",
+        source_digest_sha256=None,
+    )
 
 
 def write_mirror_stamp(source: Path, target: Path) -> Path:
@@ -104,7 +167,22 @@ def write_mirror_stamp(source: Path, target: Path) -> Path:
     return stamp_path
 
 
-def verify_mirror_stamp(target: Path) -> tuple[bool, str]:
+def write_target_only_mirror_stamp(target: Path) -> Path:
+    stamp_path = stamp_path_for_target(target)
+    stamp_path.write_text(
+        json.dumps(build_target_only_mirror_stamp(target), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    return stamp_path
+
+
+def verify_mirror_stamp(
+    target: Path,
+    source: Path | None = None,
+    *,
+    skip_missing_source: bool = False,
+) -> tuple[bool, str]:
     stamp_path = stamp_path_for_target(target)
     if not stamp_path.exists():
         return False, f"missing mirror stamp: {stamp_path}"
@@ -114,10 +192,55 @@ def verify_mirror_stamp(target: Path) -> tuple[bool, str]:
     except json.JSONDecodeError as exc:
         return False, f"invalid mirror stamp {stamp_path}: {exc}"
 
+    if not isinstance(stamp, dict):
+        return False, f"invalid mirror stamp {stamp_path}: expected a JSON object"
+
     if stamp.get("format_version") != STAMP_FORMAT_VERSION:
         return False, (
             f"unsupported mirror stamp format in {stamp_path}: "
-            f"{stamp.get('format_version')!r}"
+            f"{stamp.get('format_version')!r}; regenerate with "
+            "`python tools/sync_docs_source.py --apply --delete` when the "
+            "canonical source is available, or "
+            "`python tools/sync_docs_source.py --write-target-only-stamp` "
+            "for explicit target-only evidence"
+        )
+
+    expected_identity = {
+        "managed_target": STAMP_MANAGED_TARGET,
+        "source_hint": STAMP_SOURCE_HINT,
+        "sync_tool": STAMP_SYNC_TOOL,
+    }
+    for field, expected in expected_identity.items():
+        if stamp.get(field) != expected:
+            return False, (
+                f"mirror stamp {field} mismatch in {stamp_path}: expected "
+                f"{expected!r}, got {stamp.get(field)!r}"
+            )
+
+    expected_exclusions = sorted(PUBLIC_OWNED_EXCLUSIONS)
+    if stamp.get("public_owned_exclusions") != expected_exclusions:
+        return False, (
+            f"mirror stamp exclusions mismatch in {stamp_path}: expected "
+            f"{expected_exclusions!r}, got {stamp.get('public_owned_exclusions')!r}"
+        )
+
+    source_status = stamp.get("source_status")
+    source_digest = stamp.get("source_digest_sha256")
+    if source_status not in {"verified", "unavailable"}:
+        return False, (
+            f"invalid source_status in {stamp_path}: {source_status!r}"
+        )
+    if source_status == "verified":
+        if not isinstance(source_digest, str) or not source_digest:
+            return False, f"verified mirror stamp has no source digest: {stamp_path}"
+        if source_digest != stamp.get("target_digest_sha256"):
+            return False, (
+                f"verified mirror stamp records unequal source and target digests: "
+                f"{stamp_path}"
+            )
+    elif source_digest is not None:
+        return False, (
+            f"unavailable-source mirror stamp must use a null source digest: {stamp_path}"
         )
 
     state = _manifest_state(target)
@@ -132,7 +255,80 @@ def verify_mirror_stamp(target: Path) -> tuple[bool, str]:
             f"{stamp.get('target_digest_sha256')}, got {state['digest_sha256']}"
         )
 
-    return True, f"mirror stamp ok: {stamp_path}"
+    if source is None:
+        if not skip_missing_source:
+            return False, (
+                "canonical docs source was not supplied; rerun with a canonical "
+                "--source or explicitly allow --skip-missing-source"
+            )
+        return True, f"{CANONICAL_DRIFT_NOT_CHECKED}: source path not supplied"
+
+    if not source.exists():
+        if not skip_missing_source:
+            return False, (
+                f"canonical docs source not found: {source}; rerun with "
+                "--skip-missing-source only when target-only integrity is intended"
+            )
+        return True, f"{CANONICAL_DRIFT_NOT_CHECKED}: {source}"
+    if not source.is_dir():
+        return False, f"canonical docs source is not a directory: {source}"
+    if source.resolve() == target.resolve():
+        return False, (
+            "canonical source and mirror target resolve to the same directory; "
+            "canonical drift cannot be verified"
+        )
+
+    source_state = _manifest_state(source)
+    if source_status == "unavailable":
+        if source_state != state:
+            return False, (
+                f"canonical source drift for {source}: current managed state "
+                "does not match the target-only stamped mirror"
+            )
+        return True, (
+            "mirror target integrity ok; canonical source currently matches the "
+            "managed target, but the stored stamp remains source_status=unavailable"
+        )
+
+    if source_state["digest_sha256"] != source_digest:
+        return False, (
+            f"canonical source drift for {source}: stamp expected digest "
+            f"{source_digest}, got {source_state['digest_sha256']}"
+        )
+    if source_state["file_count"] != stamp.get("file_count"):
+        return False, (
+            f"canonical source drift for {source}: stamp expected file_count "
+            f"{stamp.get('file_count')}, got {source_state['file_count']}"
+        )
+
+    return True, f"mirror stamp ok: {stamp_path}; canonical source verified: {source}"
+
+
+def verify_target_mirror_integrity(target: Path) -> tuple[bool, str]:
+    """Verify only the checked-in public mirror and its stamped identity."""
+    ok, message = verify_mirror_stamp(
+        target,
+        source=None,
+        skip_missing_source=True,
+    )
+    if ok:
+        return True, f"checked-in docs mirror target integrity verified: {target}"
+    return False, message
+
+
+def verify_canonical_mirror_alignment(
+    target: Path,
+    source: Path,
+) -> tuple[str, str]:
+    """Return pass, fail, or skipped for live canonical-to-public alignment."""
+    if not source.exists():
+        return "skipped", f"{CANONICAL_DRIFT_NOT_CHECKED}: {source}"
+    ok, message = verify_mirror_stamp(
+        target,
+        source,
+        skip_missing_source=False,
+    )
+    return ("pass" if ok else "fail"), message
 
 
 def make_sync_plan(source: Path, target: Path, *, delete_extra: bool) -> SyncPlan:
@@ -196,14 +392,15 @@ def build_parser() -> argparse.ArgumentParser:
             "thales_agilab/docs/source tree."
         )
     )
-    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--source", type=Path, default=configured_canonical_source())
     parser.add_argument("--target", type=Path, default=DEFAULT_TARGET)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--check",
         action="store_true",
         help="Check for drift without applying changes. This is the default mode.",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--apply",
         action="store_true",
         help="Copy created/updated files into the target mirror.",
@@ -218,12 +415,20 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Suppress the sync summary output when nothing changes.",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--verify-stamp",
         action="store_true",
         help=(
-            "Verify that the managed docs/source mirror stamp matches the current "
-            "target tree. This does not require access to the canonical source tree."
+            "Verify target integrity and canonical-source drift. Use "
+            "--skip-missing-source to explicitly accept target-only verification."
+        ),
+    )
+    mode.add_argument(
+        "--write-target-only-stamp",
+        action="store_true",
+        help=(
+            "Write target-integrity evidence with source_status=unavailable. "
+            "This never claims that the canonical source was checked."
         ),
     )
     parser.add_argument(
@@ -245,20 +450,48 @@ def main(argv: list[str] | None = None) -> int:
 
     target = args.target.expanduser().resolve()
 
+    if args.write_target_only_stamp:
+        if not target.exists():
+            parser.error(f"target directory not found: {target}")
+        if not target.is_dir():
+            parser.error(f"target path is not a directory: {target}")
+        try:
+            stamp_path = write_target_only_mirror_stamp(target)
+        except ValueError as exc:
+            print(f"mirror stamp not written: {exc}", file=sys.stderr)
+            return 1
+        if not args.quiet:
+            print(
+                f"target-only mirror stamp written: {stamp_path}; "
+                "canonical drift NOT CHECKED"
+            )
+        return 0
+
     if args.verify_stamp:
         if not target.exists():
             parser.error(f"target directory not found: {target}")
-        ok, message = verify_mirror_stamp(target)
-        if not ok or not args.quiet:
+        source = args.source.expanduser().resolve()
+        ok, message = verify_mirror_stamp(
+            target,
+            source,
+            skip_missing_source=args.skip_missing_source,
+        )
+        if not ok or not args.quiet or "canonical drift NOT CHECKED" in message:
             print(message)
         return 0 if ok else 1
 
     source = args.source.expanduser().resolve()
     if not source.exists():
         if args.skip_missing_source and not args.apply:
-            if not args.quiet:
-                print(f"canonical docs source not found; skipped mirror drift check: {source}")
-            return 0
+            if not target.exists():
+                parser.error(f"target directory not found: {target}")
+            ok, message = verify_mirror_stamp(
+                target,
+                source,
+                skip_missing_source=True,
+            )
+            print(message)
+            return 0 if ok else 1
         parser.error(f"source directory not found: {source}")
     if not source.is_dir():
         parser.error(f"source path is not a directory: {source}")
@@ -271,7 +504,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.apply:
         apply_sync_plan(source, target, plan)
-        write_mirror_stamp(source, target)
+        try:
+            write_mirror_stamp(source, target)
+        except ValueError as exc:
+            print(f"mirror stamp not written: {exc}", file=sys.stderr)
+            return 1
         return 0
 
     return 1 if plan.has_changes() else 0


### PR DESCRIPTION
## Summary

- introduce mirror-stamp v2 with explicit verified/unavailable source status, stable evidence identity, exact public-owned exclusions, and fail-closed migration diagnostics
- make the public repository own the release-proof manifest, generated proof page, and UI robot evidence while canonical sync preserves those three paths
- separate checked-in target integrity from live canonical alignment so an absent private checkout is machine-visible as skipped instead of passed
- update release, docs CI, pre-push, audit, maintenance, agent-context, and packaged-help call sites to state whether canonical drift was checked

## Repro

Public CI cannot access the private canonical checkout. The old stamp proved only the current public target, while several callers either failed on the missing source or converted a skipped canonical comparison into a passing readiness/KPI check. Release tooling also refreshed proof files through the private tree, allowing the private mirror to overwrite public release evidence.

## Root Cause

The mirror contract conflated two independent owners and two independent claims: managed canonical documentation versus public release evidence, and target integrity versus canonical alignment. Callers reimplemented missing-source behavior inconsistently, and the stamp did not validate its producer/target identity.

## Regression Test

Tests cover exact public-owned exclusions, preserved sync/delete behavior, verified and target-only stamps, malformed/non-object/v1/forged-identity stamps, source and target drift, explicit missing-source warnings, skipped canonical alignment in both evidence reports, release-audit argv, public release ownership, workflow labels, pre-push classification, environment-selected canonical sources, agent-context commands, and packaged help.

## Validation

- Targeted public suite: 284 passed with the UI extra required by the KPI/report dependencies
- Docs workflow parity: PASS; Sphinx built 126 sources
- Release proof: 12/12 checks passed
- PyPI release-plan and trusted-publisher workflow contracts: PASS
- Dependency-policy and shared-skill workflow profiles: PASS
- Cross-repository mirror verification: PASS
- Private ownership guard suite: 9 passed
- Impact validation, agent provenance, instruction contract, skill drift/security checks, focused Ruff, and diff checks: PASS

Browser robot validation is not applicable: this change modifies documentation/tooling contracts and static help guidance, not Streamlit navigation or widget behavior. All 11 required GitHub checks, including GitGuardian and root-tests, are green; public-demo-smoke was expectedly skipped.

## Review Evidence

- docs_stamp_v2_impl, model unknown, edited the initial stamp-v2 implementation and focused tests; findings incorporated
- docs_v2_callsites, model unknown, edited public call sites and focused regressions; findings incorporated
- private_docs_ownership_guard, model unknown, edited only the coordinated private worktree; no files in this PR
- docs_ownership_adversarial, model unknown, read-only adversarial review; all blockers addressed and final result no remaining blocker

## Agent Metadata

- Tokki: 1.0.39
- Agent/runtime: OpenAI Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- Fast mode: not used