### PR TITLE
fix(docs): keep mirror evidence consistent

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1062,7 +1062,7 @@ jobs:
             --compact
           python tools/sync_docs_source.py \
             --target docs/source \
-            --write-target-only-stamp \
+            --refresh-target-integrity-stamp \
             --quiet
 
           release_metadata_paths=(

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -378,13 +378,14 @@ def test_docs_workflows_label_target_only_verification_honestly() -> None:
     assert "--check --delete --quiet --skip-missing-source" not in guard_text
 
 
-def test_release_workflow_writes_an_explicit_target_only_mirror_stamp() -> None:
+def test_release_workflow_preserves_valid_mirror_evidence_before_degrading() -> None:
     text = PYPI_PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
     stamp_block = text.split("python tools/sync_docs_source.py", 1)[1].split(
         "release_metadata_paths=", 1
     )[0]
 
-    assert "--write-target-only-stamp" in stamp_block
+    assert "--refresh-target-integrity-stamp" in stamp_block
+    assert "--write-target-only-stamp" not in stamp_block
     assert "--source docs/source" not in stamp_block
 
 

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -1302,7 +1302,7 @@ def test_update_release_proof_references_refreshes_public_owned_proof_only(
     assert "https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.24" in command
 
 
-def test_update_public_docs_mirror_stamp_marks_canonical_source_unavailable(
+def test_update_public_docs_mirror_stamp_preserves_valid_existing_evidence(
     tmp_path, monkeypatch
 ) -> None:
     module = _load_pypi_publish()
@@ -1322,7 +1322,8 @@ def test_update_public_docs_mirror_stamp_marks_canonical_source_unavailable(
     module.update_public_docs_mirror_stamp_from_current_tree()
 
     command = commands[0]
-    assert "--write-target-only-stamp" in command
+    assert "--refresh-target-integrity-stamp" in command
+    assert "--write-target-only-stamp" not in command
     assert "--source" not in command
     assert command[command.index("--target") + 1] == str(public_source)
 

--- a/test/test_sync_docs_source.py
+++ b/test/test_sync_docs_source.py
@@ -194,6 +194,36 @@ def test_main_check_and_apply_modes(tmp_path: Path, capsys) -> None:
     )
 
 
+def test_apply_without_delete_fails_before_mutating_target_or_stamp(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("canonical\n", encoding="utf-8")
+    (source / "new.rst").write_text("new\n", encoding="utf-8")
+    (target / "guide.rst").write_text("stale\n", encoding="utf-8")
+    (target / "removed.rst").write_text("extra\n", encoding="utf-8")
+    stamp_path = module.write_target_only_mirror_stamp(target)
+    stamp_before = stamp_path.read_bytes()
+
+    exit_code = module.main(
+        ["--source", str(source), "--target", str(target), "--apply"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "No changes were applied" in captured.err
+    assert "rerun with --apply --delete" in captured.err
+    assert (target / "guide.rst").read_text(encoding="utf-8") == "stale\n"
+    assert not (target / "new.rst").exists()
+    assert (target / "removed.rst").read_text(encoding="utf-8") == "extra\n"
+    assert stamp_path.read_bytes() == stamp_before
+
+
 def test_main_missing_canonical_source_requires_explicit_degraded_mode(
     tmp_path: Path,
     capsys,
@@ -366,6 +396,114 @@ def test_target_only_stamp_is_explicitly_noncanonical(tmp_path: Path, capsys) ->
     )
     assert exit_code == 1
     assert "canonical source drift" in capsys.readouterr().out
+
+
+def test_refresh_target_integrity_stamp_preserves_verified_evidence_for_exclusions(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    release_proof = target / "data" / "release_proof.toml"
+    release_proof.parent.mkdir(parents=True)
+    release_proof.write_text("[release]\n", encoding="utf-8")
+
+    exit_code = module.main(
+        ["--target", str(target), "--refresh-target-integrity-stamp"]
+    )
+
+    assert exit_code == 0
+    assert "existing mirror stamp preserved" in capsys.readouterr().out
+    assert stamp_path.read_bytes() == stamp_before
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    assert payload["source_status"] == "verified"
+    assert payload["source_digest_sha256"] == payload["target_digest_sha256"]
+
+
+def test_refresh_target_integrity_stamp_downgrades_changed_managed_target(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    (target / "guide.rst").write_text("release changed managed docs\n", encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--target",
+            str(target),
+            "--refresh-target-integrity-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    assert payload["source_status"] == "unavailable"
+    assert payload["source_digest_sha256"] is None
+    assert payload["target_digest_sha256"] == module._manifest_state(target)[
+        "digest_sha256"
+    ]
+
+
+def test_refresh_target_integrity_stamp_preserves_valid_target_only_evidence(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    stamp_path = module.write_target_only_mirror_stamp(target)
+    stamp_before = stamp_path.read_bytes()
+
+    exit_code = module.main(
+        [
+            "--target",
+            str(target),
+            "--refresh-target-integrity-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 0
+    assert stamp_path.read_bytes() == stamp_before
+
+
+def test_refresh_target_integrity_stamp_repairs_missing_stamp_honestly(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    stamp_path = module.stamp_path_for_target(target)
+    assert not stamp_path.exists()
+
+    exit_code = module.main(
+        [
+            "--target",
+            str(target),
+            "--refresh-target-integrity-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    assert payload["source_status"] == "unavailable"
+    assert payload["source_digest_sha256"] is None
 
 
 def test_target_only_stamp_still_detects_target_mutation(

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -2347,7 +2347,7 @@ def update_public_docs_mirror_stamp_from_current_tree() -> None:
             str(script),
             "--target",
             str(public_source),
-            "--write-target-only-stamp",
+            "--refresh-target-integrity-stamp",
             "--quiet",
         ],
         cwd=REPO_ROOT,

--- a/tools/sync_docs_source.py
+++ b/tools/sync_docs_source.py
@@ -177,6 +177,26 @@ def write_target_only_mirror_stamp(target: Path) -> Path:
     return stamp_path
 
 
+def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
+    """Preserve valid evidence or replace stale evidence with target-only state.
+
+    Release-owned exclusions do not contribute to the managed target digest.
+    When only those files changed, an existing verified canonical stamp remains
+    valid and must not be downgraded. A missing, malformed, or stale stamp is
+    replaced with honest target-only evidence.
+    """
+
+    stamp_path = stamp_path_for_target(target)
+    target_ok, _message = verify_mirror_stamp(
+        target,
+        source=None,
+        skip_missing_source=True,
+    )
+    if target_ok:
+        return stamp_path, False
+    return write_target_only_mirror_stamp(target), True
+
+
 def verify_mirror_stamp(
     target: Path,
     source: Path | None = None,
@@ -431,6 +451,15 @@ def build_parser() -> argparse.ArgumentParser:
             "This never claims that the canonical source was checked."
         ),
     )
+    mode.add_argument(
+        "--refresh-target-integrity-stamp",
+        action="store_true",
+        help=(
+            "Preserve an existing valid mirror stamp when the managed target is "
+            "unchanged; otherwise write target-only evidence with "
+            "source_status=unavailable."
+        ),
+    )
     parser.add_argument(
         "--skip-missing-source",
         action="store_true",
@@ -449,6 +478,22 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     target = args.target.expanduser().resolve()
+
+    if args.refresh_target_integrity_stamp:
+        if not target.exists():
+            parser.error(f"target directory not found: {target}")
+        if not target.is_dir():
+            parser.error(f"target path is not a directory: {target}")
+        stamp_path, written = refresh_target_integrity_stamp(target)
+        if not args.quiet:
+            if written:
+                print(
+                    f"target-only mirror stamp written: {stamp_path}; "
+                    "canonical drift NOT CHECKED"
+                )
+            else:
+                print(f"existing mirror stamp preserved: {stamp_path}")
+        return 0
 
     if args.write_target_only_stamp:
         if not target.exists():
@@ -497,12 +542,30 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"source path is not a directory: {source}")
 
     target.mkdir(parents=True, exist_ok=True)
-    plan = make_sync_plan(source, target, delete_extra=args.delete)
+    complete_plan = make_sync_plan(source, target, delete_extra=True)
+    plan = (
+        complete_plan
+        if args.delete
+        else SyncPlan(
+            created=complete_plan.created,
+            updated=complete_plan.updated,
+            deleted=[],
+        )
+    )
 
     if plan.has_changes() or not args.quiet:
         print(render_plan(plan, source=source, target=target))
 
     if args.apply:
+        if complete_plan.deleted and not args.delete:
+            print(
+                "sync not applied: the managed mirror contains "
+                f"{len(complete_plan.deleted)} file(s) absent from the canonical "
+                "source. No changes were applied; rerun with --apply --delete "
+                "so the complete sync plan and verified stamp stay aligned",
+                file=sys.stderr,
+            )
+            return 1
         apply_sync_plan(source, target, plan)
         try:
             write_mirror_stamp(source, target)


### PR DESCRIPTION
## Summary

- reject incomplete `--apply` mirror operations before the first filesystem mutation when managed target-only files require `--delete`
- refresh release-time mirror evidence without erasing still-valid canonical-source verification
- cover both Python release paths and the PyPI workflow's later release-proof commit step

## Repro

With a canonical source update plus a managed target-only file, run `sync_docs_source.py --apply` without `--delete`. Before this fix, the source update was copied first, stamp publication then failed, and the checkout was left mutated behind stale evidence.

Run a release from a checkout whose committed stamp is `source_status: verified`. Before this fix, both release stamp refresh paths unconditionally used `--write-target-only-stamp`, replacing verified canonical evidence with `source_status: unavailable` even when only public-owned exclusions changed.

## Root Cause

1. The sync plan removed target-only paths from the displayed/applied plan before checking whether the post-apply trees could support a verified mirror stamp. The equality failure was therefore detected only after mutation.
2. Release publication treated stamp refresh as stamp replacement. It did not first validate whether the existing evidence still matched the managed mirror target, and a second workflow call repeated the unconditional downgrade.

## Fix

- Build the complete sync plan first. If `--apply` omits `--delete` while managed target-only files exist, fail before `apply_sync_plan` with an actionable `--apply --delete` instruction.
- Add `--refresh-target-integrity-stamp`: preserve a valid existing stamp byte-for-byte; otherwise write an honest target-only stamp with unavailable canonical provenance.
- Use the refresh mode from `pypi_publish.py` and both release workflow stamp-refresh sites.

This provides deterministic preflight behavior for the reported incomplete-plan case; it does not claim a general filesystem transaction across arbitrary I/O failures or concurrent mutations.

## Regression Test

- updated and newly created source files remain unapplied when a target-only file makes `--delete` necessary
- the old stamp remains byte-identical on that rejected operation
- a verified stamp survives excluded release-proof changes byte-for-byte
- managed-target drift downgrades to an honest unavailable stamp
- valid target-only evidence is preserved, while a missing stamp is created
- Python and workflow command contracts reject the old unconditional release mode

## Validation

- Focused suites: 136 passed
- Impact-selected bugfix suite: 414 passed, 2 skipped
  - live GitHub AI scraper discovery skipped because `AGILAB_GITHUB_AI_SCRAPER_LIVE=1` was not enabled
  - slow fresh-clone release proof skipped because `AGILAB_RUN_RELEASE_PROOF_SLOW=1` was not enabled
- Canonical docs mirror validation passed against `/Users/agi/PycharmProjects/thales_agilab/docs/source`
- Existing verified stamp remained byte-identical after refresh
- Release-plan and trusted-publisher workflow contracts passed
- Ruff, diff hygiene, scope, and agent provenance checks passed
- GitHub CI: all 10 applicable repository checks passed; GitGuardian passed
  - `public-demo-smoke` skipped by design because it runs only for scheduled or manually dispatched workflows, not pull requests

## Review Evidence

- Codex sub-agent (model inherited; exact model version unavailable), read-only: independently reproduced the pre-apply mutation and confirmed the preflight boundary.
- Codex sub-agent (model inherited; exact model version unavailable), read-only: audited release stamp ownership, identified the second workflow downgrade site, and found no remaining blocker after the fix.
- All confirmed review findings were addressed. The unavailable ultracode review is not represented as having run.

## Agent Metadata

- Tokki: 1.0.40
- Agent/runtime: Codex (version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
