### PR TITLE
fix(notebooks): lead notebook export with the app-owned related-page contract

### DIFF
--- a/src/agilab/notebooks/notebook_export_support.py
+++ b/src/agilab/notebooks/notebook_export_support.py
@@ -611,7 +611,7 @@ def _build_view_sync_snapshot(
     modules = [page.module for page in related_pages if page.module]
     payload = {
         "schema": "agilab.notebook_view_sync.v1",
-        "source": "app_settings_and_page_bundles",
+        "source": "notebook_export_manifest_and_app_settings",
         "related_page_modules": modules,
         "sources": normalized_sources,
     }
@@ -796,7 +796,15 @@ def build_notebook_export_context(
         "",
     )
     page_manifest, manifest_order = _load_related_page_manifest(active_app)
-    related_pages = _load_related_pages_from_settings(settings_file) or _load_related_pages_from_settings(source_settings) or manifest_order
+    settings_pages = _load_related_pages_from_settings(
+        settings_file
+    ) or _load_related_pages_from_settings(source_settings)
+    # The app-owned notebook_export.toml is the curated export contract
+    # (labels, artifact globs, launch notes); it leads the related-page list.
+    # Settings-only pages are appended so live view selections stay visible.
+    related_pages = tuple(
+        dict.fromkeys((*manifest_order, *settings_pages))
+    )
     pages_root = _normalize_path(getattr(env, "AGILAB_PAGES_ABS", ""))
     related_page_records_list: list[RelatedPageExport] = []
     for page in related_pages:
@@ -1524,7 +1532,7 @@ def _related_page_manifest_records(metadata: Mapping[str, Any]) -> list[dict[str
                 "label": str(page.get("label", "") or ""),
                 "description": str(page.get("description", "") or ""),
                 "artifacts": [str(item) for item in page.get("artifacts", []) if str(item or "").strip()]
-                if isinstance(page.get("artifacts", []), list)
+                if isinstance(page.get("artifacts", []), (list, tuple))
                 else [],
                 "launch_note": str(page.get("launch_note", "") or ""),
                 "script_path": str(page.get("script_path", "") or ""),

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -2289,6 +2289,32 @@ def test_notebook_export_and_import_cleanup_edge_helpers(monkeypatch, tmp_path, 
     assert support._project_notebook_mirror_path(context, "lab_stages.ipynb") is None
 
 
+def test_related_page_manifest_records_accept_tuple_artifacts():
+    """RelatedPageExport.artifacts is a tuple; manifest records must keep them.
+
+    Regression: asdict(RelatedPageExport) leaves artifacts as a tuple and the
+    manifest builder silently dropped every curated artifact glob
+    (sb3_trainer_project exports shipped related pages with zero artifacts).
+    """
+    records = notebook_export_support._related_page_manifest_records(
+        {
+            "related_pages": [
+                {
+                    "module": "view_curated",
+                    "label": "Curated",
+                    "artifacts": ("demo/*.json", "", "demo/*.csv"),
+                },
+                {
+                    "module": "view_list",
+                    "artifacts": ["plain.json"],
+                },
+            ]
+        }
+    )
+    assert records[0]["artifacts"] == ["demo/*.json", "demo/*.csv"]
+    assert records[1]["artifacts"] == ["plain.json"]
+
+
 def test_notebook_export_related_page_and_provider_edge_helpers(monkeypatch, tmp_path):
     support = notebook_export_support
 
@@ -3513,6 +3539,74 @@ launch_note = "Open this after the run."
         "analysis_page_script",
         "analysis_page_inline_renderer",
     } <= sync_kinds
+
+
+def test_build_notebook_export_context_manifest_leads_settings_pages(tmp_path):
+    """The app-owned notebook_export.toml contract must not lose to user settings.
+
+    Regression for the sb3_trainer_project export: the app ships a curated
+    related-pages manifest (labels, artifact globs, launch notes) while the
+    workspace settings list different generic views. The export must lead with
+    the curated manifest pages and append settings-only pages, instead of
+    dropping the manifest wholesale.
+    """
+    pages_root = tmp_path / "apps-pages"
+    for module in ("view_curated", "view_generic"):
+        page_script = pages_root / module / "src" / module / f"{module}.py"
+        page_script.parent.mkdir(parents=True, exist_ok=True)
+        page_script.write_text("print('page')\n", encoding="utf-8")
+
+    source_app = tmp_path / "apps" / "demo_project"
+    source_settings = source_app / "src" / "app_settings.toml"
+    source_settings.parent.mkdir(parents=True, exist_ok=True)
+    source_settings.write_text("[pages]\nview_module=['view_generic']\n", encoding="utf-8")
+    (source_app / "notebook_export.toml").write_text(
+        """
+[notebook_export]
+
+[[notebook_export.related_pages]]
+module = "view_curated"
+label = "Curated Analysis"
+description = "Curated export contract page."
+artifacts = ["demo/pipeline/*/allocations_steps.json"]
+launch_note = "Open this first."
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    workspace_settings = tmp_path / ".agilab" / "apps" / "demo_project" / "app_settings.toml"
+    workspace_settings.parent.mkdir(parents=True, exist_ok=True)
+    workspace_settings.write_text("[pages]\nview_module=['view_generic']\n", encoding="utf-8")
+
+    env = SimpleNamespace(
+        AGILAB_PAGES_ABS=pages_root,
+        active_app=source_app,
+        app_settings_file=workspace_settings,
+        resolve_user_app_settings_file=lambda app_name, ensure_exists=False: workspace_settings,
+        find_source_app_settings_file=lambda app_name: source_settings,
+        read_agilab_path=lambda: tmp_path,
+    )
+
+    context = pipeline_editor.build_notebook_export_context(
+        env,
+        Path("demo_project"),
+        tmp_path / "export" / "demo_project" / "lab_stages.toml",
+        project_name="demo_project",
+    )
+
+    assert tuple(page.module for page in context.related_pages) == (
+        "view_curated",
+        "view_generic",
+    )
+    curated = context.related_pages[0]
+    assert curated.label == "Curated Analysis"
+    assert curated.artifacts == ("demo/pipeline/*/allocations_steps.json",)
+    assert curated.launch_note == "Open this first."
+    generic = context.related_pages[1]
+    assert generic.module == "view_generic"
+    assert generic.label == ""
+    assert context.view_sync["related_page_modules"] == ["view_curated", "view_generic"]
 
 
 def test_notebook_export_view_sync_detects_changed_analysis_page_source(tmp_path):


### PR DESCRIPTION
## Summary
- The notebook exporter let the workspace `app_settings` view list override the app-owned `notebook_export.toml` manifest wholesale. Curated related pages (labels, artifact globs, launch notes) were dropped whenever user settings diverged — `sb3_trainer_project`'s export showed two generic pages with zero artifacts instead of its five curated ones. Related pages now lead with the manifest order and append settings-only pages.
- `_related_page_manifest_records` silently emptied artifact lists for tuple sequences (`asdict(RelatedPageExport)` keeps `artifacts` as a tuple), so every in-memory manifest build lost the curated artifact globs.
- `view_sync.source` label updated to `notebook_export_manifest_and_app_settings` to reflect the merge (no consumer reads the value; sources list unchanged).

## Effect on sb3_trainer_project
Regenerated exports now carry real stage ids (`flight_install` … `kpi_summary`) in topological order — `kpi_summary` runs after all seven of its dependencies instead of before three of them — and the full curated related-page contract (5 pages with artifacts, then settings extras).

## Validation
- `uv run pytest test/test_pipeline_editor.py test/test_notebook_export_overwrite.py test/test_notebook_export_docs.py test/test_notebook_app_roundtrip.py test/test_notebook_pipeline_import_report.py test/test_analysis_page_helpers.py` → 233 passed
- sb3 app-local: `test_workflow_stage_contract.py test_notebook_portability.py` → 9 passed (tracked plain notebook untouched)
- `./dev impact --files …` → required slice green

🤖 Generated with [Claude Code](https://claude.com/claude-code)