### PR TITLE
docs(diagrams): sync arrow-collision and overflow fixes from canonical

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "5bee4250964fcbb8c1b0b2646c80338e01248a08f599e90b26681b22b54e6617",
     "release-proof.rst": "fa2c88ad0a60cd30d6cca2899d0defaca43c3345209663c3907bfa3dc36ce084"
   },
-  "source_digest_sha256": "2a9f314bc386459c9cf1b4232e8c656a8e2129a740a5f321a9f0c5b9d4d77692",
+  "source_digest_sha256": "3c2ceb03f17a8a4c7409f1f95b84b87c3cba63e34ab315c21e2276a83385c15e",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "2a9f314bc386459c9cf1b4232e8c656a8e2129a740a5f321a9f0c5b9d4d77692"
+  "target_digest_sha256": "3c2ceb03f17a8a4c7409f1f95b84b87c3cba63e34ab315c21e2276a83385c15e"
 }

--- a/docs/source/diagrams/agi-core-overview.svg
+++ b/docs/source/diagrams/agi-core-overview.svg
@@ -124,8 +124,8 @@
     <rect class="card" width="296" height="104" fill="#ffe8ac" />
     <text class="card-title" x="148" y="36" text-anchor="middle">agi_env</text>
     <text class="card-body" x="24" y="62">
-      <tspan x="24" dy="0">Paths, configs, logging, credentials</tspan>
-      <tspan x="24" dy="20">and share roots</tspan>
+      <tspan x="24" dy="0">Paths, configs, logging,</tspan>
+      <tspan x="24" dy="20">credentials and share roots</tspan>
     </text>
   </g>
 
@@ -162,7 +162,7 @@
 
   <g transform="translate(54,566)">
     <rect class="callout" width="520" height="66" fill="#ffffff" />
-    <text class="callout-title" x="20" y="33">Reading guide</text>
+    <text class="callout-title" x="20" y="30">Reading guide</text>
     <text class="callout-body" x="136" y="30">
       <tspan x="136" dy="0">Entry points run in an agi-core install, then flow</tspan>
       <tspan x="136" dy="18">through environment setup to cluster and workers.</tspan>
@@ -182,7 +182,7 @@
 
   <line class="arrow" x1="470" y1="166" x2="484" y2="210" marker-end="url(#arrowhead-core)" />
   <line class="arrow" x1="470" y1="302" x2="484" y2="254" marker-end="url(#arrowhead-core)" />
-  <line class="arrow" x1="648" y1="312" x2="648" y2="350" marker-end="url(#arrowhead-core)" />
+  <line class="arrow" x1="648" y1="324" x2="648" y2="350" marker-end="url(#arrowhead-core)" />
   <line class="arrow" x1="792" y1="236" x2="864" y2="198" marker-end="url(#arrowhead-core)" />
   <line class="arrow" x1="796" y1="396" x2="864" y2="331" marker-end="url(#arrowhead-core)" />
   <line class="arrow" x1="1024" y1="388" x2="1024" y2="420" marker-end="url(#arrowhead-core)" />

--- a/docs/source/diagrams/distributed_orchestrate_pipeline_handoff.svg
+++ b/docs/source/diagrams/distributed_orchestrate_pipeline_handoff.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="420" viewBox="0 0 1180 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="436" viewBox="0 0 1180 436" role="img" aria-labelledby="title desc">
   <title id="title">UI-driven distributed workflow from ORCHESTRATE to WORKFLOW</title>
   <desc id="desc">Diagram showing that users configure distributed workers in ORCHESTRATE, generate AGI snippets there, and then import the generated run snippet into WORKFLOW instead of writing it by hand.</desc>
   <defs>
@@ -13,25 +13,26 @@
       .note-text { font: 400 15px Arial, Helvetica, sans-serif; fill: #6a5531; }
       .label { font: 700 15px Arial, Helvetica, sans-serif; fill: #24557a; }
     </style>
-    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
-      <path d="M0,0 L12,6 L0,12 z" fill="#24557a"/>
+    <marker id="arrow" markerWidth="16" markerHeight="12" refX="15" refY="6" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L16,6 L0,12 z" fill="#24557a"/>
     </marker>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1180" height="420" rx="28"/>
+  <rect class="bg" x="0" y="0" width="1180" height="436" rx="28"/>
 
   <text class="title" x="64" y="54">Distributed workflow is UI-driven</text>
   <text class="subtitle" x="64" y="84">Configure workers in ORCHESTRATE, generate the snippet there, then reuse that generated stage in WORKFLOW.</text>
 
-  <rect x="64" y="118" width="438" height="212" rx="24" fill="#e8f1fb" stroke="#2f6fa3" stroke-width="3"/>
+  <rect x="64" y="118" width="438" height="232" rx="24" fill="#e8f1fb" stroke="#2f6fa3" stroke-width="3"/>
   <text class="card-title" x="283" y="162" text-anchor="middle">ORCHESTRATE</text>
   <rect x="170" y="180" width="226" height="34" rx="17" fill="#d7e8f7" stroke="#2f6fa3" stroke-width="2"/>
   <text class="chip-text" x="283" y="202" text-anchor="middle">Generate AGI.run(...)</text>
   <text class="card-text" x="112" y="244">1. Configure scheduler, workers, and mode flags</text>
-  <text class="card-text" x="112" y="276">2. Use Deploy scheduler &amp; workers / CHECK distribute / RUN</text>
-  <text class="card-text" x="112" y="308">3. Copy the generated snippet, do not rewrite it</text>
+  <text class="card-text" x="112" y="276">2. Use Deploy scheduler &amp; workers,</text>
+  <text class="card-text" x="134" y="298">CHECK distribute / RUN</text>
+  <text class="card-text" x="112" y="330">3. Copy the generated snippet, do not rewrite it</text>
 
-  <rect x="678" y="118" width="438" height="212" rx="24" fill="#efe8d9" stroke="#9b6c1f" stroke-width="3"/>
+  <rect x="678" y="118" width="438" height="232" rx="24" fill="#efe8d9" stroke="#9b6c1f" stroke-width="3"/>
   <text class="card-title" x="897" y="162" text-anchor="middle">WORKFLOW</text>
   <rect x="776" y="180" width="242" height="34" rx="17" fill="#f7edd9" stroke="#9b6c1f" stroke-width="2"/>
   <text class="chip-text" x="897" y="202" text-anchor="middle">Import generated stage</text>
@@ -39,10 +40,10 @@
   <text class="card-text" x="726" y="276">2. Import the generated run snippet</text>
   <text class="card-text" x="726" y="308">3. Track and rerun it from lab_stages.toml</text>
 
-  <path d="M516 224 H662" fill="none" stroke="#24557a" stroke-width="5" marker-end="url(#arrow)"/>
-  <text class="label" x="589" y="212" text-anchor="middle">generated snippet</text>
+  <path d="M516 234 H652" fill="none" stroke="#24557a" stroke-width="5" marker-end="url(#arrow)"/>
+  <text class="label" x="590" y="220" text-anchor="middle">generated snippet</text>
 
-  <rect x="64" y="350" width="1052" height="42" rx="18" fill="#fff0c7" stroke="#d6a93d" stroke-width="2"/>
-  <text class="note-title" x="88" y="376">Snapshot rule:</text>
-  <text class="note-text" x="198" y="376">if worker settings or app arguments change, regenerate in ORCHESTRATE and re-import in WORKFLOW.</text>
+  <rect x="64" y="368" width="1052" height="42" rx="18" fill="#fff0c7" stroke="#d6a93d" stroke-width="2"/>
+  <text class="note-title" x="88" y="394">Snapshot rule:</text>
+  <text class="note-text" x="198" y="394">if worker settings or app arguments change, regenerate in ORCHESTRATE and re-import in WORKFLOW.</text>
 </svg>

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -44,7 +44,9 @@ Status legend:
      - ``agi-app-weather-forecast``
      - PyPI app package
      - Notebook-to-app migration using a small weather forecast dataset,
-       forecast metrics, and promotion evidence.
+       forecast metrics, and promotion evidence. Historical
+       ``weather_forecast_legacy_project`` identifiers resolve here for
+       compatibility; new work should use the maintained name.
    * - ``sklearn_pipeline_project``
      - ``agi-app-sklearn-pipeline``
      - PyPI app package


### PR DESCRIPTION
## Summary
Quality pass on the two recently-touched core diagrams (canonical edited first in thales_agilab, mirror synced with verified stamp):

- **distributed_orchestrate_pipeline_handoff.svg** — the arrow marker used default `markerUnits=strokeWidth` with a 5px stroke, so the arrowhead rendered 60×60px, swallowing the "generated snippet" label and crowding the corridor. Now `userSpaceOnUse` at 16×12 with recomputed connector/label. Item 2 of ORCHESTRATE overflowed the card border; wrapped semantically, cards grown to a shared bottom, snapshot band re-anchored.
- **agi-core-overview.svg** — the agi-core→agi_env arrow started *inside* the card (y=312 vs bottom edge 324), cutting through "agi-cluster at one version"; it now starts at the card edge. agi_env body rewrapped on the phrase boundary; Reading-guide title baseline aligned.
- **agilab_global_architecture.svg** — inspected, clean, untouched.
- Carries the canonical `public-app-catalog.rst` sync: keeps the new weather-legacy alias wording; the premature row removal was restored in canonical (thales a46b10c) because `app_contract_matrix` requires every existing built-in listed — the row goes away together with the actual app retirement.

## Validation
- Rendered before/after with rsvg-convert + Quick Look; visual sweep per svg-diagram-tuning checklist
- XML parse clean on both SVGs
- `sync_docs_source.py --verify-stamp` → target integrity + canonical source verified
- `app_contract_matrix` → pass (152 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)