### PR TITLE
fix(cluster): accept proven shutdown after retirement delay

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -1262,6 +1262,19 @@ async def _stop_runtime_resources(
             fatal_error = fatal_error or exc
 
     if shutdown_owned_runtime and client_shutdown_proven and background_cleanup_proven:
+        retirement_failures = [
+            exc for phase, exc in failures if phase == "worker retirement"
+        ]
+        if retirement_failures:
+            log.warning(
+                "AGI worker retirement was not observed before scheduler shutdown; "
+                "final scheduler and owned-process cleanup succeeded"
+            )
+            failures = [
+                (phase, exc)
+                for phase, exc in failures
+                if phase != "worker retirement"
+            ]
         # Do not retain a successfully closed client across a lifecycle retry.
         # A service-state unlink may fail after runtime cleanup and keep the
         # ownership lease; the next stop must not query the already-closed

--- a/src/agilab/core/test/test_agi_distributor.py
+++ b/src/agilab/core/test/test_agi_distributor.py
@@ -95,10 +95,10 @@ async def test_stop_handles_scheduler_info_and_retire_failures(monkeypatch):
     retire_fails_client = _RetireFailsClient()
     AGI._dask_client = retire_fails_client
     monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
-    with pytest.raises(RuntimeCleanupRequiredError, match="worker retirement"):
-        await AGI._stop()
+    await AGI._stop()
     assert retire_fails_client.shutdown_calls == 1
     assert AGI._dask_client is None
+    assert AGI._service_cleanup_unproven is False
     assert closed["count"] == 1
 
 

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import shlex
 import subprocess
@@ -762,7 +763,7 @@ async def test_stop_retry_reuses_client_shutdown_proof_until_process_cleanup_suc
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("phase", ["scheduler_info", "retire_workers", "shutdown"])
+@pytest.mark.parametrize("phase", ["scheduler_info", "shutdown"])
 async def test_stop_marks_operational_cleanup_errors_unproven(monkeypatch, phase):
     class _Client:
         def __init__(self):
@@ -771,13 +772,9 @@ async def test_stop_marks_operational_cleanup_errors_unproven(monkeypatch, phase
         async def scheduler_info(self):
             if phase == "scheduler_info":
                 raise RuntimeError("expected shutdown failure")
-            if phase == "retire_workers":
-                return {"workers": {"tcp://127.0.0.1:8787": {}}}
             return {"workers": {}}
 
         async def retire_workers(self, workers, close_workers=True, remove=True):
-            if phase == "retire_workers":
-                raise RuntimeError("expected shutdown failure")
             return None
 
         async def shutdown(self):
@@ -806,6 +803,93 @@ async def test_stop_marks_operational_cleanup_errors_unproven(monkeypatch, phase
         await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
 
     assert closed["count"] == 1
+    assert AGI._service_cleanup_unproven is True
+
+
+@pytest.mark.asyncio
+async def test_stop_accepts_retirement_failure_after_proven_shutdown(monkeypatch, caplog):
+    class _Client:
+        def __init__(self):
+            self.retire_calls = 0
+            self.shutdown_calls = 0
+
+        async def scheduler_info(self):
+            return {"workers": {"tcp://127.0.0.1:8787": {}}}
+
+        async def retire_workers(self, workers, close_workers=True, remove=True):
+            self.retire_calls += 1
+
+        async def shutdown(self):
+            self.shutdown_calls += 1
+
+    client = _Client()
+    AGI._dask_client = client
+    AGI._mode_auto = False
+    AGI._mode = AGI.DASK_MODE
+    AGI._TIMEOUT = 2
+
+    async def _fake_close_all():
+        return None
+
+    async def _fake_background_cleanup(_agi_cls, *, log):
+        return None
+
+    async def _fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
+    monkeypatch.setattr(
+        runtime_distribution_support,
+        "_terminate_owned_background_jobs",
+        _fake_background_cleanup,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
+
+    assert client.retire_calls == 2
+    assert client.shutdown_calls == 1
+    assert AGI._dask_client is None
+    assert AGI._service_cleanup_unproven is False
+    assert "final scheduler and owned-process cleanup succeeded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stop_keeps_retirement_failure_when_shutdown_is_unproven(monkeypatch):
+    class _Client:
+        def __init__(self):
+            self.retire_calls = 0
+
+        async def scheduler_info(self):
+            return {"workers": {"tcp://127.0.0.1:8787": {}}}
+
+        async def retire_workers(self, workers, close_workers=True, remove=True):
+            self.retire_calls += 1
+
+        async def shutdown(self):
+            raise RuntimeError("scheduler shutdown failed")
+
+    client = _Client()
+    AGI._dask_client = client
+    AGI._mode_auto = False
+    AGI._mode = AGI.DASK_MODE
+    AGI._TIMEOUT = 2
+
+    async def _fake_close_all():
+        return None
+
+    async def _fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="worker retirement",
+    ):
+        await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
+
+    assert client.retire_calls == 2
     assert AGI._service_cleanup_unproven is True
 
 


### PR DESCRIPTION
## Summary
- treat worker-retirement delay as resolved when scheduler shutdown and owned-process cleanup are proven
- preserve fail-closed behavior for unproven scheduler, process, or connection cleanup
- add production-shaped cleanup regressions

## Repro
Run a one-partition Dask stage with two configured workers. Let `retire_workers()` return while `scheduler_info()` continues reporting one worker through the retirement retry limit. Scheduler shutdown and owned-process cleanup then succeed, but the run currently raises `RuntimeCleanupRequiredError`, retains its lease, and blocks the next workflow stage.

## Root Cause
The fail-closed cleanup hardening retained every intermediate worker-retirement failure even after later scheduler shutdown and owned-process cleanup proved that the runtime was fully stopped.

## Regression Test
- covers a worker remaining registered through every retirement attempt followed by proven final shutdown
- covers the same condition with failed scheduler shutdown and verifies the lease remains unproven
- updates the prior operational-error contract test to distinguish intermediate retirement failure from final cleanup failure

## Validation
- focused runtime cleanup tests: passed
- inferred narrow core tests: 82 passed
- full `src/agilab/core/test` suite: passed
- shared-core strict typing: passed
- impact validation: high-risk shared-core scope acknowledged and explicitly approved by the user

## Review Evidence
No sub-agent or separate model review was used.

## Agent Metadata
- Tokki: 1.0.40
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: no
