### PR TITLE
fix(installer): enforce declared dependency installation

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -17,9 +17,18 @@ from tempfile import TemporaryDirectory
 from typing import Any, Callable, cast
 
 import tomlkit
+from packaging.markers import default_environment
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 
 from agi_env.runtime.atomic_write_support import atomic_write_text
+from agi_env.runtime.import_layout_support import (
+    distribution_installation_matches,
+    inspect_pth_import_layout,
+    is_typing_only_distribution,
+    top_level_modules_from_distribution,
+    top_level_modules_from_project,
+)
 
 from agi_cluster.agi_distributor import deployment_dask_support
 from agi_cluster.agi_distributor.deployment.deployment_build_support import (
@@ -554,7 +563,7 @@ def _parse_dependency_names(entries: Any) -> set[str]:
         if not isinstance(entry, str):
             continue
         try:
-            names.add(Requirement(entry).name.lower())
+            names.add(canonicalize_name(Requirement(entry).name))
         except DEPENDENCY_PARSE_EXCEPTIONS:
             continue
     return names
@@ -569,17 +578,17 @@ def _manager_dependency_names(pyproject_file: Path) -> set[str]:
     return _parse_dependency_names(project.get("dependencies"))
 
 
-def _local_uv_source_names(pyproject_file: Path) -> set[str]:
+def _local_uv_source_projects(pyproject_file: Path) -> dict[str, Path]:
     try:
         data = tomlkit.parse(pyproject_file.read_text())
     except PYPROJECT_PARSE_EXCEPTIONS:
-        return set()
+        return {}
 
     sources = data.get("tool", {}).get("uv", {}).get("sources")
     if not isinstance(sources, dict):
-        return set()
+        return {}
 
-    names: set[str] = set()
+    projects: dict[str, Path] = {}
     for name, meta in sources.items():
         if not isinstance(meta, dict):
             continue
@@ -589,9 +598,17 @@ def _local_uv_source_names(pyproject_file: Path) -> set[str]:
         source_path = Path(path_value).expanduser()
         if not source_path.is_absolute():
             source_path = pyproject_file.parent / source_path
-        if source_path.resolve(strict=False).exists():
-            names.add(str(name).lower())
-    return names
+        source_path = source_path.resolve(strict=False)
+        projects[canonicalize_name(str(name))] = source_path
+    return projects
+
+
+def _local_uv_source_names(pyproject_file: Path) -> set[str]:
+    return {
+        name
+        for name, project in _local_uv_source_projects(pyproject_file).items()
+        if project.exists()
+    }
 
 
 def _filter_worker_core_add_specs(
@@ -768,6 +785,21 @@ def _update_pyproject_dependencies(
 _PYPROJECT_DEPENDENCY_CACHE: dict[tuple[str, int, int], tuple[str, ...] | None] = {}
 
 
+def _marker_environment_for_python_version(
+    python_version: str | None,
+) -> dict[str, str]:
+    environment = default_environment()
+    parsed = _python_version_tuple(python_version)
+    if not parsed:
+        return environment
+    major = parsed[0]
+    minor = parsed[1] if len(parsed) > 1 else 0
+    patch = parsed[2] if len(parsed) > 2 else 0
+    environment["python_version"] = f"{major}.{minor}"
+    environment["python_full_version"] = f"{major}.{minor}.{patch}"
+    return environment
+
+
 def _pyproject_dependency_strings(resolved_pyproject: Path) -> tuple[str, ...] | None:
     try:
         stat_result = resolved_pyproject.stat()
@@ -794,6 +826,8 @@ def _pyproject_dependency_strings(resolved_pyproject: Path) -> tuple[str, ...] |
 
 def _gather_dependency_specs(
     projects: list[Path | None],
+    *,
+    marker_environment: dict[str, str] | None = None,
 ) -> tuple[dict[str, dict[str, Any]], set[str]]:
     dependency_info: dict[str, dict[str, Any]] = {}
     worker_pyprojects: set[str] = set()
@@ -813,15 +847,16 @@ def _gather_dependency_specs(
         deps = _pyproject_dependency_strings(resolved_pyproject)
         if not deps:
             continue
+        local_source_projects = _local_uv_source_projects(resolved_pyproject)
         worker_pyprojects.add(str(resolved_pyproject))
         for dep in deps:
             try:
                 req = Requirement(str(dep))
             except DEPENDENCY_PARSE_EXCEPTIONS:
                 continue
-            if req.marker and not req.marker.evaluate():
+            if req.marker and not req.marker.evaluate(environment=marker_environment):
                 continue
-            normalized = req.name.lower()
+            normalized = canonicalize_name(req.name)
             if normalized.startswith("agi-") or normalized == "agilab":
                 continue
             meta = dependency_info.setdefault(
@@ -832,11 +867,15 @@ def _gather_dependency_specs(
                     "specifiers": [],
                     "has_exact": False,
                     "sources": set(),
+                    "source_projects": set(),
                 },
             )
             if req.extras:
                 meta["extras"].update(req.extras)
             meta["sources"].add(str(resolved_pyproject))
+            source_project = local_source_projects.get(normalized)
+            if source_project is not None:
+                meta["source_projects"].add(source_project)
             if req.specifier:
                 for specifier in req.specifier:
                     spec_str = str(specifier)
@@ -855,18 +894,32 @@ def _gather_dependency_specs(
 
 def _dependency_modules_from_info(
     dependency_info: dict[str, dict[str, Any]],
+    *,
+    site_packages: tuple[Path, ...] = (),
 ) -> tuple[str, ...]:
     modules: list[str] = []
     for key, meta in dependency_info.items():
         if key.startswith("agi-") or key == "agilab":
+            continue
+        if is_typing_only_distribution(key):
             continue
         extras = {
             str(item).strip().lower()
             for item in meta.get("extras", set())
             if str(item).strip()
         }
+        source_modules = tuple(
+            module
+            for project in sorted(
+                meta.get("source_projects", set()), key=lambda path: str(path)
+            )
+            for module in top_level_modules_from_project(project)
+        )
+        installed_modules = top_level_modules_from_distribution(site_packages, key)
         modules.extend(
-            DEPENDENCY_MODULE_ALIASES.get(
+            source_modules
+            or installed_modules
+            or DEPENDENCY_MODULE_ALIASES.get(
                 key,
                 (str(meta.get("name") or key).replace("-", "_"),),
             )
@@ -877,34 +930,24 @@ def _dependency_modules_from_info(
 
 
 def _pth_import_roots(site_packages: Path) -> tuple[Path, ...]:
-    roots: list[Path] = []
-    try:
-        pth_files = sorted(site_packages.glob("*.pth"))
-    except OSError:
-        return ()
-    for pth_file in pth_files:
-        try:
-            lines = pth_file.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
-            continue
-        for line in lines:
-            value = line.strip()
-            if not value or value.startswith("#") or value.startswith("import "):
-                continue
-            candidate = Path(value).expanduser()
-            if not candidate.is_absolute():
-                candidate = site_packages / candidate
-            candidate = candidate.resolve(strict=False)
-            if candidate.is_dir():
-                roots.append(candidate)
-    return tuple(dict.fromkeys(roots))
+    return inspect_pth_import_layout(site_packages).roots
 
 
 def _module_available_on_root(root: Path, module: str) -> bool:
     package_path = root / module
     if package_path.exists():
         return True
-    return any((root / f"{module}{suffix}").exists() for suffix in (".py", ".so", ".pyd", ".dylib"))
+    if any(
+        (root / f"{module}{suffix}").exists()
+        for suffix in (".py", ".so", ".pyd", ".dylib")
+    ):
+        return True
+    try:
+        return any(root.glob(f"{module}.*.so")) or any(
+            root.glob(f"{module}.*.pyd")
+        )
+    except OSError:
+        return False
 
 
 def _project_venv_has_modules(
@@ -916,10 +959,85 @@ def _project_venv_has_modules(
     if not modules:
         return True
     site_packages = _project_site_packages_dir(project, python_version=python_version)
-    roots = tuple(dict.fromkeys((site_packages, *_pth_import_roots(site_packages))))
+    layout = inspect_pth_import_layout(site_packages)
+    roots = tuple(dict.fromkeys((site_packages, *layout.roots)))
     return all(
-        any(_module_available_on_root(root, module) for root in roots)
+        layout.exposes_module(module)
+        or any(_module_available_on_root(root, module) for root in roots)
         for module in modules
+    )
+
+
+def _project_venv_dependency_failures(
+    project: Path,
+    dependency_info: dict[str, dict[str, Any]],
+    *,
+    python_version: str | None = None,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    site_packages = _project_site_packages_dir(project, python_version=python_version)
+    site_package_dirs = (site_packages,)
+    missing_distributions = tuple(
+        key
+        for key, meta in dependency_info.items()
+        if not distribution_installation_matches(
+            site_package_dirs,
+            key,
+            expected_projects=meta.get("source_projects", set()),
+        )
+    )
+    modules = _dependency_modules_from_info(
+        dependency_info,
+        site_packages=site_package_dirs,
+    )
+    layout = inspect_pth_import_layout(site_packages)
+    roots = tuple(dict.fromkeys((site_packages, *layout.roots)))
+    missing_modules = tuple(
+        module
+        for module in modules
+        if not layout.exposes_module(module)
+        and not any(_module_available_on_root(root, module) for root in roots)
+    )
+    return missing_distributions, missing_modules
+
+
+def _project_venv_has_dependencies(
+    project: Path,
+    dependency_info: dict[str, dict[str, Any]],
+    *,
+    python_version: str | None = None,
+) -> bool:
+    return not any(
+        _project_venv_dependency_failures(
+            project,
+            dependency_info,
+            python_version=python_version,
+        )
+    )
+
+
+def _require_project_venv_dependencies(
+    project: Path,
+    dependency_info: dict[str, dict[str, Any]],
+    *,
+    environment_name: str,
+    python_version: str | None = None,
+) -> None:
+    missing_distributions, missing_modules = _project_venv_dependency_failures(
+        project,
+        dependency_info,
+        python_version=python_version,
+    )
+    if not missing_distributions and not missing_modules:
+        return
+    details: list[str] = []
+    if missing_distributions:
+        details.append("missing distributions: " + ", ".join(missing_distributions))
+    if missing_modules:
+        details.append("missing modules: " + ", ".join(missing_modules))
+    raise RuntimeError(
+        f"AGI.install did not establish the declared {environment_name} dependencies "
+        f"in {project}: {'; '.join(details)}. Re-run Deploy workers and inspect the "
+        "preceding uv sync output."
     )
 
 
@@ -933,6 +1051,9 @@ async def deploy_local_worker(
     runtime_file: str,
     run_fn: Callable[..., Any] = AgiEnv.run,
     set_env_var_fn: Callable[..., Any] = AgiEnv.set_env_var,
+    require_project_venv_dependencies_fn: Callable[..., None] = (
+        _require_project_venv_dependencies
+    ),
     log: Any = logger,
 ) -> None:
     env = agi_cls.env
@@ -954,7 +1075,8 @@ async def deploy_local_worker(
     repo_core_project: Path | None = None
     repo_cluster_project: Path | None = None
     repo_agilab_root: Path | None = None
-    dependency_info: dict[str, dict[str, Any]] = {}
+    manager_dependency_info: dict[str, dict[str, Any]] = {}
+    worker_dependency_info: dict[str, dict[str, Any]] = {}
     dep_versions: dict[str, str] = {}
     worker_pyprojects: set[str] = set()
 
@@ -1002,8 +1124,17 @@ async def deploy_local_worker(
             node_project,
             core_project,
         ]
-        dependency_info, worker_pyprojects = _gather_dependency_specs(
-            projects_for_specs
+        manager_dependency_info, _ = _gather_dependency_specs(
+            projects_for_specs,
+            marker_environment=_marker_environment_for_python_version(
+                getattr(env, "python_version", None)
+            ),
+        )
+        worker_dependency_info, worker_pyprojects = _gather_dependency_specs(
+            projects_for_specs,
+            marker_environment=_marker_environment_for_python_version(
+                getattr(env, "pyvers_worker", None)
+            ),
         )
     else:
         env_project = env.agi_env
@@ -1062,20 +1193,28 @@ async def deploy_local_worker(
         log.info(f"Rapids-capable GPU[{ip}]: {hw_rapids_capable}")
 
     app_path = env.active_app
-    manager_probe_dependency_info, _ = _gather_dependency_specs(
-        [env_project, node_project, core_project, cluster_project, app_path]
-    )
-    manager_probe_modules = _dependency_modules_from_info(manager_probe_dependency_info)
+    def manager_probe_dependency_info() -> dict[str, dict[str, Any]]:
+        probe_info, _ = _gather_dependency_specs(
+            [app_path],
+            marker_environment=_marker_environment_for_python_version(pyvers),
+        )
+        return probe_info
+
+    def worker_probe_dependency_info() -> dict[str, dict[str, Any]]:
+        probe_info, _ = _gather_dependency_specs(
+            [wenv_abs],
+            marker_environment=_marker_environment_for_python_version(
+                getattr(env, "pyvers_worker", None)
+            ),
+        )
+        return probe_info
 
     def worker_probe_modules() -> tuple[str, ...]:
-        worker_probe_dependency_info, _ = _gather_dependency_specs(
-            [env_project, node_project, wenv_abs]
-        )
-        return _dependency_modules_from_info(worker_probe_dependency_info)
+        return _dependency_modules_from_info(worker_probe_dependency_info())
 
     manager_pyproject = app_path / "pyproject.toml"
     manager_pyproject_is_repo_file = _is_within_repo(manager_pyproject, repo_root)
-    if (not env.is_source_env) and (not env.is_worker_env) and dependency_info:
+    if (not env.is_source_env) and (not env.is_worker_env) and manager_dependency_info:
         if manager_pyproject_is_repo_file:
             log.info(
                 "Skipping dependency rewrite for %s to avoid mutating source checkout.",
@@ -1084,7 +1223,7 @@ async def deploy_local_worker(
         else:
             _update_pyproject_dependencies(
                 manager_pyproject,
-                dependency_info,
+                manager_dependency_info,
                 worker_pyprojects,
                 pinned_versions=None,
                 filter_to_worker=False,
@@ -1172,9 +1311,9 @@ async def deploy_local_worker(
                 output_probe=lambda: _project_venv_matches(
                     app_path, python_version=pyvers
                 )
-                and _project_venv_has_modules(
+                and _project_venv_has_dependencies(
                     app_path,
-                    manager_probe_modules,
+                    manager_probe_dependency_info(),
                     python_version=pyvers,
                 ),
             )
@@ -1255,9 +1394,9 @@ async def deploy_local_worker(
         site_packages_manager = env.env_pck.parent
         _cleanup_editable(site_packages_manager)
 
-        if dependency_info:
+        if manager_dependency_info:
             dep_versions = {}
-            for key, meta in dependency_info.items():
+            for key, meta in manager_dependency_info.items():
                 try:
                     dep_versions[key] = pkg_version(meta["name"])
                 except PackageNotFoundError:
@@ -1277,6 +1416,13 @@ async def deploy_local_worker(
             python_version=pyvers,
             install_cache_enabled=stage_cache_enabled,
         )
+
+    require_project_venv_dependencies_fn(
+        app_path,
+        manager_probe_dependency_info(),
+        environment_name="manager",
+        python_version=pyvers,
+    )
 
     started_at = time.perf_counter()
     await agi_cls._build_lib_local()
@@ -1378,7 +1524,7 @@ async def deploy_local_worker(
     ):
         _update_pyproject_dependencies(
             wenv_abs / "pyproject.toml",
-            dependency_info,
+            worker_dependency_info,
             worker_pyprojects,
             dep_versions,
             filter_to_worker=True,
@@ -1501,13 +1647,20 @@ async def deploy_local_worker(
                 worker_venv_project,
                 python_version=pyvers_worker,
             )
-            and _project_venv_has_modules(
+            and _project_venv_has_dependencies(
                 worker_venv_project,
-                worker_probe_modules(),
+                worker_probe_dependency_info(),
                 python_version=pyvers_worker,
             ),
             dependencies=tuple(worker_dependency_names),
         )
+    )
+
+    require_project_venv_dependencies_fn(
+        worker_venv_project,
+        worker_probe_dependency_info(),
+        environment_name="worker",
+        python_version=pyvers_worker,
     )
 
     if deployment_dask_support.dask_mode_enabled(agi_cls):

--- a/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
@@ -1,0 +1,460 @@
+"""Read Python import layouts without executing environment-owned code."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import unquote, urlsplit
+
+
+_EDITABLE_FINDER_PREFIX = "__editable___"
+_EDITABLE_FINDER_SUFFIX = "_finder"
+_MODULE_SUFFIXES = (".py", ".so", ".pyd", ".dylib")
+
+
+@dataclass(frozen=True)
+class PthImportLayout:
+    """Filesystem roots and explicit module mappings declared by ``.pth`` files."""
+
+    roots: tuple[Path, ...] = ()
+    module_locations: tuple[tuple[str, Path], ...] = ()
+
+    def exposes_module(self, module: str) -> bool:
+        """Return whether an explicit editable mapping exposes ``module``."""
+
+        top_level = module.partition(".")[0]
+        return any(
+            name.partition(".")[0] == top_level for name, _path in self.module_locations
+        )
+
+
+def inspect_pth_import_layout(site_packages: Path) -> PthImportLayout:
+    """Inspect plain paths and canonical setuptools PEP 660 finders safely.
+
+    Executable ``.pth`` files and their finder modules are parsed as syntax only.
+    They are never imported or executed.
+    """
+
+    roots: list[Path] = []
+    module_locations: list[tuple[str, Path]] = []
+    parsed_finders: set[Path] = set()
+    try:
+        pth_files = sorted(site_packages.glob("*.pth"))
+    except OSError:
+        return PthImportLayout()
+
+    for pth_file in pth_files:
+        try:
+            lines = pth_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("import "):
+                finder_module = _canonical_setuptools_finder_module(line)
+                if finder_module is None:
+                    continue
+                finder_path = _finder_path(site_packages, finder_module)
+                if finder_path is None or finder_path in parsed_finders:
+                    continue
+                parsed_finders.add(finder_path)
+                module_locations.extend(
+                    _finder_module_locations(finder_path, site_packages)
+                )
+                continue
+
+            candidate = Path(line).expanduser()
+            if not candidate.is_absolute():
+                candidate = site_packages / candidate
+            candidate = _resolve_without_failure(candidate)
+            try:
+                if candidate.is_dir():
+                    roots.append(candidate)
+            except OSError:
+                continue
+
+    return PthImportLayout(
+        roots=tuple(dict.fromkeys(roots)),
+        module_locations=tuple(dict.fromkeys(module_locations)),
+    )
+
+
+def top_level_modules_from_distribution(
+    site_packages: Iterable[Path],
+    distribution_name: str,
+) -> tuple[str, ...]:
+    """Return installed top-level import names for a distribution."""
+
+    normalized = _normalized_distribution_name(distribution_name)
+    modules: list[str] = []
+    for site_package in site_packages:
+        try:
+            metadata_files = sorted(site_package.glob("*.dist-info/METADATA"))
+        except OSError:
+            continue
+        for metadata_file in metadata_files:
+            if _metadata_distribution_name(metadata_file) != normalized:
+                continue
+            modules.extend(_top_level_modules_from_metadata_dir(metadata_file.parent))
+    return tuple(dict.fromkeys(modules))
+
+
+def is_typing_only_distribution(distribution_name: str) -> bool:
+    """Return whether a distribution intentionally supplies typing data only."""
+
+    normalized = _normalized_distribution_name(distribution_name)
+    return normalized.endswith("-stubs") or normalized.startswith("types-")
+
+
+def distribution_installation_matches(
+    site_packages: Iterable[Path],
+    distribution_name: str,
+    *,
+    expected_projects: Iterable[Path] = (),
+) -> bool:
+    """Return whether matching distribution metadata is installed.
+
+    When local source projects are supplied, a matching ``direct_url.json``
+    must point at one of them.  This prevents a stray importable directory or a
+    stale editable finder from satisfying an installation postcondition.
+    """
+
+    expected = tuple(
+        dict.fromkeys(
+            _resolve_without_failure(path.expanduser()) for path in expected_projects
+        )
+    )
+    for metadata_dir in _distribution_metadata_dirs(site_packages, distribution_name):
+        if not expected:
+            return True
+        direct_project = _direct_url_project(metadata_dir / "direct_url.json")
+        if direct_project is not None and any(
+            _same_path(direct_project, project) for project in expected
+        ):
+            return True
+    return False
+
+
+def top_level_modules_from_project(project_root: Path) -> tuple[str, ...]:
+    """Return explicit setuptools top-level imports declared by a source project."""
+
+    try:
+        data = tomllib.loads(
+            (project_root / "pyproject.toml").read_text(encoding="utf-8")
+        )
+    except (OSError, tomllib.TOMLDecodeError):
+        return ()
+    setuptools = data.get("tool", {}).get("setuptools", {})
+    if not isinstance(setuptools, dict):
+        return ()
+    modules: list[str] = []
+    for key in ("packages", "py-modules"):
+        values = setuptools.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            module = value.strip().partition(".")[0]
+            if module.isidentifier():
+                modules.append(module)
+    return tuple(dict.fromkeys(modules))
+
+
+def _canonical_setuptools_finder_module(line: str) -> str | None:
+    try:
+        tree = ast.parse(line, mode="exec")
+    except SyntaxError:
+        return None
+    if len(tree.body) != 2:
+        return None
+    import_node, install_node = tree.body
+    if not isinstance(import_node, ast.Import) or len(import_node.names) != 1:
+        return None
+    imported = import_node.names[0]
+    module = imported.name
+    if imported.asname is not None or not module.isidentifier():
+        return None
+    if not module.startswith(_EDITABLE_FINDER_PREFIX) or not module.endswith(
+        _EDITABLE_FINDER_SUFFIX
+    ):
+        return None
+    if not isinstance(install_node, ast.Expr) or not isinstance(
+        install_node.value, ast.Call
+    ):
+        return None
+    call = install_node.value
+    if call.args or call.keywords or not isinstance(call.func, ast.Attribute):
+        return None
+    if call.func.attr != "install" or not isinstance(call.func.value, ast.Name):
+        return None
+    return module if call.func.value.id == module else None
+
+
+def _finder_path(site_packages: Path, finder_module: str) -> Path | None:
+    candidate = site_packages / f"{finder_module}.py"
+    try:
+        site_root = site_packages.resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(site_root)
+        if not resolved.is_file():
+            return None
+    except (FileNotFoundError, OSError, RuntimeError, ValueError):
+        return None
+    return resolved
+
+
+def _finder_module_locations(
+    finder_path: Path,
+    site_packages: Path,
+) -> tuple[tuple[str, Path], ...]:
+    try:
+        tree = ast.parse(
+            finder_path.read_text(encoding="utf-8", errors="replace"),
+            filename=str(finder_path),
+        )
+    except (OSError, SyntaxError, ValueError):
+        return ()
+    if any(
+        not isinstance(
+            node,
+            (
+                ast.Import,
+                ast.ImportFrom,
+                ast.Assign,
+                ast.AnnAssign,
+                ast.FunctionDef,
+                ast.AsyncFunctionDef,
+                ast.ClassDef,
+            ),
+        )
+        for node in tree.body
+    ):
+        return ()
+
+    mapping = _literal_assignment(tree, "MAPPING", expected_type=dict)
+    namespaces = _literal_assignment(tree, "NAMESPACES", expected_type=dict)
+    locations: list[tuple[str, Path]] = []
+
+    if isinstance(mapping, dict):
+        for module, raw_path in mapping.items():
+            if not _valid_dotted_module(module) or not isinstance(raw_path, str):
+                continue
+            location = _import_location(raw_path, site_packages)
+            if location is not None:
+                locations.append((module, location))
+
+    if isinstance(namespaces, dict):
+        for module, raw_paths in namespaces.items():
+            if not _valid_dotted_module(module) or not isinstance(
+                raw_paths, list | tuple
+            ):
+                continue
+            for raw_path in raw_paths:
+                if not isinstance(raw_path, str):
+                    continue
+                location = _import_location(raw_path, site_packages, namespace=True)
+                if location is not None:
+                    locations.append((module, location))
+
+    return tuple(dict.fromkeys(locations))
+
+
+def _literal_assignment(
+    tree: ast.Module,
+    name: str,
+    *,
+    expected_type: type[dict],
+) -> object | None:
+    value_node: ast.expr | None = None
+    for node in tree.body:
+        candidate: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == name:
+                candidate = node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id == name:
+                candidate = node.value
+        if candidate is None:
+            continue
+        if value_node is not None:
+            return None
+        value_node = candidate
+    if value_node is None:
+        return None
+    try:
+        value = ast.literal_eval(value_node)
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        return None
+    return value if isinstance(value, expected_type) else None
+
+
+def _import_location(
+    raw_path: str,
+    site_packages: Path,
+    *,
+    namespace: bool = False,
+) -> Path | None:
+    if not raw_path.strip():
+        return None
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = site_packages / candidate
+    candidate = _resolve_without_failure(candidate)
+    try:
+        if namespace:
+            return candidate if candidate.is_dir() else None
+        if (candidate / "__init__.py").is_file():
+            return candidate
+        if any(candidate.with_suffix(suffix).is_file() for suffix in _MODULE_SUFFIXES):
+            return candidate
+        if any(candidate.parent.glob(f"{candidate.name}.*.so")) or any(
+            candidate.parent.glob(f"{candidate.name}.*.pyd")
+        ):
+            return candidate
+    except OSError:
+        return None
+    return None
+
+
+def _resolve_without_failure(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path
+
+
+def _valid_dotted_module(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and all(part.isidentifier() for part in value.split("."))
+    )
+
+
+def _normalized_distribution_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value.strip()).strip("-").lower()
+
+
+def _metadata_distribution_name(metadata_file: Path) -> str | None:
+    try:
+        for line in metadata_file.read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines():
+            if line.startswith("Name:"):
+                return _normalized_distribution_name(line.partition(":")[2])
+    except OSError:
+        return None
+    return None
+
+
+def _distribution_metadata_dirs(
+    site_packages: Iterable[Path],
+    distribution_name: str,
+) -> tuple[Path, ...]:
+    normalized = _normalized_distribution_name(distribution_name)
+    metadata_dirs: list[Path] = []
+    for site_package in site_packages:
+        try:
+            metadata_files = sorted(site_package.glob("*.dist-info/METADATA"))
+        except OSError:
+            continue
+        for metadata_file in metadata_files:
+            if _metadata_distribution_name(metadata_file) == normalized:
+                metadata_dirs.append(metadata_file.parent)
+    return tuple(dict.fromkeys(metadata_dirs))
+
+
+def _direct_url_project(direct_url_file: Path) -> Path | None:
+    try:
+        payload = json.loads(direct_url_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+    url = payload.get("url") if isinstance(payload, dict) else None
+    if not isinstance(url, str):
+        return None
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() != "file":
+        return None
+    raw_path = unquote(parsed.path)
+    if os.name == "nt" and re.match(r"^/[A-Za-z]:", raw_path):
+        raw_path = raw_path[1:]
+    elif parsed.netloc and parsed.netloc.lower() != "localhost":
+        raw_path = f"//{parsed.netloc}{raw_path}"
+    return _resolve_without_failure(Path(raw_path).expanduser()) if raw_path else None
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.samefile(right)
+    except (FileNotFoundError, OSError):
+        return _resolve_without_failure(left) == _resolve_without_failure(right)
+
+
+def _top_level_modules_from_metadata_dir(metadata_dir: Path) -> tuple[str, ...]:
+    modules: list[str] = []
+    try:
+        lines = (
+            (metadata_dir / "top_level.txt")
+            .read_text(
+                encoding="utf-8",
+                errors="replace",
+            )
+            .splitlines()
+        )
+    except OSError:
+        lines = []
+    for line in lines:
+        module = line.strip()
+        if (
+            module
+            and not module.startswith("#")
+            and module.isidentifier()
+            and not (module.startswith("__") and module.endswith("__"))
+        ):
+            modules.append(module)
+    if modules:
+        return tuple(dict.fromkeys(modules))
+
+    try:
+        record_lines = (
+            (metadata_dir / "RECORD")
+            .read_text(
+                encoding="utf-8",
+                errors="replace",
+            )
+            .splitlines()
+        )
+    except OSError:
+        return ()
+    for line in record_lines:
+        module = _module_name_from_record_path(line)
+        if module:
+            modules.append(module)
+    return tuple(dict.fromkeys(modules))
+
+
+def _module_name_from_record_path(path_text: str) -> str | None:
+    root = path_text.strip().split(",", 1)[0].replace("\\", "/").split("/", 1)[0]
+    if not root or root.endswith((".dist-info", ".egg-info", ".data")):
+        return None
+    if root.endswith(".py"):
+        module = root[:-3]
+    elif root.endswith((".so", ".pyd", ".dylib")):
+        module = root.split(".", 1)[0]
+    elif "." in root:
+        return None
+    else:
+        module = root
+    if module.startswith("__editable__"):
+        return None
+    return module if module.isidentifier() else None

--- a/src/agilab/core/agi-env/test/test_import_layout_support.py
+++ b/src/agilab/core/agi-env/test/test_import_layout_support.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agi_env.runtime.import_layout_support import (
+    distribution_installation_matches,
+    inspect_pth_import_layout,
+    top_level_modules_from_distribution,
+    top_level_modules_from_project,
+)
+
+
+def _write_finder(
+    site_packages: Path,
+    module: str,
+    source: str,
+) -> None:
+    (site_packages / f"{module}.py").write_text(source, encoding="utf-8")
+    (site_packages / "editable.pth").write_text(
+        f"import {module}; {module}.install()\n",
+        encoding="utf-8",
+    )
+
+
+def test_inspect_pth_import_layout_reads_paths_and_pep660_mapping_without_execution(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    relative_root = site_packages / "relative-src"
+    relative_root.mkdir()
+    mapped_package = tmp_path / "staged" / "distribution-directory"
+    mapped_package.mkdir(parents=True)
+    (mapped_package / "__init__.py").write_text("", encoding="utf-8")
+    namespace_root = tmp_path / "namespace"
+    namespace_root.mkdir()
+    finder = "__editable___demo_1_0_finder"
+    _write_finder(
+        site_packages,
+        finder,
+        "\n".join(
+            (
+                f"MAPPING = {{'exported_module': {str(mapped_package)!r}}}",
+                f"NAMESPACES = {{'demo_namespace': [{str(namespace_root)!r}]}}",
+                "def never_called():",
+                "    raise AssertionError('finder code must never execute')",
+            )
+        ),
+    )
+    with (site_packages / "plain.pth").open("w", encoding="utf-8") as handle:
+        handle.write("# comment\nrelative-src\nimport site\n")
+
+    layout = inspect_pth_import_layout(site_packages)
+
+    assert layout.roots == (relative_root.resolve(strict=False),)
+    assert layout.module_locations == (
+        ("exported_module", mapped_package.resolve(strict=False)),
+        ("demo_namespace", namespace_root.resolve(strict=False)),
+    )
+    assert layout.exposes_module("exported_module") is True
+    assert layout.exposes_module("exported_module.child") is True
+    assert layout.exposes_module("distribution_directory") is False
+
+
+def test_inspect_pth_import_layout_rejects_dynamic_or_noncanonical_finders(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    mapped_package = tmp_path / "mapped"
+    mapped_package.mkdir()
+    finder = "__editable___dynamic_finder"
+    _write_finder(
+        site_packages,
+        finder,
+        "MAPPING = dict(exported_module='dynamic')\nNAMESPACES = {}\n",
+    )
+    (site_packages / "noncanonical.pth").write_text(
+        f"import {finder}; {finder}.install(); raise RuntimeError()\n",
+        encoding="utf-8",
+    )
+
+    layout = inspect_pth_import_layout(site_packages)
+
+    assert layout.module_locations == ()
+
+    _write_finder(
+        site_packages,
+        finder,
+        f"MAPPING = {{'exported_module': {str(mapped_package)!r}}}\n"
+        "NAMESPACES = {}\nraise RuntimeError('unsafe import-time code')\n",
+    )
+    assert inspect_pth_import_layout(site_packages).module_locations == ()
+
+
+def test_inspect_pth_import_layout_accepts_abi_tagged_editable_extension(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    extension_base = tmp_path / "native_module"
+    extension_base.with_name("native_module.cp314-win_amd64.pyd").write_bytes(b"")
+    finder = "__editable___native_1_0_finder"
+    _write_finder(
+        site_packages,
+        finder,
+        f"MAPPING = {{'native_module': {str(extension_base)!r}}}\nNAMESPACES = {{}}\n",
+    )
+
+    layout = inspect_pth_import_layout(site_packages)
+
+    assert layout.exposes_module("native_module") is True
+
+
+def test_inspect_pth_import_layout_rejects_empty_mapped_package(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    empty_package = tmp_path / "empty-package"
+    empty_package.mkdir()
+    finder = "__editable___empty_1_0_finder"
+    _write_finder(
+        site_packages,
+        finder,
+        f"MAPPING = {{'empty_package': {str(empty_package)!r}}}\nNAMESPACES = {{}}\n",
+    )
+
+    assert not inspect_pth_import_layout(site_packages).exposes_module("empty_package")
+
+
+def test_top_level_modules_from_distribution_prefers_metadata_and_falls_back_to_record(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    metadata = site_packages / "link_sim_project-1.0.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.4\nName: link-sim-project\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text(
+        "link_sim_worker\n__placeholder__\n",
+        encoding="utf-8",
+    )
+
+    assert top_level_modules_from_distribution(
+        (site_packages,),
+        "link_sim_project",
+    ) == ("link_sim_worker",)
+
+    (metadata / "top_level.txt").unlink()
+    (metadata / "RECORD").write_text(
+        "link_sim_worker/__init__.py,,\nlink_sim_project-1.0.dist-info/METADATA,,\n",
+        encoding="utf-8",
+    )
+    assert top_level_modules_from_distribution(
+        (site_packages,),
+        "link-sim-project",
+    ) == ("link_sim_worker",)
+
+
+def test_top_level_modules_from_project_reads_explicit_setuptools_exports(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "link_sim_project"
+
+[tool.setuptools]
+packages = ["link_sim_worker", "link_sim_worker.runtime"]
+py-modules = ["link_sim_cli"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert top_level_modules_from_project(tmp_path) == (
+        "link_sim_worker",
+        "link_sim_cli",
+    )
+
+
+def test_distribution_installation_requires_metadata_and_local_source_provenance(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    shadow_module = site_packages / "link_sim_worker"
+    shadow_module.mkdir(parents=True)
+    source_project = tmp_path / "link_sim_project"
+    source_project.mkdir()
+
+    assert not distribution_installation_matches(
+        (site_packages,),
+        "link_sim_project",
+        expected_projects=(source_project,),
+    )
+
+    metadata = site_packages / "link_sim_project-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.4\nName: link-sim-project\n",
+        encoding="utf-8",
+    )
+    (metadata / "direct_url.json").write_text(
+        '{"url":"file:///different/source","dir_info":{"editable":true}}',
+        encoding="utf-8",
+    )
+    assert distribution_installation_matches(
+        (site_packages,),
+        "link-sim-project",
+    )
+    assert not distribution_installation_matches(
+        (site_packages,),
+        "link-sim-project",
+        expected_projects=(source_project,),
+    )
+
+    (metadata / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": source_project.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert distribution_installation_matches(
+        (site_packages,),
+        "link_sim_project",
+        expected_projects=(source_project,),
+    )

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -116,6 +116,7 @@ async def _call_deploy_local_worker(
     run_fn,
     set_env_var_fn,
     log,
+    require_project_venv_dependencies_fn=None,
 ) -> None:
     # src/wenv_rel are accepted for call-site compatibility but the production
     # signature dropped them: deploy_local_worker derives both from agi_cls.env.
@@ -129,6 +130,10 @@ async def _call_deploy_local_worker(
         runtime_file=runtime_file or deployment_local_support.__file__,
         run_fn=run_fn,
         set_env_var_fn=set_env_var_fn,
+        require_project_venv_dependencies_fn=(
+            require_project_venv_dependencies_fn
+            or (lambda *_args, **_kwargs: None)
+        ),
         log=log,
     )
 
@@ -1117,6 +1122,173 @@ def test_dependency_module_and_pth_import_roots_cover_edge_branches(monkeypatch,
 
     monkeypatch.setattr(Path, "glob", _raise_for_site_packages)
     assert deployment_local_support._pth_import_roots(site_packages) == ()
+
+
+def test_dependency_specs_evaluate_markers_for_target_python(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """
+[project]
+name = "marker-demo"
+dependencies = [
+    "old-only; python_version < '3.14'",
+    "new-only; python_version >= '3.14'",
+]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    old_info, _ = deployment_local_support._gather_dependency_specs(
+        [project],
+        marker_environment=deployment_local_support._marker_environment_for_python_version(
+            "3.13.9"
+        ),
+    )
+    new_info, _ = deployment_local_support._gather_dependency_specs(
+        [project],
+        marker_environment=deployment_local_support._marker_environment_for_python_version(
+            "3.14.1"
+        ),
+    )
+
+    assert set(old_info) == {"old-only"}
+    assert set(new_info) == {"new-only"}
+
+
+def test_dependency_postcondition_rejects_shadow_module_without_distribution(
+    tmp_path,
+):
+    source_project = tmp_path / "link-source"
+    source_project.mkdir()
+    (source_project / "pyproject.toml").write_text(
+        """
+[project]
+name = "link-sim-project"
+
+[tool.setuptools]
+packages = ["link_sim_worker"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    (consumer / "pyproject.toml").write_text(
+        f"""
+[project]
+name = "consumer"
+dependencies = ["link-sim-project"]
+
+[tool.uv.sources]
+link-sim-project = {{ path = {json.dumps(str(source_project))}, editable = true }}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    dependency_info, _ = deployment_local_support._gather_dependency_specs(
+        [consumer],
+        marker_environment=deployment_local_support._marker_environment_for_python_version(
+            "3.14"
+        ),
+    )
+    _write_venv_python(consumer, python_version="3.14.1")
+    site_packages = deployment_local_support._project_site_packages_dir(
+        consumer,
+        python_version="3.14",
+    )
+    shadow = site_packages / "link_sim_worker"
+    shadow.mkdir(parents=True)
+    (shadow / "__init__.py").write_text("", encoding="utf-8")
+
+    assert deployment_local_support._project_venv_dependency_failures(
+        consumer,
+        dependency_info,
+        python_version="3.14",
+    ) == (("link-sim-project",), ())
+    with pytest.raises(RuntimeError, match="missing distributions: link-sim-project"):
+        deployment_local_support._require_project_venv_dependencies(
+            consumer,
+            dependency_info,
+            environment_name="manager",
+            python_version="3.14",
+        )
+
+    dist_info = site_packages / "link_sim_project-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.4\nName: link-sim-project\n",
+        encoding="utf-8",
+    )
+    (dist_info / "top_level.txt").write_text(
+        "link_sim_worker\n",
+        encoding="utf-8",
+    )
+    (dist_info / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": source_project.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    deployment_local_support._require_project_venv_dependencies(
+        consumer,
+        dependency_info,
+        environment_name="manager",
+        python_version="3.14",
+    )
+
+
+@pytest.mark.parametrize("distribution", ("pandas-stubs", "types-requests"))
+def test_dependency_postcondition_requires_typing_distribution_without_runtime_module(
+    tmp_path,
+    distribution,
+):
+    project = tmp_path / distribution
+    _write_venv_python(project, python_version="3.14.1")
+    site_packages = deployment_local_support._project_site_packages_dir(
+        project,
+        python_version="3.14",
+    )
+    dist_info = site_packages / f"{distribution.replace('-', '_')}-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.4\nName: {distribution}\n",
+        encoding="utf-8",
+    )
+    dependency_info = {
+        distribution: {
+            "name": distribution,
+            "extras": set(),
+            "source_projects": set(),
+        }
+    }
+
+    assert deployment_local_support._project_venv_dependency_failures(
+        project,
+        dependency_info,
+        python_version="3.14",
+    ) == ((), ())
+    deployment_local_support._require_project_venv_dependencies(
+        project,
+        dependency_info,
+        environment_name="manager",
+        python_version="3.14",
+    )
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ("native.cpython-314-darwin.so", "native.cp314-win_amd64.pyd"),
+)
+def test_module_probe_accepts_abi_tagged_extensions(tmp_path, filename):
+    (tmp_path / filename).write_bytes(b"")
+
+    assert deployment_local_support._module_available_on_root(tmp_path, "native")
 
 
 def test_worker_post_install_sync_args_only_skips_when_modules_are_ready(tmp_path):
@@ -2605,11 +2777,38 @@ dependencies = ["numpy>=1.0", "scipy>=1.0; python_version < '2'"]
 
 @pytest.mark.asyncio
 async def test_deploy_local_worker_non_source_flow(tmp_path):
+    link_source = tmp_path / "link-source"
+    link_source.mkdir()
+    (link_source / "pyproject.toml").write_text(
+        """
+[project]
+name = "link-sim-project"
+
+[tool.setuptools]
+packages = ["link_sim_worker"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    def _dependency_manifest(name: str) -> str:
+        return f"""
+[project]
+name = {json.dumps(name)}
+dependencies = [
+    "link-sim-project",
+    "manager-only; python_version < '3.14'",
+    "worker-only; python_version >= '3.14'",
+]
+
+[tool.uv.sources]
+link-sim-project = {{ path = {json.dumps(str(link_source))}, editable = true }}
+"""
     app_path = tmp_path / "app"
     app_path.mkdir(parents=True, exist_ok=True)
     (app_path / "pyproject.toml").write_text(
-        "[project]\nname='demo-app'\n", encoding="utf-8"
+        _dependency_manifest("demo-app"), encoding="utf-8"
     )
+    _write_venv_python(app_path, python_version="3.13.1")
 
     agi_env_root = tmp_path / "agi_env"
     (agi_env_root / "src" / "agi_env" / "resources").mkdir(parents=True, exist_ok=True)
@@ -2628,8 +2827,17 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
     wenv_abs = tmp_path / "worker_env"
     wenv_abs.mkdir(parents=True, exist_ok=True)
     (wenv_abs / "pyproject.toml").write_text(
-        "[project]\nname='worker-app'\n", encoding="utf-8"
+        _dependency_manifest("worker-app"), encoding="utf-8"
     )
+    _write_venv_python(wenv_abs, python_version="3.14.1")
+    for project, python_version in ((app_path, "3.13"), (wenv_abs, "3.14")):
+        site_packages = deployment_local_support._project_site_packages_dir(
+            project,
+            python_version=python_version,
+        )
+        shadow = site_packages / "link_sim_worker"
+        shadow.mkdir(parents=True)
+        (shadow / "__init__.py").write_text("", encoding="utf-8")
 
     env = SimpleNamespace(
         is_source_env=False,
@@ -2643,7 +2851,7 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
         uv="uv",
         uv_worker="uv",
         python_version="3.13",
-        pyvers_worker="3.13",
+        pyvers_worker="3.14",
         envars={},
         verbose=1,
         env_pck=agi_env_root / "src" / "agi_env",
@@ -2656,8 +2864,68 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
     )
     commands = []
 
+    def _install_distribution(
+        project: Path,
+        distribution: str,
+        module: str,
+        *,
+        python_version: str,
+        source: Path | None = None,
+    ) -> None:
+        site_packages = deployment_local_support._project_site_packages_dir(
+            project,
+            python_version=python_version,
+        )
+        dist_info = site_packages / f"{distribution.replace('-', '_')}-1.0.dist-info"
+        dist_info.mkdir(parents=True, exist_ok=True)
+        (dist_info / "METADATA").write_text(
+            f"Metadata-Version: 2.4\nName: {distribution}\n",
+            encoding="utf-8",
+        )
+        (dist_info / "top_level.txt").write_text(
+            f"{module}\n",
+            encoding="utf-8",
+        )
+        package = site_packages / module
+        package.mkdir(exist_ok=True)
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        if source is not None:
+            (dist_info / "direct_url.json").write_text(
+                json.dumps(
+                    {
+                        "url": source.resolve().as_uri(),
+                        "dir_info": {"editable": True},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
     async def _fake_run(cmd, cwd):
         commands.append((cmd, str(cwd)))
+        if cmd.startswith("uv sync"):
+            project = Path(cwd)
+            python_version = "3.13" if project == app_path else "3.14"
+            _install_distribution(
+                project,
+                "link-sim-project",
+                "link_sim_worker",
+                python_version=python_version,
+                source=link_source,
+            )
+            if project == app_path:
+                _install_distribution(
+                    project,
+                    "manager-only",
+                    "manager_only",
+                    python_version=python_version,
+                )
+            else:
+                _install_distribution(
+                    project,
+                    "worker-only",
+                    "worker_only",
+                    python_version=python_version,
+                )
         return ""
 
     async def _fake_build():
@@ -2678,6 +2946,17 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
         _uninstall_modules=_fake_uninstall,
     )
 
+    observed_contracts: dict[str, set[str]] = {}
+
+    def _require_dependencies(project, info, *, environment_name, python_version):
+        observed_contracts[environment_name] = set(info)
+        deployment_local_support._require_project_venv_dependencies(
+            project,
+            info,
+            environment_name=environment_name,
+            python_version=python_version,
+        )
+
     await _call_deploy_local_worker(
         agi_cls,
         app_path,
@@ -2686,6 +2965,7 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
         agi_version_missing_on_pypi_fn=lambda _p: False,
         run_fn=_fake_run,
         set_env_var_fn=lambda *_a, **_k: None,
+        require_project_venv_dependencies_fn=_require_dependencies,
         log=mock.Mock(),
     )
 
@@ -2701,6 +2981,21 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
         for cmd, _ in commands
     )
     assert any("threaded" in cmd for cmd, _ in commands)
+    assert observed_contracts["manager"] == {"link-sim-project", "manager-only"}
+    assert observed_contracts["worker"] == {"link-sim-project", "worker-only"}
+    assert all(
+        deployment_local_support._project_venv_has_dependencies(
+            project,
+            deployment_local_support._gather_dependency_specs(
+                [project],
+                marker_environment=deployment_local_support._marker_environment_for_python_version(
+                    python_version
+                ),
+            )[0],
+            python_version=python_version,
+        )
+        for project, python_version in ((app_path, "3.13"), (wenv_abs, "3.14"))
+    )
 
 
 @pytest.mark.asyncio
@@ -3074,6 +3369,19 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
             "[project]\nname='demo'\ndependencies=['pip>=1']\n",
             encoding="utf-8",
         )
+    (env_project / "pyproject.toml").write_text(
+        """
+[project]
+name = "agi-env"
+dependencies = [
+    "pip>=1",
+    "manager-only; python_version < '3.14'",
+    "worker-only; python_version >= '3.14'",
+]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
     (env_project / "src" / "agi_env" / "resources").mkdir(parents=True, exist_ok=True)
     (env_project / "src" / "agi_env" / "resources" / "resource.txt").write_text(
         "x", encoding="utf-8"
@@ -3094,7 +3402,7 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     (wenv_abs / "pyproject.toml").write_text(
         "[project]\nname='worker'\n", encoding="utf-8"
     )
-    _write_venv_python(wenv_abs, python_version="3.13.13")
+    _write_venv_python(wenv_abs, python_version="3.14.1")
     (wenv_abs / "_uv_sources" / "ilp_worker").mkdir(parents=True, exist_ok=True)
 
     env_pck = tmp_path / "env_pck" / "agi_env"
@@ -3128,7 +3436,7 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
         uv="uv",
         uv_worker="uv",
         python_version="3.13",
-        pyvers_worker="3.13",
+        pyvers_worker="3.14",
         envars={},
         verbose=1,
         env_pck=env_pck,
@@ -3188,6 +3496,8 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     manager_toml = (app_path / "pyproject.toml").read_text(encoding="utf-8")
     worker_toml = (wenv_abs / "pyproject.toml").read_text(encoding="utf-8")
     assert "pip" in manager_toml
+    assert "manager-only" in manager_toml
+    assert "worker-only" not in manager_toml
     assert "pip==" not in worker_toml
     assert (wenv_abs / "src" / "demo_worker" / "dataset.7z").exists()
     # New contract: the generic deployer always copies archives; app-specific
@@ -3196,12 +3506,12 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     assert (wenv_abs / "src" / "demo_worker" / "Trajectory.7z").exists() is True
     pth_path = (
         deployment_local_support._project_site_packages_dir(
-            wenv_abs, python_version="3.13"
+            wenv_abs, python_version="3.14"
         )
         / "agilab_uv_sources.pth"
     )
     pth_content = pth_path.read_text(encoding="utf-8").strip()
-    # Path depth differs between POSIX (.venv/lib/python3.13/site-packages) and
+    # Path depth differs between POSIX (.venv/lib/pythonX.Y/site-packages) and
     # Windows (.venv/Lib/site-packages); compare against the actual depth.
     relative_levels = len(pth_path.parent.relative_to(wenv_abs).parts)
     expected_prefix = "../" * relative_levels + "_uv_sources"
@@ -3665,6 +3975,11 @@ async def test_deploy_local_worker_source_env_branch(tmp_path, monkeypatch):
             encoding="utf-8",
         )
         (project / "dist").mkdir(parents=True, exist_ok=True)
+    (agi_cluster / "pyproject.toml").write_text(
+        "[project]\nname='agi-cluster'\nversion='0.0.1'\n"
+        "dependencies=['uninstalled-core-dependency']\n",
+        encoding="utf-8",
+    )
     (agi_env / "dist" / "agi_env-0.0.1-py3-none-any.whl").write_text(
         "whl", encoding="utf-8"
     )
@@ -3735,6 +4050,9 @@ async def test_deploy_local_worker_source_env_branch(tmp_path, monkeypatch):
         agi_version_missing_on_pypi_fn=lambda _p: False,
         run_fn=_fake_run,
         set_env_var_fn=lambda *_a, **_k: None,
+        require_project_venv_dependencies_fn=(
+            deployment_local_support._require_project_venv_dependencies
+        ),
         log=mock.Mock(),
     )
 

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -8,6 +8,11 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from agi_env.runtime.import_layout_support import (
+    inspect_pth_import_layout,
+    is_typing_only_distribution,
+    top_level_modules_from_distribution,
+)
 from agi_env.snippet_contract import snippet_contract_block
 from agilab.environment.logging_utils import compact_log_view, render_compact_log_view
 
@@ -188,7 +193,7 @@ _REQUIREMENT_NAME_PATTERN = re.compile(
 
 
 def _is_typing_only_distribution(normalized_name: str) -> bool:
-    return normalized_name.endswith("-stubs") or normalized_name.startswith("types-")
+    return is_typing_only_distribution(normalized_name)
 
 
 def _is_placeholder_top_level_module(module: str) -> bool:
@@ -1379,30 +1384,7 @@ def _venv_site_package_dirs(venv: Path) -> tuple[Path, ...]:
 
 
 def _pth_import_roots(site_packages: Path) -> tuple[Path, ...]:
-    roots: list[Path] = []
-    try:
-        pth_files = sorted(site_packages.glob("*.pth"))
-    except OSError:
-        return ()
-    for pth_file in pth_files:
-        try:
-            lines = pth_file.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
-            continue
-        for raw_line in lines:
-            line = raw_line.strip()
-            if not line or line.startswith("#") or line.startswith("import "):
-                continue
-            candidate = Path(line).expanduser()
-            if not candidate.is_absolute():
-                candidate = site_packages / candidate
-            try:
-                candidate = candidate.resolve(strict=False)
-            except OSError:
-                pass
-            if candidate.exists() and candidate.is_dir():
-                roots.append(candidate)
-    return tuple(dict.fromkeys(roots))
+    return inspect_pth_import_layout(site_packages).roots
 
 
 def _module_available_on_root(root: Path, module: str) -> bool:
@@ -1440,12 +1422,14 @@ def _symbol_available_on_root(root: Path, dotted_module: str, symbol: str) -> bo
 
 def _missing_modules_on_import_roots(venv: Path, modules: Sequence[str]) -> tuple[tuple[str, ...], tuple[Path, ...]]:
     site_packages = _venv_site_package_dirs(venv)
-    editable_roots = tuple(root for site in site_packages for root in _pth_import_roots(site))
+    layouts = tuple(inspect_pth_import_layout(site) for site in site_packages)
+    editable_roots = tuple(root for layout in layouts for root in layout.roots)
     roots = tuple(dict.fromkeys((*site_packages, *editable_roots)))
     missing = tuple(
         module
         for module in modules
-        if not any(_module_available_on_root(root, module) for root in roots)
+        if not any(layout.exposes_module(module) for layout in layouts)
+        and not any(_module_available_on_root(root, module) for root in roots)
     )
     return missing, roots
 
@@ -1612,18 +1596,7 @@ def _top_level_modules_from_distribution(
     site_packages: Sequence[Path],
     distribution_name: str,
 ) -> tuple[str, ...]:
-    normalized = _normalized_distribution_name(distribution_name)
-    modules: list[str] = []
-    for site_package in site_packages:
-        try:
-            metadata_files = sorted(site_package.glob("*.dist-info/METADATA"))
-        except OSError:
-            continue
-        for metadata_file in metadata_files:
-            if _metadata_distribution_name(metadata_file) != normalized:
-                continue
-            modules.extend(_top_level_modules_from_metadata_dir(metadata_file.parent))
-    return tuple(dict.fromkeys(modules))
+    return top_level_modules_from_distribution(site_packages, distribution_name)
 
 
 def _dependency_modules_from_requirement(

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -1585,6 +1585,57 @@ def test_app_install_status_detects_editable_pth_import_roots(tmp_path: Path) ->
     assert status["worker_ready"] is True
 
 
+def test_app_install_status_detects_pep660_mapped_dependency_module(
+    tmp_path: Path,
+) -> None:
+    active_app = tmp_path / "routing_training_project"
+    worker_root = tmp_path / "wenv" / "routing_training_worker"
+    manager_site = _seed_fake_venv_modules(active_app / ".venv", "agi_env", "agi_node")
+    worker_site = _seed_fake_venv_modules(worker_root / ".venv", "agi_env", "agi_node")
+    active_app.mkdir(exist_ok=True)
+    worker_root.mkdir(parents=True, exist_ok=True)
+    dependency_manifest = (
+        '[project]\nname = "runtime"\ndependencies = ["link-sim-project"]\n'
+    )
+    (active_app / "pyproject.toml").write_text(
+        dependency_manifest,
+        encoding="utf-8",
+    )
+    (worker_root / "pyproject.toml").write_text(
+        dependency_manifest,
+        encoding="utf-8",
+    )
+    mapped_package = tmp_path / "link-source" / "link_sim_worker"
+    mapped_package.mkdir(parents=True)
+    (mapped_package / "__init__.py").write_text("", encoding="utf-8")
+
+    for site_packages in (manager_site, worker_site):
+        _seed_dist_info(
+            site_packages,
+            "link-sim-project",
+            top_level="link_sim_worker\n",
+        )
+        finder = "__editable___link_sim_project_1_0_finder"
+        (site_packages / f"{finder}.py").write_text(
+            f"MAPPING = {{'link_sim_worker': {str(mapped_package)!r}}}\n"
+            "NAMESPACES = {}\n",
+            encoding="utf-8",
+        )
+        (site_packages / "__editable__.link_sim_project-1.0.pth").write_text(
+            f"import {finder}; {finder}.install()\n",
+            encoding="utf-8",
+        )
+
+    status = orchestrate_page_support.app_install_status(
+        SimpleNamespace(active_app=active_app, wenv_abs=worker_root)
+    )
+
+    assert status["manager_ready"] is True
+    assert status["worker_ready"] is True
+    assert status["manager_missing_modules"] == ()
+    assert status["worker_missing_modules"] == ()
+
+
 def test_append_log_lines_filters_tracebacks_and_dask_noise():
     buffer: list[str] = []
     state = {"active": False}


### PR DESCRIPTION
## Summary

- make `AGI.install` verify the distributions declared by the manager and copied worker manifests after `uv sync`
- derive exported import names from installed metadata or local project metadata, including safe static inspection of setuptools PEP 660 finders
- require matching `dist-info` and local `direct_url.json` provenance so stale source directories or editable mappings cannot satisfy the cache/postcondition
- evaluate dependency markers independently for manager and worker Python versions, while keeping typing-only distributions metadata-only
- make ORCHESTRATE readiness recognize valid PEP 660 mappings such as `link_sim_project` exporting `link_sim_worker`

## Repro

`routing_training_project` declares the distribution `link_sim_project`, whose import package is `link_sim_worker`. A deployed editable environment could contain the source directory or finder while lacking valid distribution installation evidence, and ORCHESTRATE could also report `link_sim_worker` missing because executable `.pth` mappings were ignored.

## Root Cause

The deploy cache probed a guessed module name and accepted filesystem presence as readiness. It did not bind the declared distribution to its exported module or editable source provenance, did not enforce a post-sync installation contract, and evaluated markers with the controller interpreter rather than each target interpreter.

## Regression Test

- polluted environment with a shadow `link_sim_worker` but no `link_sim_project.dist-info` forces sync and fails closed until installation evidence exists
- manager Python 3.13 and worker Python 3.14 receive independent marker-filtered dependency contracts
- PEP 660 mappings accept packages and ABI-tagged extensions, reject empty mapped directories, and are parsed without executing finder code
- source deployments ignore unrelated core-only dependencies installed with `--no-deps`
- typing-only distributions still require metadata without requiring a runtime import module
- ORCHESTRATE resolves `link_sim_worker` from manager and worker PEP 660 evidence

## Validation

- focused deployment, import-layout, and ORCHESTRATE suites passed
- full `agi-env` and shared core test suites passed
- shared-core strict typing passed
- targeted Ruff checks passed
- live readiness probe against `routing_training_project` and `routing_training_worker`: manager and worker ready, no missing modules
- browser robot not run because the existing localhost Streamlit process is user-owned; the exact page readiness function was exercised against the live environments

## Review Evidence

- Codex sub-agent contract trace, read-only: identified the distribution/import-name and cache gap
- Codex sub-agent live-environment probe, read-only: identified the manager environment failure without altering user-owned processes
- two Codex adversarial review passes, read-only: all marker, provenance, typing-only, source-mode, and empty-mapping findings addressed; final result clean
- sub-agent model versions: unavailable

## Agent Metadata

- Tokki: 1.0.40
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
