### PR TITLE
fix(orchestrate): load safe editable manager dependencies

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 36792f9db9cb26858aebdd794ac7bae096c2c7d26ae6ba98c05c63e428bb4763
+source_sha256: 210ec42e45e5904bc20ea49014e5a923b500193970081ed873df9ce04535546d
 title: ANALYSIS page session environment and sidecar ownership contract
-verified_commit: 844b0c05447aacdd999592aaa1f43d1e3373f8ed
+verified_commit: c8387f96015503d20420664334f58968a9390551
 ---
 
 # ANALYSIS page session environment and sidecar ownership contract
@@ -65,3 +65,11 @@ with a stale free-threaded ABI is replaced instead of silently reused. Analysis
 view sidecars retain their per-project interpreter selection. The polluted-venv
 regression, focused ANALYSIS/UI tests, AGI GUI parity profile, and an isolated
 browser launch of `lab_stages.ipynb` passed.
+
+2026-07-30 re-verification: hosted inline views now prepend the active app and
+safe editable manager dependency source roots while applying the same roots to
+module eviction and restoration. Manager `site-packages`, foreign hosted
+runtime packages, native extensions, and source-tree escapes remain excluded.
+Focused ANALYSIS/UI and import-isolation tests, the AGI GUI parity profile, the
+real routing-training form import, and an isolated ORCHESTRATE browser robot
+scenario passed.

--- a/src/agilab/app_management/app_surface.py
+++ b/src/agilab/app_management/app_surface.py
@@ -299,6 +299,49 @@ def _isolated_import_process_state() -> Any:
     return isolated_import_process_state
 
 
+def app_editable_import_roots(
+    active_app: str | Path,
+) -> tuple[Path, ...]:
+    """Return isolated source roots for an app and its installed editables.
+
+    ``AGI.install`` owns the manager environment, but inline Streamlit forms and
+    surfaces execute in the AGILAB UI interpreter.  This reads the manager's
+    editable layout as data, without executing its ``.pth`` code or adding its
+    foreign-version ``site-packages`` directory.
+    """
+
+    app_path = Path(active_app).expanduser().resolve(strict=False)
+    app_source = app_path / "src"
+    try:
+        from agi_env.runtime import import_layout_support
+    except ModuleNotFoundError as exc:
+        if exc.name and not (
+            exc.name == "agi_env" or exc.name.startswith("agi_env.")
+        ):
+            raise
+        return (app_source,)
+    except ImportError as exc:
+        raise RuntimeError(
+            "The installed AGILAB UI runtime cannot inspect manager editables. "
+            "Upgrade the aligned AGILAB packages and restart Streamlit."
+        ) from exc
+    editable_roots = getattr(
+        import_layout_support,
+        "hosted_editable_source_import_roots",
+        None,
+    )
+    if not callable(editable_roots):
+        raise RuntimeError(
+            "The installed AGILAB UI runtime is stale: agi_env does not expose "
+            "hosted editable import support. Upgrade the aligned AGILAB packages "
+            "and restart Streamlit."
+        )
+
+    return tuple(
+        dict.fromkeys((app_source, *editable_roots(app_path / ".venv")))
+    )
+
+
 def render_app_surface(
     active_app: str | Path | None,
     *,
@@ -319,7 +362,12 @@ def render_app_surface(
     entrypoint = resolve_app_surface_entrypoint(active_app_path, selected.entrypoint)
     if entrypoint is None:
         return False
-    import_roots = (active_app_path / "src", entrypoint.parent)
+    app_import_roots = app_editable_import_roots(active_app_path)
+    import_roots = tuple(
+        dict.fromkeys(
+            (app_import_roots[0], entrypoint.parent, *app_import_roots[1:])
+        )
+    )
     with _isolated_import_process_state()(
         argv=[str(entrypoint), "--active-app", str(active_app_path)],
         prepend_paths=import_roots,

--- a/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
+++ b/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
@@ -90,12 +90,43 @@ def _load_module(path: Path) -> ModuleType:
     return module
 
 
+def _manager_editable_import_roots(active_app: Path) -> tuple[Path, ...]:
+    try:
+        from agi_env.runtime import import_layout_support
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "The installed AGILAB UI runtime cannot inspect manager editables. "
+            "Upgrade the aligned AGILAB packages and restart Streamlit."
+        ) from exc
+    resolver = getattr(
+        import_layout_support,
+        "hosted_editable_source_import_roots",
+        None,
+    )
+    if not callable(resolver):
+        raise RuntimeError(
+            "The installed AGILAB UI runtime is stale: agi_env does not expose "
+            "hosted editable import support. Upgrade the aligned AGILAB packages "
+            "and restart Streamlit."
+        )
+    return resolver(active_app / ".venv")
+
+
 def _run_app_ui(entrypoint: Path, active_app: Path) -> None:
     app_src = active_app / "src"
+    import_roots = tuple(
+        dict.fromkeys(
+            (
+                app_src,
+                entrypoint.parent,
+                *_manager_editable_import_roots(active_app),
+            )
+        )
+    )
     with isolated_import_process_state(
         argv=[str(entrypoint), "--active-app", str(active_app)],
-        prepend_paths=(app_src, entrypoint.parent),
-        module_roots=(app_src, entrypoint.parent),
+        prepend_paths=import_roots,
+        module_roots=import_roots,
         timeout=_APP_UI_INLINE_IMPORT_LEASE_TIMEOUT_SECONDS,
     ):
         module = _load_module(entrypoint)

--- a/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
@@ -16,6 +16,31 @@ from urllib.parse import unquote, urlsplit
 _EDITABLE_FINDER_PREFIX = "__editable___"
 _EDITABLE_FINDER_SUFFIX = "_finder"
 _MODULE_SUFFIXES = (".py", ".so", ".pyd", ".dylib")
+_NATIVE_MODULE_SUFFIXES = (".so", ".pyd", ".dylib")
+_NATIVE_SCAN_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+    }
+)
+HOSTED_UI_RUNTIME_MODULES = frozenset(
+    {
+        "agilab",
+        "agi_apps",
+        "agi_cluster",
+        "agi_core",
+        "agi_env",
+        "agi_gui",
+        "agi_node",
+        "agi_pages",
+        "agi_web",
+        "streamlit",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -85,6 +110,47 @@ def inspect_pth_import_layout(site_packages: Path) -> PthImportLayout:
         roots=tuple(dict.fromkeys(roots)),
         module_locations=tuple(dict.fromkeys(module_locations)),
     )
+
+
+def hosted_editable_source_import_roots(venv: Path) -> tuple[Path, ...]:
+    """Return manager-owned editable source roots safe for hosted UI imports.
+
+    The manager interpreter may use a different Python minor version from the
+    long-lived Streamlit process.  This function therefore reads ``.pth`` and
+    canonical PEP 660 metadata without executing it, requires an editable local
+    ``direct_url.json`` owner, rejects foreign AGILAB UI runtime packages, and
+    refuses source trees containing native code or external directory symlinks.
+    The manager's ``site-packages`` directory itself is never returned.
+    """
+
+    manager_version = _venv_python_version(venv)
+    roots: list[Path] = []
+    for site_packages in _active_venv_site_package_dirs(venv, manager_version):
+        editable_projects = _editable_project_roots(site_packages)
+        if not editable_projects:
+            continue
+        layout = inspect_pth_import_layout(site_packages)
+        for root in layout.roots:
+            if not any(_path_is_within(root, project) for project in editable_projects):
+                continue
+            if _hosted_source_root_is_safe(root):
+                roots.append(root)
+        for module, location in layout.module_locations:
+            owners = tuple(
+                project
+                for project in editable_projects
+                if _path_is_within(location, project)
+            )
+            if not owners:
+                continue
+            source_root = _structural_source_import_root(module, location)
+            if source_root is None or not any(
+                _path_is_within(source_root, owner) for owner in owners
+            ):
+                continue
+            if _hosted_source_root_is_safe(source_root):
+                roots.append(source_root)
+    return tuple(dict.fromkeys(roots))
 
 
 def top_level_modules_from_distribution(
@@ -333,6 +399,181 @@ def _resolve_without_failure(path: Path) -> Path:
         return path
 
 
+def _venv_python_version(venv: Path) -> tuple[int, int] | None:
+    try:
+        lines = (venv / "pyvenv.cfg").read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        key, separator, raw_value = line.partition("=")
+        if not separator or key.strip().lower() not in {"version", "version_info"}:
+            continue
+        match = re.match(r"\s*(\d+)\.(\d+)", raw_value)
+        if match is not None:
+            return int(match.group(1)), int(match.group(2))
+    return None
+
+
+def _active_venv_site_package_dirs(
+    venv: Path,
+    manager_version: tuple[int, int] | None,
+) -> tuple[Path, ...]:
+    if os.name == "nt":
+        candidate = venv / "Lib" / "site-packages"
+        return (candidate,) if candidate.is_dir() else ()
+    try:
+        candidates = tuple(
+            candidate
+            for candidate in sorted((venv / "lib").glob("python*/site-packages"))
+            if candidate.is_dir()
+        )
+    except OSError:
+        return ()
+    if not candidates:
+        return ()
+    if manager_version is None:
+        return candidates if len(candidates) == 1 else ()
+    directory_name = f"python{manager_version[0]}.{manager_version[1]}"
+    supported_directory_names = {directory_name, f"{directory_name}t"}
+    matching = tuple(
+        candidate
+        for candidate in candidates
+        if candidate.parent.name in supported_directory_names
+    )
+    return matching if len(matching) == 1 else ()
+
+
+def _editable_project_roots(site_packages: Path) -> tuple[Path, ...]:
+    try:
+        direct_url_files = sorted(site_packages.glob("*.dist-info/direct_url.json"))
+    except OSError:
+        return ()
+    projects: list[Path] = []
+    for direct_url_file in direct_url_files:
+        project = _direct_url_project(direct_url_file, editable_only=True)
+        try:
+            if project is not None and project.is_dir():
+                projects.append(project)
+        except OSError:
+            continue
+    return tuple(dict.fromkeys(projects))
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        _resolve_without_failure(path).relative_to(_resolve_without_failure(root))
+        return True
+    except ValueError:
+        return False
+
+
+def _structural_source_import_root(module: str, location: Path) -> Path | None:
+    """Project a non-aliased pure-Python PEP 660 mapping onto ``sys.path``."""
+
+    parts = module.split(".")
+    if not parts or any(not part.isidentifier() for part in parts):
+        return None
+    try:
+        source_backed = location.is_dir() or location.with_suffix(".py").is_file()
+    except OSError:
+        return None
+    if not source_backed:
+        return None
+    root = location
+    for part in reversed(parts):
+        if root.name != part:
+            return None
+        root = root.parent
+    try:
+        return root.resolve(strict=False) if root.is_dir() else None
+    except OSError:
+        return None
+
+
+def _root_exposes_hosted_runtime(root: Path) -> bool:
+    try:
+        return any(
+            (root / module).is_dir()
+            or (root / f"{module}.py").is_file()
+            or any(
+                (root / f"{module}{suffix}").is_file()
+                or any(root.glob(f"{module}.*{suffix}"))
+                for suffix in _NATIVE_MODULE_SUFFIXES
+            )
+            for module in HOSTED_UI_RUNTIME_MODULES
+        )
+    except OSError:
+        return True
+
+
+def _root_contains_native_code(root: Path) -> bool:
+    """Fail closed on native modules or directory links escaping ``root``."""
+
+    scan_failed = False
+
+    def _record_error(_error: OSError) -> None:
+        nonlocal scan_failed
+        scan_failed = True
+
+    try:
+        root = root.resolve(strict=True)
+    except (FileNotFoundError, OSError, RuntimeError):
+        return True
+
+    seen_directories: set[tuple[int, int]] = set()
+    try:
+        for dirpath, dirnames, filenames in os.walk(
+            root,
+            topdown=True,
+            onerror=_record_error,
+            followlinks=True,
+        ):
+            current = Path(dirpath)
+            try:
+                current_stat = current.stat()
+            except OSError:
+                return True
+            current_identity = (current_stat.st_dev, current_stat.st_ino)
+            if current_identity in seen_directories:
+                dirnames[:] = []
+                continue
+            seen_directories.add(current_identity)
+
+            dirnames[:] = sorted(
+                name for name in dirnames if name not in _NATIVE_SCAN_SKIP_DIRS
+            )
+            safe_dirnames: list[str] = []
+            for name in dirnames:
+                child = current / name
+                try:
+                    if child.is_symlink():
+                        child.resolve(strict=True).relative_to(root)
+                    child_stat = child.stat()
+                except (FileNotFoundError, OSError, RuntimeError, ValueError):
+                    return True
+                child_identity = (child_stat.st_dev, child_stat.st_ino)
+                if child_identity not in seen_directories:
+                    safe_dirnames.append(name)
+            dirnames[:] = safe_dirnames
+            if any(
+                Path(name).suffix.lower() in _NATIVE_MODULE_SUFFIXES
+                for name in filenames
+            ):
+                return True
+    except OSError:
+        return True
+    return scan_failed
+
+
+def _hosted_source_root_is_safe(root: Path) -> bool:
+    if _root_exposes_hosted_runtime(root):
+        return False
+    return not _root_contains_native_code(root)
+
+
 def _valid_dotted_module(value: object) -> bool:
     return (
         isinstance(value, str)
@@ -374,12 +615,25 @@ def _distribution_metadata_dirs(
     return tuple(dict.fromkeys(metadata_dirs))
 
 
-def _direct_url_project(direct_url_file: Path) -> Path | None:
+def _direct_url_project(
+    direct_url_file: Path,
+    *,
+    editable_only: bool = False,
+) -> Path | None:
     try:
         payload = json.loads(direct_url_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         return None
-    url = payload.get("url") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        return None
+    if editable_only:
+        directory_info = payload.get("dir_info")
+        if (
+            not isinstance(directory_info, dict)
+            or directory_info.get("editable") is not True
+        ):
+            return None
+    url = payload.get("url")
     if not isinstance(url, str):
         return None
     parsed = urlsplit(url)

--- a/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/import_layout_support.py
@@ -27,20 +27,8 @@ _NATIVE_SCAN_SKIP_DIRS = frozenset(
         "__pycache__",
     }
 )
-HOSTED_UI_RUNTIME_MODULES = frozenset(
-    {
-        "agilab",
-        "agi_apps",
-        "agi_cluster",
-        "agi_core",
-        "agi_env",
-        "agi_gui",
-        "agi_node",
-        "agi_pages",
-        "agi_web",
-        "streamlit",
-    }
-)
+_HOSTED_RUNTIME_EXACT_MODULES = frozenset({"agilab", "streamlit"})
+_HOSTED_RUNTIME_MODULE_PREFIXES = ("agi_",)
 
 
 @dataclass(frozen=True)
@@ -495,18 +483,29 @@ def _structural_source_import_root(module: str, location: Path) -> Path | None:
 
 def _root_exposes_hosted_runtime(root: Path) -> bool:
     try:
-        return any(
-            (root / module).is_dir()
-            or (root / f"{module}.py").is_file()
-            or any(
-                (root / f"{module}{suffix}").is_file()
-                or any(root.glob(f"{module}.*{suffix}"))
-                for suffix in _NATIVE_MODULE_SUFFIXES
-            )
-            for module in HOSTED_UI_RUNTIME_MODULES
-        )
+        entries = sorted(root.iterdir(), key=lambda path: path.name)
     except OSError:
         return True
+    for entry in entries:
+        try:
+            if entry.is_dir():
+                module = entry.name
+            elif entry.is_file() and entry.suffix.lower() in (
+                ".py",
+                *_NATIVE_MODULE_SUFFIXES,
+            ):
+                module = entry.name.split(".", 1)[0]
+            else:
+                continue
+        except OSError:
+            return True
+        if not module.isidentifier():
+            continue
+        if module in _HOSTED_RUNTIME_EXACT_MODULES or module.startswith(
+            _HOSTED_RUNTIME_MODULE_PREFIXES
+        ):
+            return True
+    return False
 
 
 def _root_contains_native_code(root: Path) -> bool:

--- a/src/agilab/core/agi-env/src/agi_env/ui/sidecar_registry.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/sidecar_registry.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 import hashlib
 import hmac
+from importlib.machinery import EXTENSION_SUFFIXES
 import json
 import os
 from pathlib import Path
@@ -78,6 +79,13 @@ _PREPARATION_THREAD_GUARDS: dict[str, threading.RLock] = {}
 HOSTED_INLINE_RENDER_LEASE = threading.RLock()
 HOSTED_INLINE_RENDER_SESSION_LEASE = threading.Lock()
 _HOSTED_INLINE_RENDER_LOCK_TIMEOUT_SECONDS = 5.0
+_NATIVE_IMPORT_SUFFIXES = tuple(
+    sorted(
+        {*EXTENSION_SUFFIXES, ".dylib", ".pyd", ".so"},
+        key=len,
+        reverse=True,
+    )
+)
 
 
 @contextmanager
@@ -127,27 +135,44 @@ def _importable_root_names(root: Path) -> set[str]:
     except OSError:
         return names
     for child in children:
-        if child.is_file() and child.suffix == ".py" and child.stem != "__init__":
-            names.add(child.stem)
-        elif child.is_dir() and (child / "__init__.py").is_file():
+        if child.is_file():
+            if child.suffix == ".py" and child.stem != "__init__":
+                names.add(child.stem)
+                continue
+            for suffix in _NATIVE_IMPORT_SUFFIXES:
+                if not child.name.endswith(suffix):
+                    continue
+                module_name = child.name[: -len(suffix)].partition(".")[0]
+                if module_name.isidentifier():
+                    names.add(module_name)
+                break
+        elif child.is_dir() and child.name.isidentifier():
+            # PEP 420 namespace packages are importable without __init__.py and
+            # must be evicted/restored just like regular packages.
             names.add(child.name)
     return names
 
 
 def _module_is_below(module: Any, roots: tuple[Path, ...]) -> bool:
-    raw_path = getattr(module, "__file__", None)
-    if not raw_path:
-        return False
+    raw_paths: list[Any] = []
+    raw_file = getattr(module, "__file__", None)
+    if raw_file:
+        raw_paths.append(raw_file)
     try:
-        module_path = Path(raw_path).resolve(strict=False)
-    except (OSError, TypeError, ValueError):
-        return False
-    for root in roots:
+        raw_paths.extend(getattr(module, "__path__", ()) or ())
+    except TypeError:
+        pass
+    for raw_path in raw_paths:
         try:
-            module_path.relative_to(root)
-            return True
-        except ValueError:
+            module_path = Path(raw_path).resolve(strict=False)
+        except (OSError, TypeError, ValueError):
             continue
+        for root in roots:
+            try:
+                module_path.relative_to(root)
+                return True
+            except ValueError:
+                continue
     return False
 
 

--- a/src/agilab/core/agi-env/test/test_import_layout_support.py
+++ b/src/agilab/core/agi-env/test/test_import_layout_support.py
@@ -324,8 +324,8 @@ def test_hosted_editable_roots_use_only_owned_active_minor_safe_sources(
     hosted_project = tmp_path / "hosted-runtime-project"
     hosted_root = hosted_project / "src"
     _write_importable_package(hosted_root, "otherwise_safe_dep")
-    (hosted_root / "agi_web").mkdir(parents=True)
-    (hosted_root / "agi_core").mkdir()
+    (hosted_root / "agi_future_runtime").mkdir(parents=True)
+    (hosted_root / "streamlit.py").write_text("", encoding="utf-8")
     _write_editable_owner(active_site, "hosted_runtime_project", hosted_project)
     (active_site / "40-hosted-runtime.pth").write_text(
         f"{hosted_root}\n",

--- a/src/agilab/core/agi-env/test/test_import_layout_support.py
+++ b/src/agilab/core/agi-env/test/test_import_layout_support.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import sys
+
+import pytest
 
 from agi_env.runtime.import_layout_support import (
     distribution_installation_matches,
+    hosted_editable_source_import_roots,
     inspect_pth_import_layout,
     top_level_modules_from_distribution,
     top_level_modules_from_project,
@@ -21,6 +26,33 @@ def _write_finder(
         f"import {module}; {module}.install()\n",
         encoding="utf-8",
     )
+
+
+def _write_editable_owner(
+    site_packages: Path,
+    distribution: str,
+    project: Path,
+    *,
+    editable: bool = True,
+) -> None:
+    metadata = site_packages / f"{distribution}-1.0.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": project.resolve().as_uri(),
+                "dir_info": {"editable": editable},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_importable_package(root: Path, module: str) -> Path:
+    package = root / module
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    return package
 
 
 def test_inspect_pth_import_layout_reads_paths_and_pep660_mapping_without_execution(
@@ -232,3 +264,213 @@ def test_distribution_installation_requires_metadata_and_local_source_provenance
         "link_sim_project",
         expected_projects=(source_project,),
     )
+
+
+def test_hosted_editable_roots_use_only_owned_active_minor_safe_sources(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    venv = tmp_path / "manager-venv"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        "version_info = 99.99.1\n",
+        encoding="utf-8",
+    )
+    active_site = (
+        venv / "Lib" / "site-packages"
+        if os.name == "nt"
+        else venv / "lib" / "python99.99" / "site-packages"
+    )
+    stale_site = venv / "lib" / "python98.98" / "site-packages"
+    active_site.mkdir(parents=True)
+    stale_site.mkdir(parents=True)
+
+    owned_project = tmp_path / "owned-project"
+    owned_root = owned_project / "src"
+    _write_importable_package(owned_root, "owned_dep")
+    _write_editable_owner(active_site, "owned_project", owned_project)
+    (active_site / "10-owned.pth").write_text(
+        f"{owned_root}\n",
+        encoding="utf-8",
+    )
+
+    stale_project = tmp_path / "stale-project"
+    stale_root = stale_project / "src"
+    _write_importable_package(stale_root, "stale_dep")
+    _write_editable_owner(stale_site, "stale_project", stale_project)
+    (stale_site / "stale.pth").write_text(f"{stale_root}\n", encoding="utf-8")
+
+    unowned_root = tmp_path / "unowned" / "src"
+    _write_importable_package(unowned_root, "unowned_dep")
+    (active_site / "20-unowned.pth").write_text(
+        f"{unowned_root}\n",
+        encoding="utf-8",
+    )
+
+    noneditable_project = tmp_path / "noneditable-project"
+    noneditable_root = noneditable_project / "src"
+    _write_importable_package(noneditable_root, "noneditable_dep")
+    _write_editable_owner(
+        active_site,
+        "noneditable_project",
+        noneditable_project,
+        editable=False,
+    )
+    (active_site / "30-noneditable.pth").write_text(
+        f"{noneditable_root}\n",
+        encoding="utf-8",
+    )
+
+    hosted_project = tmp_path / "hosted-runtime-project"
+    hosted_root = hosted_project / "src"
+    _write_importable_package(hosted_root, "otherwise_safe_dep")
+    (hosted_root / "agi_web").mkdir(parents=True)
+    (hosted_root / "agi_core").mkdir()
+    _write_editable_owner(active_site, "hosted_runtime_project", hosted_project)
+    (active_site / "40-hosted-runtime.pth").write_text(
+        f"{hosted_root}\n",
+        encoding="utf-8",
+    )
+
+    native_project = tmp_path / "native-project"
+    native_root = native_project / "src"
+    native_package = _write_importable_package(native_root, "native_dep")
+    (native_package / "accelerator.so").write_bytes(b"")
+    _write_editable_owner(active_site, "native_project", native_project)
+    (active_site / "50-native.pth").write_text(
+        f"{native_root}\n",
+        encoding="utf-8",
+    )
+
+    mapped_project = tmp_path / "mapped-project"
+    mapped_package = _write_importable_package(mapped_project / "src", "mapped_dep")
+    aliased_project = tmp_path / "aliased-project"
+    aliased_package = _write_importable_package(
+        aliased_project / "src",
+        "actual_dep",
+    )
+    escaped_project = tmp_path / "escaped-parent" / "owned_project"
+    escaped_package = _write_importable_package(escaped_project, "pkg")
+    _write_editable_owner(active_site, "mapped_project", mapped_project)
+    _write_editable_owner(active_site, "aliased_project", aliased_project)
+    _write_editable_owner(active_site, "escaped_project", escaped_project)
+    finder = "__editable___mapped_projects_1_0_finder"
+    _write_finder(
+        active_site,
+        finder,
+        "\n".join(
+            (
+                "MAPPING = {",
+                f"    'mapped_dep': {str(mapped_package)!r},",
+                f"    'alias_dep': {str(aliased_package)!r},",
+                f"    'owned_project.pkg': {str(escaped_package)!r},",
+                "}",
+                "NAMESPACES = {}",
+            )
+        ),
+    )
+
+    # A root already present in the hosted interpreter remains part of the
+    # isolation contract; callers need it in module_roots to evict stale names.
+    monkeypatch.syspath_prepend(str(owned_root))
+
+    roots = hosted_editable_source_import_roots(venv)
+
+    assert roots == (owned_root.resolve(), mapped_package.parent.resolve())
+    assert stale_root.resolve() not in roots
+    assert unowned_root.resolve() not in roots
+    assert noneditable_root.resolve() not in roots
+    assert hosted_root.resolve() not in roots
+    assert native_root.resolve() not in roots
+    assert aliased_package.parent.resolve() not in roots
+    assert escaped_project.parent.resolve() not in roots
+    assert active_site.resolve() not in roots
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows venvs do not use lib/pythonXt")
+def test_hosted_editable_roots_support_free_threaded_site_for_pure_source(
+    tmp_path: Path,
+) -> None:
+    venv = tmp_path / "free-threaded-venv"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        "version_info = 97.97.0\n",
+        encoding="utf-8",
+    )
+    site_packages = venv / "lib" / "python97.97t" / "site-packages"
+    project = tmp_path / "pure-project"
+    source_root = project / "src"
+    _write_importable_package(source_root, "pure_dep")
+    _write_editable_owner(site_packages, "pure_project", project)
+    (site_packages / "pure-project.pth").write_text(
+        f"{source_root}\n",
+        encoding="utf-8",
+    )
+
+    assert hosted_editable_source_import_roots(venv) == (source_root.resolve(),)
+
+
+def test_hosted_editable_roots_reject_native_code_in_build_on_same_minor(
+    tmp_path: Path,
+) -> None:
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    venv = tmp_path / "same-minor-venv"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        f"version_info = {version}.0\n",
+        encoding="utf-8",
+    )
+    site_packages = (
+        venv / "Lib" / "site-packages"
+        if os.name == "nt"
+        else venv / "lib" / f"python{version}" / "site-packages"
+    )
+    project = tmp_path / "native-build-project"
+    source_root = project / "src"
+    _write_importable_package(source_root, "pure_surface")
+    native_build = source_root / "build" / "native_dep.so"
+    native_build.parent.mkdir()
+    native_build.write_bytes(b"native")
+    _write_editable_owner(site_packages, "native_build_project", project)
+    (site_packages / "native-build-project.pth").write_text(
+        f"{source_root}\n",
+        encoding="utf-8",
+    )
+
+    assert hosted_editable_source_import_roots(venv) == ()
+
+
+def test_hosted_editable_roots_reject_external_directory_symlinks(
+    tmp_path: Path,
+) -> None:
+    venv = tmp_path / "symlink-venv"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        "version_info = 96.96.0\n",
+        encoding="utf-8",
+    )
+    site_packages = (
+        venv / "Lib" / "site-packages"
+        if os.name == "nt"
+        else venv / "lib" / "python96.96" / "site-packages"
+    )
+    project = tmp_path / "symlink-project"
+    source_root = project / "src"
+    source_root.mkdir(parents=True)
+    external_package = tmp_path / "external-package"
+    external_package.mkdir()
+    (external_package / "native_dep.so").write_bytes(b"native")
+    try:
+        (source_root / "linked_dep").symlink_to(
+            external_package,
+            target_is_directory=True,
+        )
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    _write_editable_owner(site_packages, "symlink_project", project)
+    (site_packages / "symlink-project.pth").write_text(
+        f"{source_root}\n",
+        encoding="utf-8",
+    )
+
+    assert hosted_editable_source_import_roots(venv) == ()

--- a/src/agilab/core/agi-env/test/test_sidecar_registry.py
+++ b/src/agilab/core/agi-env/test/test_sidecar_registry.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import importlib
 import socket
 import subprocess
 import sys
 import threading
 import time
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import psutil
 import pytest
@@ -703,3 +704,109 @@ def test_hosted_import_lease_is_reentrant_on_the_owning_thread() -> None:
                 nested = True
 
     assert nested is True
+
+
+def test_isolated_import_state_replaces_and_restores_pep420_namespaces(
+    tmp_path: Path,
+) -> None:
+    namespace = "_agi_env_test_pep420_namespace"
+    fresh_namespace = "_agi_env_test_fresh_namespace"
+    old_root = tmp_path / "old"
+    current_root = tmp_path / "current"
+    old_package = old_root / namespace
+    current_package = current_root / namespace
+    old_package.mkdir(parents=True)
+    current_package.mkdir(parents=True)
+    (old_package / "value.py").write_text("VALUE = 'old'\n", encoding="utf-8")
+    (current_package / "value.py").write_text(
+        "VALUE = 'current'\n",
+        encoding="utf-8",
+    )
+    (current_package / "transient.py").write_text(
+        "VALUE = 'transient'\n",
+        encoding="utf-8",
+    )
+    (current_root / fresh_namespace).mkdir()
+
+    relevant_names = (
+        namespace,
+        f"{namespace}.value",
+        f"{namespace}.transient",
+        fresh_namespace,
+    )
+    missing = object()
+    previous_modules = {name: sys.modules.get(name, missing) for name in relevant_names}
+    original_path = list(sys.path)
+    try:
+        sys.path.insert(0, str(old_root))
+        importlib.invalidate_caches()
+        old_namespace = importlib.import_module(namespace)
+        old_value = importlib.import_module(f"{namespace}.value")
+        assert old_value.VALUE == "old"
+        sys.path.remove(str(old_root))
+        path_before_scope = list(sys.path)
+
+        with sidecar_registry_module.isolated_import_process_state(
+            prepend_paths=(current_root,),
+            module_roots=(current_root,),
+        ):
+            current_namespace = importlib.import_module(namespace)
+            current_value = importlib.import_module(f"{namespace}.value")
+            transient = importlib.import_module(f"{namespace}.transient")
+            imported_fresh_namespace = importlib.import_module(fresh_namespace)
+
+            assert current_namespace is not old_namespace
+            assert current_value is not old_value
+            assert current_value.VALUE == "current"
+            assert transient.VALUE == "transient"
+            assert tuple(imported_fresh_namespace.__path__) == (
+                str(current_root / fresh_namespace),
+            )
+
+        assert sys.path == path_before_scope
+        assert sys.modules[namespace] is old_namespace
+        assert sys.modules[f"{namespace}.value"] is old_value
+        assert f"{namespace}.transient" not in sys.modules
+        assert fresh_namespace not in sys.modules
+    finally:
+        sys.path[:] = original_path
+        for name, previous in previous_modules.items():
+            if previous is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+        importlib.invalidate_caches()
+
+
+def test_isolated_import_state_restores_tagged_native_module_names(
+    tmp_path: Path,
+) -> None:
+    module_name = "_agi_env_test_native_scope"
+    old_root = tmp_path / "old-native"
+    current_root = tmp_path / "current-native"
+    old_root.mkdir()
+    current_root.mkdir()
+    old_module_path = old_root / f"{module_name}.cpython-old.so"
+    current_module_path = current_root / f"{module_name}.cpython-current.so"
+    old_module_path.write_bytes(b"")
+    current_module_path.write_bytes(b"")
+    old_module = ModuleType(module_name)
+    old_module.__file__ = str(old_module_path)
+    previous = sys.modules.get(module_name)
+    sys.modules[module_name] = old_module
+    try:
+        with sidecar_registry_module.isolated_import_process_state(
+            prepend_paths=(current_root,),
+            module_roots=(current_root,),
+        ):
+            assert module_name not in sys.modules
+            current_module = ModuleType(module_name)
+            current_module.__file__ = str(current_module_path)
+            sys.modules[module_name] = current_module
+
+        assert sys.modules[module_name] is old_module
+    finally:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -208,6 +208,7 @@ import_agilab_symbols(
     globals(),
     "agilab.app_surface",
     {
+        "app_editable_import_roots": "app_editable_import_roots",
         "configured_app_surface_entrypoint": "configured_app_surface_entrypoint",
         "render_app_surface": "render_app_surface",
     },
@@ -362,10 +363,11 @@ AgiEnv = _LazyAgiEnv()
 
 
 def _active_app_import_scope(env: Any):
-    app_src = Path(env.active_app).expanduser().resolve(strict=False) / "src"
+    active_app = Path(env.active_app).expanduser().resolve(strict=False)
+    import_roots = app_editable_import_roots(active_app)
     return isolated_import_process_state(
-        prepend_paths=(app_src,),
-        module_roots=(app_src,),
+        prepend_paths=import_roots,
+        module_roots=import_roots,
     )
 
 

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -153,6 +153,7 @@ import_agilab_symbols(
     globals(),
     "agilab.app_surface",
     {
+        "app_editable_import_roots": "app_editable_import_roots",
         "app_surface_config": "app_surface_config",
         "app_surface_title": "app_surface_title",
         "configured_app_surface_entrypoint": "configured_app_surface_entrypoint",
@@ -3505,6 +3506,16 @@ async def _render_view_page_inline(view_path: Path, active_app: str) -> None:
         if not resolved_view.exists():
             raise FileNotFoundError(f"Analysis view does not exist: {resolved_view}")
 
+        import_roots = [resolved_view.parent]
+        if active_app:
+            try:
+                active_app_path = Path(active_app).expanduser().resolve(strict=True)
+            except OSError:
+                active_app_path = None
+            if active_app_path is not None and active_app_path.is_dir():
+                import_roots.extend(app_editable_import_roots(active_app_path))
+        scoped_import_roots = tuple(dict.fromkeys(import_roots))
+
         module_name = f"agilab_analysis_inline_{resolved_view.stem}_{_short_page_token(resolved_view)}"
         original_module = sys.modules.get(module_name)
         try:
@@ -3514,8 +3525,8 @@ async def _render_view_page_inline(view_path: Path, active_app: str) -> None:
 
             with isolated_import_process_state(
                 argv=render_argv,
-                prepend_paths=(resolved_view.parent,),
-                module_roots=(resolved_view.parent,),
+                prepend_paths=scoped_import_roots,
+                module_roots=scoped_import_roots,
             ):
                 spec = importlib.util.spec_from_file_location(module_name, resolved_view)
                 if spec is None or spec.loader is None:

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 from contextlib import contextmanager
 import importlib.util
+import json
 import os
 import signal
 import subprocess
@@ -3000,6 +3001,93 @@ def main():
     asyncio.run(module._render_view_page_inline(page_path, str(active_app)))
 
     assert fake_streamlit.session_state["inline_active_app"] == str(active_app)
+
+
+def test_render_view_page_inline_scopes_app_and_owned_editable_dependencies(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_analysis_module()
+    coordination = types.ModuleType("agilab_inline_editable_coordination")
+    monkeypatch.setitem(sys.modules, coordination.__name__, coordination)
+
+    active_app = tmp_path / "demo_project"
+    app_source = active_app / "src"
+    app_source.mkdir(parents=True)
+    (app_source / "app_inline_helper.py").write_text(
+        'VALUE = "app"\n',
+        encoding="utf-8",
+    )
+
+    dependency_project = tmp_path / "manager_dependency"
+    dependency_source = dependency_project / "src"
+    dependency_source.mkdir(parents=True)
+    (dependency_source / "manager_inline_dependency.py").write_text(
+        'VALUE = "manager"\n',
+        encoding="utf-8",
+    )
+
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    manager_venv = active_app / ".venv"
+    manager_venv.mkdir()
+    (manager_venv / "pyvenv.cfg").write_text(
+        f"version_info = {python_version}.0\n",
+        encoding="utf-8",
+    )
+    site_packages = (
+        manager_venv / "Lib" / "site-packages"
+        if os.name == "nt"
+        else manager_venv / "lib" / f"python{python_version}" / "site-packages"
+    )
+    site_packages.mkdir(parents=True)
+    (site_packages / "manager-dependency.pth").write_text(
+        f"{dependency_source}\n",
+        encoding="utf-8",
+    )
+    dist_info = site_packages / "manager_dependency-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": dependency_project.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    view_dir = tmp_path / "views"
+    view_dir.mkdir()
+    (view_dir / "view_inline_helper.py").write_text(
+        'VALUE = "view"\n',
+        encoding="utf-8",
+    )
+    page_path = view_dir / "demo_view.py"
+    page_path.write_text(
+        "import app_inline_helper\n"
+        "import manager_inline_dependency\n"
+        "import view_inline_helper\n"
+        "import agilab_inline_editable_coordination as coordination\n\n"
+        "def main():\n"
+        "    coordination.values = (\n"
+        "        view_inline_helper.VALUE,\n"
+        "        app_inline_helper.VALUE,\n"
+        "        manager_inline_dependency.VALUE,\n"
+        "    )\n",
+        encoding="utf-8",
+    )
+    original_path = list(sys.path)
+
+    asyncio.run(module._render_view_page_inline(page_path, str(active_app)))
+
+    assert coordination.values == ("view", "app", "manager")
+    assert sys.path == original_path
+    for imported_name in (
+        "view_inline_helper",
+        "app_inline_helper",
+        "manager_inline_dependency",
+    ):
+        assert imported_name not in sys.modules
 
 
 def test_render_view_page_inline_fails_fast_and_restores_process_state(tmp_path: Path, monkeypatch):

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import json
+import os
 import sys
 import threading
 import time
@@ -12,6 +14,37 @@ import pytest
 
 MODULE_PATH = Path("src/agilab/app_surface.py")
 IMPLEMENTATION_MODULE_PATH = Path("src/agilab/app_management/app_surface.py")
+
+
+def _manager_site_packages(app: Path) -> Path:
+    venv = app / ".venv"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True, exist_ok=True)
+    (venv / "pyvenv.cfg").write_text("version_info = 99.99.0\n", encoding="utf-8")
+    if os.name == "nt":
+        site_packages = venv / "Lib" / "site-packages"
+    else:
+        site_packages = venv / "lib" / "python99.99" / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    return site_packages
+
+
+def _write_editable_owner(
+    site_packages: Path,
+    *,
+    distribution: str,
+    project: Path,
+) -> None:
+    metadata = site_packages / f"{distribution}-1.0.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": project.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def _load_app_surface_module():
@@ -45,6 +78,40 @@ def test_base_app_surface_import_does_not_require_optional_agi_env(
 
     with pytest.raises(ModuleNotFoundError, match=r"agilab\[ui\]"):
         module._isolated_import_process_state()
+
+
+def test_app_editable_import_roots_reports_stale_agi_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agi_env.runtime import import_layout_support
+
+    module = _load_app_surface_module()
+    monkeypatch.delattr(
+        import_layout_support,
+        "hosted_editable_source_import_roots",
+    )
+
+    with pytest.raises(RuntimeError, match="AGILAB UI runtime is stale"):
+        module.app_editable_import_roots(tmp_path / "demo_project")
+
+
+def test_app_editable_import_roots_reports_missing_import_layout_module(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_app_surface_module()
+    real_import = builtins.__import__
+
+    def _without_import_layout(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agi_env.runtime" and "import_layout_support" in fromlist:
+            raise ImportError("cannot import name 'import_layout_support'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _without_import_layout)
+
+    with pytest.raises(RuntimeError, match="cannot inspect manager editables"):
+        module.app_editable_import_roots(tmp_path / "demo_project")
 
 
 def _write_app_surface_project(tmp_path: Path) -> Path:
@@ -186,6 +253,140 @@ def test_render_app_surface_calls_project_render_hook_and_restores_argv(tmp_path
         }
     ]
     assert sys.argv == before_argv
+
+
+def test_app_editable_import_roots_admits_source_without_foreign_site_packages(
+    tmp_path: Path,
+) -> None:
+    module = _load_app_surface_module()
+    app = tmp_path / "manager_project"
+    app_source = app / "src"
+    app_source.mkdir(parents=True)
+    site_packages = _manager_site_packages(app)
+
+    plain_project = tmp_path / "plain-project"
+    plain_root = plain_project / "src"
+    (plain_root / "plain_dep").mkdir(parents=True)
+    (plain_root / "plain_dep" / "__init__.py").write_text("", encoding="utf-8")
+    _write_editable_owner(
+        site_packages,
+        distribution="plain_dep",
+        project=plain_project,
+    )
+    (site_packages / "plain-editable.pth").write_text(
+        f"{plain_root}\n",
+        encoding="utf-8",
+    )
+    foreign_project = tmp_path / "other-agilab-checkout"
+    foreign_framework_root = foreign_project / "src"
+    (foreign_framework_root / "agi_web").mkdir(parents=True)
+    _write_editable_owner(
+        site_packages,
+        distribution="foreign_framework",
+        project=foreign_project,
+    )
+    (site_packages / "foreign-framework.pth").write_text(
+        f"{foreign_framework_root}\n",
+        encoding="utf-8",
+    )
+
+    mapped_project = tmp_path / "mapped-project"
+    mapped_root = mapped_project / "src"
+    mapped_package = mapped_root / "mapped_dep"
+    mapped_package.mkdir(parents=True)
+    (mapped_package / "__init__.py").write_text("", encoding="utf-8")
+    _write_editable_owner(
+        site_packages,
+        distribution="mapped_dep",
+        project=mapped_project,
+    )
+    finder_name = "__editable___manager_deps_finder"
+    (site_packages / f"{finder_name}.py").write_text(
+        "from __future__ import annotations\n"
+        f"MAPPING = {{'mapped_dep': {str(mapped_package)!r}}}\n"
+        "NAMESPACES = {}\n"
+        "def install():\n    pass\n",
+        encoding="utf-8",
+    )
+    (site_packages / "mapped-editable.pth").write_text(
+        f"import {finder_name}; {finder_name}.install()\n",
+        encoding="utf-8",
+    )
+
+    unowned_root = tmp_path / "unowned-source"
+    unowned_root.mkdir()
+    (site_packages / "unowned.pth").write_text(
+        f"{unowned_root}\n",
+        encoding="utf-8",
+    )
+
+    native_project = tmp_path / "native-project"
+    native_root = native_project / "src"
+    native_root.mkdir(parents=True)
+    (native_root / "native_dep.so").write_bytes(b"foreign ABI")
+    _write_editable_owner(
+        site_packages,
+        distribution="native_dep",
+        project=native_project,
+    )
+    (site_packages / "native.pth").write_text(
+        f"{native_root}\n",
+        encoding="utf-8",
+    )
+
+    assert module.app_editable_import_roots(app) == (
+        app_source.resolve(strict=False),
+        plain_root.resolve(strict=False),
+        mapped_root.resolve(strict=False),
+    )
+    assert site_packages not in module.app_editable_import_roots(app)
+    assert foreign_framework_root not in module.app_editable_import_roots(app)
+    assert unowned_root not in module.app_editable_import_roots(app)
+    assert native_root not in module.app_editable_import_roots(app)
+
+
+def test_render_app_surface_imports_manager_editable_dependency(
+    tmp_path: Path,
+) -> None:
+    module = _load_app_surface_module()
+    app = _write_app_surface_project(tmp_path)
+    dependency_project = tmp_path / "dependency-project"
+    dependency_root = dependency_project / "src"
+    dependency = dependency_root / "surface_dependency"
+    dependency.mkdir(parents=True)
+    (dependency / "__init__.py").write_text(
+        "MARKER = 'surface dependency loaded'\n",
+        encoding="utf-8",
+    )
+    site_packages = _manager_site_packages(app)
+    _write_editable_owner(
+        site_packages,
+        distribution="surface_dependency",
+        project=dependency_project,
+    )
+    (site_packages / "surface-dependency.pth").write_text(
+        f"{dependency_root}\n",
+        encoding="utf-8",
+    )
+    entrypoint = app / "src" / "demo" / "app_surface.py"
+    entrypoint.write_text(
+        "import surface_dependency\n"
+        "def render(*, container, **_kwargs):\n"
+        "    container.append(surface_dependency.MARKER)\n",
+        encoding="utf-8",
+    )
+    events: list[str] = []
+
+    assert (
+        module.render_app_surface(
+            app,
+            mode="configure",
+            container=events,
+        )
+        is True
+    )
+    assert events == ["surface dependency loaded"]
+    assert "surface_dependency" not in sys.modules
 
 
 def test_render_app_surface_serializes_and_restores_project_import_state(

--- a/test/test_app_ui.py
+++ b/test/test_app_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -18,6 +19,22 @@ def _load_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def test_app_ui_reports_stale_agi_env_import_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agi_env.runtime import import_layout_support
+
+    module = _load_module()
+    monkeypatch.delattr(
+        import_layout_support,
+        "hosted_editable_source_import_roots",
+    )
+
+    with pytest.raises(RuntimeError, match="AGILAB UI runtime is stale"):
+        module._manager_editable_import_roots(tmp_path / "demo_project")
 
 
 def test_app_ui_resolves_project_scoped_entrypoint(tmp_path: Path) -> None:
@@ -133,6 +150,73 @@ def test_app_ui_runs_app_main_with_script_local_imports(
     module._run_app_ui(ui, app)
 
     assert marker.read_text(encoding="utf-8") == "script-local-core"
+    assert sys.path == original_path
+
+
+def test_app_ui_imports_owned_manager_editable_dependency_and_cleans_modules(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    app = tmp_path / "demo_project"
+    ui = app / "src" / "demo" / "ui.py"
+    marker = tmp_path / "editable_dependency.txt"
+    ui.parent.mkdir(parents=True)
+
+    dependency_project = tmp_path / "editable_dependency_project"
+    dependency_root = dependency_project / "src"
+    dependency_package = dependency_root / "editable_app_ui_dep"
+    dependency_package.mkdir(parents=True)
+    (dependency_package / "__init__.py").write_text(
+        "VALUE = 'manager-editable-dependency'\n",
+        encoding="utf-8",
+    )
+
+    venv = app / ".venv"
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    (venv / "pyvenv.cfg").parent.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        f"version_info = {version}.0\n",
+        encoding="utf-8",
+    )
+    if sys.platform == "win32":
+        site_packages = venv / "Lib" / "site-packages"
+    else:
+        site_packages = venv / "lib" / f"python{version}" / "site-packages"
+    metadata = site_packages / "editable_dependency-1.0.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": dependency_project.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (site_packages / "editable-dependency.pth").write_text(
+        f"{dependency_root}\n",
+        encoding="utf-8",
+    )
+    ui.write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "import editable_app_ui_dep",
+                "def main():",
+                f"    Path({str(marker)!r}).write_text(editable_app_ui_dep.VALUE, encoding='utf-8')",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    original_path = list(sys.path)
+    monkeypatch.delitem(sys.modules, "editable_app_ui_dep", raising=False)
+
+    module._run_app_ui(ui, app)
+
+    assert marker.read_text(encoding="utf-8") == "manager-editable-dependency"
+    assert "editable_app_ui_dep" not in sys.modules
     assert sys.path == original_path
 
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -2106,6 +2106,85 @@ def test_execute_page_hides_distribution_preview_for_workerless_app(mock_ui_env)
     )
 
 
+def test_orchestrate_custom_form_imports_manager_editable_dependency(mock_ui_env):
+    """Custom forms reuse source-only dependencies deployed by ``AGI.install``."""
+
+    apps_dir = mock_ui_env["apps_dir"]
+    project_dir = apps_dir / "routing_like_project"
+    source_root = project_dir / "src"
+    manager_package = source_root / "routing_like"
+    manager_package.mkdir(parents=True)
+    (manager_package / "__init__.py").write_text("", encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text(
+        "[project]\nname = 'routing-like-project'\nrequires-python = '>=3.12'\n"
+        "\n[tool.agilab.app]\nruntime = 'local'\nworkerless = true\n",
+        encoding="utf-8",
+    )
+    (source_root / "app_settings.toml").write_text("[args]\n", encoding="utf-8")
+    marker = "manager editable dependency loaded"
+    (source_root / "app_args_form.py").write_text(
+        "import streamlit as st\n"
+        "import sb3_trainer\n"
+        "st.caption(sb3_trainer.MARKER)\n",
+        encoding="utf-8",
+    )
+
+    dependency_root = project_dir.parent / "sb3-trainer-source"
+    dependency_package = dependency_root / "sb3_trainer"
+    dependency_package.mkdir(parents=True)
+    (dependency_package / "__init__.py").write_text(
+        f"MARKER = {marker!r}\n",
+        encoding="utf-8",
+    )
+    manager_site_packages = (
+        project_dir / ".venv" / "Lib" / "site-packages"
+        if os.name == "nt"
+        else project_dir / ".venv" / "lib" / "python3.14" / "site-packages"
+    )
+    manager_site_packages.mkdir(parents=True)
+    (project_dir / ".venv" / "pyvenv.cfg").write_text(
+        "version_info = 3.14.0\n",
+        encoding="utf-8",
+    )
+    metadata = manager_site_packages / "sb3_trainer-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "url": dependency_root.resolve().as_uri(),
+                "dir_info": {"editable": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (manager_site_packages / "sb3-editable.pth").write_text(
+        f"{dependency_root}\n",
+        encoding="utf-8",
+    )
+
+    at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
+    env = AgiEnv(apps_path=apps_dir, app="routing_like_project", verbose=0)
+    env.init_done = True
+    env.st_resources = (
+        Path(__file__).resolve().parents[1] / "src/agilab/resources"
+    ).resolve()
+    at.session_state["env"] = env
+    at.session_state["app_settings"] = {
+        "args": {},
+        "cluster": {"cluster_enabled": False},
+    }
+
+    at.run()
+
+    assert not at.exception
+    assert marker in [str(item.value) for item in at.caption]
+    assert all(
+        "No module named 'sb3_trainer'" not in str(item.value)
+        for item in at.warning
+    )
+    assert "sb3_trainer" not in sys.modules
+
+
 def test_execute_page_install_robot_allows_benign_uv_self_update_warning(mock_ui_env):
     """Robot-style INSTALL regression for handled remote uv self-update warnings."""
 


### PR DESCRIPTION
## Summary

- expose safe source roots for manager-environment editable dependencies to hosted ORCHESTRATE and ANALYSIS imports
- preserve process isolation by never adding manager `site-packages`, native extension trees, foreign hosted-runtime packages, or escaped paths
- reject hosted runtime shadowing through the generic reserved `agi_*` namespace plus `agilab` and `streamlit`, without coupling `agi-env` to upper core package names
- use the same roots for `sys.path` setup and module eviction/restoration across direct app surfaces, app-ui sidecars, and hosted ANALYSIS views
- reverify the path-scoped ANALYSIS maintenance contract

## Repro

1. Install and deploy `routing_training_project`.
2. Open `/ORCHESTRATE?active_app=routing_training_project` in an already-running source Streamlit process.
3. Render the custom run form.
4. The page failed with `No module named 'sb3_trainer'` although the routing manager environment already contained the editable dependency.

## Root Cause

The long-lived Streamlit UI interpreter only prepended the active app's own `src` directory. It did not expose safe editable dependency source roots recorded in the deployed manager environment. Importing the manager environment's whole `site-packages` would be unsafe and ABI-incompatible, so this change parses editable metadata without executing manager code and admits only confined, pure-Python source roots.

The first PR CI run also exposed an architectural regression in the initial safety denylist: it named `agi-node`, `agi-cluster`, and `agi-core` inside lower-layer `agi-env`. The corrected policy reserves the full `agi_*` namespace generically, preserving both the security boundary and the package dependency direction.

## Regression Test

Added coverage for:

- ordinary and PEP 660 editable metadata
- Python-minor selection, ambiguity, native-code rejection, reserved future `agi_*` runtime names, exact hosted runtime names, symlink escapes, and cyclic paths
- namespace/native module eviction and complete process-state restoration
- direct app surface, ORCHESTRATE, app-ui sidecar, and ANALYSIS consumers
- stale or missing import-layout support with actionable diagnostics
- the existing upper-layer-independence contract remains green

## Validation

- full `agi-env` slice after the CI correction: 1016 passed, 1 skipped
- exact upper-layer independence repro plus resolver slice: 12 passed
- exact impact slice: 248 passed
- focused ANALYSIS/UI slice: 96 passed
- full local `agi-gui` workflow parity: 3822 passed, 3 skipped
- real routing-training manager metadata resolved `routing_training_project`, `ilp_project`, `routing_emulation_cli`, and `sb3_trainer_project` source roots; `link_sim` parent and manager `site-packages` remained excluded
- exact routing custom-form imports completed and restored process state
- isolated ORCHESTRATE widget robot passed after Streamlit stabilization: 78 widgets, 75 probed, 0 failures; browser issue checks passed and `No module named 'sb3_trainer'` was absent
- initial docs-alignment parity attempt observed unrelated dirty canonical sibling docs; the required clean-source rerun used the public main docs source and passed
- Tokki command execution was unavailable because its protected-runtime integrity gate rejected the locally dirty protected sources; direct `uv`/Git commands were used without bypassing AGILAB guards

## Shared Core Approval / Blast Radius

The user's reported missing dependency follows the previously approved requirement that `AGI.install` deploy transitive app runtime dependencies. An app-only path cannot make those installed manager editables visible to hosted UI imports without duplicating unsafe logic, so this fixes the shared `agi-env` import isolation layer.

Blast radius reviewed: manager metadata parsing, isolated module state, ORCHESTRATE, ANALYSIS, app-ui sidecars, Python-minor/ABI boundaries, package dependency direction, local release dependency floors, and current routing-training editable layouts. The full core and GUI parity suites passed.

## Review Evidence

Codex sub-agents, model inherited/unknown:

- app-ui dependency-scope agent: edited app-ui and focused tests
- ANALYSIS dependency-scope agent: edited ANALYSIS and focused tests
- core import-scope test agent: edited core regression tests
- live routing probe, manifest trace, final install/release review, and root-runner CI diagnosis agents: review-only

All actionable findings were addressed. The first GitHub `root-tests` run failed only `test_agi_env_does_not_hardcode_upper_core_package_names`; all later groups passed. The finding was reproduced locally and fixed with a generic namespace policy before rerunning the full core slice. Final adversarial review found no product merge blocker; the remaining theoretical same-owner PEP 660 sibling exposure has no current app instance and does not weaken the documented foreign-runtime/native-code boundaries.

## Agent Metadata

- Tokki version: unavailable (protected-runtime integrity gate refused execution)
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
