### PR TITLE
docs(svg): sync top-quality diagram pass from canonical

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "5bee4250964fcbb8c1b0b2646c80338e01248a08f599e90b26681b22b54e6617",
     "release-proof.rst": "fa2c88ad0a60cd30d6cca2899d0defaca43c3345209663c3907bfa3dc36ce084"
   },
-  "source_digest_sha256": "d8cd7e29933fe3a85d6b56a4c7f39a116609c4b79ab4cdf2833dae55cb242965",
+  "source_digest_sha256": "47ed9614e0da2680d150fc52e841c57dabd7b413e10410cbd236ae2aec0ce5fc",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d8cd7e29933fe3a85d6b56a4c7f39a116609c4b79ab4cdf2833dae55cb242965"
+  "target_digest_sha256": "47ed9614e0da2680d150fc52e841c57dabd7b413e10410cbd236ae2aec0ce5fc"
 }

--- a/docs/source/AI-Problematic.svg
+++ b/docs/source/AI-Problematic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 590" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" role="img" aria-labelledby="title desc">
   <title id="title">AI Problematic</title>
   <desc id="desc">Diagram showing how domain expertise and data science collaborate through an experiment loop to deliver deployable models.</desc>
   <defs>
@@ -19,7 +19,7 @@
     </marker>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="960" height="590"/>
+  <rect class="bg" x="0" y="0" width="960" height="600"/>
   <text class="title" x="480" y="56" text-anchor="middle">From Problem to Deployed Model</text>
   <text class="t muted" x="480" y="84" text-anchor="middle">A practical workflow: iterate quickly, then ship reproducibly.</text>
 
@@ -54,9 +54,9 @@
   <line class="arrow" x1="540" y1="419" x2="580" y2="419"/>
   <path class="arrow" d="M 640 398 C 690 384 692 452 640 440"/>
 
-  <rect class="box" x="230" y="490" rx="16" ry="16" width="500" height="66"/>
-  <text class="h" x="250" y="526">Deployment &amp; operations</text>
-  <text class="t" x="250" y="548">Versioned artifacts • repeatable runs • monitoring • audit trail</text>
+  <rect class="box" x="230" y="490" rx="16" ry="16" width="500" height="76"/>
+  <text class="h" x="250" y="524">Deployment &amp; operations</text>
+  <text class="t" x="250" y="550">Versioned artifacts • repeatable runs • monitoring • audit trail</text>
 
   <line class="arrow" x1="235" y1="290" x2="322" y2="324"/>
   <line class="arrow" x1="725" y1="290" x2="638" y2="324"/>

--- a/docs/source/Agilab-Overview.svg
+++ b/docs/source/Agilab-Overview.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="1040" viewBox="0 0 1360 1040" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1040" viewBox="0 0 1400 1040" role="img" aria-labelledby="title desc">
   <title id="title">AGILAB runtime stack</title>
   <desc id="desc">Layered AGILAB diagram showing entry surfaces, control-plane components, execution services, and produced artifacts on one readable control path.</desc>
   <defs>
@@ -21,10 +21,6 @@
         letter-spacing: 0.08em;
         text-transform: uppercase;
         fill: #657d99;
-      }
-      .lane-rule {
-        stroke: #d5dfeb;
-        stroke-width: 2.2;
       }
       .box {
         stroke: #12304d;
@@ -102,38 +98,34 @@
     </filter>
   </defs>
 
-  <rect width="1360" height="1040" fill="url(#bg)" rx="40" ry="40" />
+  <rect width="1400" height="1040" fill="url(#bg)" rx="40" ry="40" />
 
   <g transform="translate(72,72)">
     <text class="title" x="0" y="0">AGILAB runtime stack</text>
     <text class="subtitle" x="0" y="40">One readable path from UI and CLI entrypoints to packaged workers, execution, and artifacts.</text>
   </g>
 
-  <rect x="160" y="140" width="904" height="120" fill="#f4fbff" rx="28" ry="28" />
-  <rect x="160" y="288" width="904" height="156" fill="#f6f2ff" rx="28" ry="28" />
-  <rect x="160" y="472" width="904" height="160" fill="#fff8e5" rx="28" ry="28" />
-  <rect x="160" y="660" width="904" height="156" fill="#fff3f6" rx="28" ry="28" />
+  <rect x="200" y="140" width="904" height="120" fill="#f4fbff" rx="28" ry="28" />
+  <rect x="200" y="288" width="904" height="156" fill="#f6f2ff" rx="28" ry="28" />
+  <rect x="200" y="472" width="904" height="160" fill="#fff8e5" rx="28" ry="28" />
+  <rect x="200" y="660" width="904" height="156" fill="#fff3f6" rx="28" ry="28" />
 
   <g transform="translate(72,154)">
-    <text class="lane-label" x="0" y="34">Entry</text>
-    <line class="lane-rule" x1="170" y1="25" x2="262" y2="25" />
-    <text class="lane-label" x="0" y="180">Control</text>
-    <line class="lane-rule" x1="170" y1="171" x2="262" y2="171" />
-    <text class="lane-label" x="0" y="366">Execution</text>
-    <line class="lane-rule" x1="170" y1="357" x2="262" y2="357" />
+    <text class="lane-label" x="0" y="38">Entry</text>
+    <text class="lane-label" x="0" y="186">Control</text>
+    <text class="lane-label" x="0" y="370">Execution</text>
     <text class="lane-label" x="0" y="558">Artifacts</text>
-    <line class="lane-rule" x1="170" y1="549" x2="262" y2="549" />
   </g>
 
-  <g transform="translate(198,152)">
+  <g transform="translate(238,152)">
     <rect class="box" width="828" height="96" fill="#d8efff" />
     <text class="box-title" x="414" y="40" text-anchor="middle">User surfaces</text>
-    <text class="box-body" x="36" y="72">
+    <text class="box-body" x="36" y="70">
       <tspan x="36" dy="0">Streamlit pages, CLI mirrors, and PyCharm run configurations</tspan>
     </text>
   </g>
 
-  <g transform="translate(198,300)">
+  <g transform="translate(238,300)">
     <rect class="box" width="828" height="132" fill="#dfdcff" />
     <text class="box-title" x="414" y="40" text-anchor="middle">agi_core</text>
     <text class="box-body" x="36" y="70">
@@ -144,7 +136,7 @@
     </text>
   </g>
 
-  <g transform="translate(198,484)">
+  <g transform="translate(238,484)">
     <rect class="box" width="828" height="136" fill="#ffe39e" />
     <text class="box-title" x="414" y="40" text-anchor="middle">agi_env</text>
     <text class="box-body" x="36" y="70">
@@ -155,7 +147,7 @@
     </text>
   </g>
 
-  <g transform="translate(198,672)">
+  <g transform="translate(238,672)">
     <rect class="box" width="828" height="132" fill="#ffdbe5" />
     <text class="box-title" x="414" y="40" text-anchor="middle">agi_cluster and agi_node</text>
     <text class="box-body" x="36" y="70">
@@ -166,22 +158,22 @@
     </text>
   </g>
 
-  <g transform="translate(1108,188)">
+  <g transform="translate(1148,188)">
     <rect class="badge" width="224" height="38" rx="19" ry="19" />
     <text class="badge-text" x="112" y="24" text-anchor="middle">Execution path</text>
-    <line class="arrow" x1="112" y1="52" x2="112" y2="346" />
-    <polygon class="arrow-head" points="104,346 120,346 112,362" />
+    <line class="arrow" x1="112" y1="52" x2="112" y2="370" />
+    <polygon class="arrow-head" points="104,370 120,370 112,386" />
   </g>
 
-  <g transform="translate(1108,586)">
+  <g transform="translate(1148,586)">
     <rect class="callout" width="224" height="206" fill="#ffffff" />
     <text class="callout-title" x="112" y="32" text-anchor="middle">Workers and data</text>
     <circle class="bullet" cx="24" cy="64" r="4.5" />
     <text class="callout-body" x="38" y="69">Worker bundles</text>
     <circle class="bullet" cx="24" cy="92" r="4.5" />
     <text class="callout-body" x="38" y="96">
-      <tspan x="38" dy="0">Cluster and local</tspan>
-      <tspan x="38" dy="18">storage</tspan>
+      <tspan x="38" dy="0">Cluster and</tspan>
+      <tspan x="38" dy="18">local storage</tspan>
     </text>
     <circle class="bullet" cx="24" cy="134" r="4.5" />
     <text class="callout-body" x="38" y="139">Exported artifacts</text>
@@ -190,17 +182,17 @@
   </g>
 
   <g transform="translate(60,864)">
-    <rect class="callout" width="1272" height="76" fill="#ffffff" />
-    <text class="callout-title" x="22" y="36">Typical flow</text>
-    <text class="callout-body" x="154" y="42">
+    <rect class="callout" width="1312" height="76" fill="#ffffff" />
+    <text class="callout-title" x="22" y="45">Typical flow</text>
+    <text class="callout-body" x="154" y="45">
       <tspan x="154" dy="0">User action → manifest build → environment resolution → worker execution → artifacts and feedback</tspan>
     </text>
   </g>
 
-  <line class="arrow" x1="612" y1="256" x2="612" y2="284" />
-  <polygon class="arrow-head" points="604,284 620,284 612,300" />
-  <line class="arrow" x1="612" y1="440" x2="612" y2="468" />
-  <polygon class="arrow-head" points="604,468 620,468 612,484" />
-  <line class="arrow" x1="612" y1="628" x2="612" y2="656" />
-  <polygon class="arrow-head" points="604,656 620,656 612,672" />
+  <line class="arrow" x1="652" y1="248" x2="652" y2="284" />
+  <polygon class="arrow-head" points="644,284 660,284 652,300" />
+  <line class="arrow" x1="652" y1="432" x2="652" y2="468" />
+  <polygon class="arrow-head" points="644,468 660,468 652,484" />
+  <line class="arrow" x1="652" y1="620" x2="652" y2="656" />
+  <polygon class="arrow-head" points="644,656 660,656 652,672" />
 </svg>

--- a/docs/source/diagrams/agent_commit_provenance_guard.svg
+++ b/docs/source/diagrams/agent_commit_provenance_guard.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 560" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1376 560" role="img" aria-labelledby="title desc">
   <title id="title">AGILAB agent commit provenance guard</title>
   <desc id="desc">Flow diagram showing how agent-prefixed branches are checked before commit and before push so Codex or other agent work cannot silently use a human Git identity.</desc>
   <defs>
@@ -9,29 +9,29 @@
       .bad { fill: #ffe6df; stroke: #b84c2f; stroke-width: 2.5; }
       .good { fill: #e7f3e8; stroke: #2f7d52; stroke-width: 2.5; }
       .guard { fill: #e5edf8; stroke: #2d5f91; stroke-width: 2.5; }
-      .title { font: 700 28px "Aptos", "Segoe UI", sans-serif; fill: #243043; }
-      .subtitle { font: 500 17px "Aptos", "Segoe UI", sans-serif; fill: #5e6878; }
-      .label { font: 700 21px "Aptos", "Segoe UI", sans-serif; fill: #243043; }
-      .body { font: 500 17px "Aptos", "Segoe UI", sans-serif; fill: #374255; }
-      .small { font: 600 14px "Aptos", "Segoe UI", sans-serif; fill: #5e6878; }
+      .title { font: 700 28px Arial, Helvetica, sans-serif; fill: #243043; }
+      .subtitle { font: 500 17px Arial, Helvetica, sans-serif; fill: #5e6878; }
+      .label { font: 700 21px Arial, Helvetica, sans-serif; fill: #243043; }
+      .body { font: 500 17px Arial, Helvetica, sans-serif; fill: #374255; }
+      .small { font: 600 14px Arial, Helvetica, sans-serif; fill: #5e6878; }
       .arrow { stroke: #243043; stroke-width: 3; fill: none; marker-end: url(#arrowhead); }
       .reject { stroke: #b84c2f; stroke-width: 3; fill: none; marker-end: url(#arrowhead-red); }
       .ok { stroke: #2f7d52; stroke-width: 3; fill: none; marker-end: url(#arrowhead-green); }
       .badge { fill: #243043; }
-      .badgeText { font: 700 13px "Aptos", "Segoe UI", sans-serif; fill: #fffaf0; letter-spacing: .4px; }
+      .badgeText { font: 700 13px Arial, Helvetica, sans-serif; fill: #fffaf0; letter-spacing: .4px; }
     </style>
-    <marker id="arrowhead" markerWidth="12" markerHeight="8" refX="10" refY="4" orient="auto">
-      <path d="M0,0 L12,4 L0,8 Z" fill="#243043"/>
+    <marker id="arrowhead" markerUnits="userSpaceOnUse" markerWidth="14" markerHeight="10" refX="12" refY="5" orient="auto">
+      <path d="M0,0 L14,5 L0,10 Z" fill="#243043"/>
     </marker>
-    <marker id="arrowhead-red" markerWidth="12" markerHeight="8" refX="10" refY="4" orient="auto">
-      <path d="M0,0 L12,4 L0,8 Z" fill="#b84c2f"/>
+    <marker id="arrowhead-red" markerUnits="userSpaceOnUse" markerWidth="14" markerHeight="10" refX="12" refY="5" orient="auto">
+      <path d="M0,0 L14,5 L0,10 Z" fill="#b84c2f"/>
     </marker>
-    <marker id="arrowhead-green" markerWidth="12" markerHeight="8" refX="10" refY="4" orient="auto">
-      <path d="M0,0 L12,4 L0,8 Z" fill="#2f7d52"/>
+    <marker id="arrowhead-green" markerUnits="userSpaceOnUse" markerWidth="14" markerHeight="10" refX="12" refY="5" orient="auto">
+      <path d="M0,0 L14,5 L0,10 Z" fill="#2f7d52"/>
     </marker>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1280" height="560"/>
+  <rect class="bg" x="0" y="0" width="1376" height="560"/>
   <text class="title" x="64" y="58">Agent commit provenance guard</text>
   <text class="subtitle" x="64" y="88">Agent-prefixed branches must carry explicit agent or bot identity, not a human author line.</text>
 
@@ -54,62 +54,62 @@
     <tspan x="88" dy="24">agent commits looked human.</tspan>
   </text>
 
-  <rect class="guard" x="400" y="132" width="290" height="190" rx="18"/>
-  <rect class="badge" x="424" y="154" width="104" height="24" rx="12"/>
-  <text class="badgeText" x="476" y="171" text-anchor="middle">PRE-COMMIT</text>
-  <text class="label" x="424" y="206">Config guard</text>
-  <text class="body" x="424" y="236">
-    <tspan x="424" dy="0">Rejects human Git identity</tspan>
-    <tspan x="424" dy="24">before a commit is created</tspan>
-    <tspan x="424" dy="24">on an agent branch.</tspan>
+  <rect class="guard" x="448" y="132" width="290" height="190" rx="18"/>
+  <rect class="badge" x="472" y="154" width="104" height="24" rx="12"/>
+  <text class="badgeText" x="524" y="171" text-anchor="middle">PRE-COMMIT</text>
+  <text class="label" x="472" y="206">Config guard</text>
+  <text class="body" x="472" y="236">
+    <tspan x="472" dy="0">Rejects human Git identity</tspan>
+    <tspan x="472" dy="24">before a commit is created</tspan>
+    <tspan x="472" dy="24">on an agent branch.</tspan>
   </text>
 
-  <rect class="guard" x="400" y="352" width="290" height="132" rx="18"/>
-  <text class="label" x="424" y="392">Required identity</text>
-  <text class="body" x="424" y="422">
-    <tspan x="424" dy="0">AGILAB Codex Agent</tspan>
-    <tspan x="424" dy="24">&lt;codex-agent@users.</tspan>
-    <tspan x="424" dy="24">noreply.github.com&gt;</tspan>
+  <rect class="guard" x="448" y="352" width="290" height="132" rx="18"/>
+  <text class="label" x="472" y="392">Required identity</text>
+  <text class="body" x="472" y="422">
+    <tspan x="472" dy="0">AGILAB Codex Agent</tspan>
+    <tspan x="472" dy="24">&lt;codex-agent@users.</tspan>
+    <tspan x="472" dy="24">noreply.github.com&gt;</tspan>
   </text>
 
-  <rect class="guard" x="766" y="132" width="290" height="190" rx="18"/>
-  <rect class="badge" x="790" y="154" width="94" height="24" rx="12"/>
-  <text class="badgeText" x="837" y="171" text-anchor="middle">PRE-PUSH</text>
-  <text class="label" x="790" y="206">Commit range guard</text>
-  <text class="body" x="790" y="236">
-    <tspan x="790" dy="0">Checks every pushed commit</tspan>
-    <tspan x="790" dy="24">on the agent branch for bad</tspan>
-    <tspan x="790" dy="24">author or committer fields.</tspan>
+  <rect class="guard" x="862" y="132" width="290" height="190" rx="18"/>
+  <rect class="badge" x="886" y="154" width="94" height="24" rx="12"/>
+  <text class="badgeText" x="933" y="171" text-anchor="middle">PRE-PUSH</text>
+  <text class="label" x="886" y="206">Commit range guard</text>
+  <text class="body" x="886" y="236">
+    <tspan x="886" dy="0">Checks every pushed commit</tspan>
+    <tspan x="886" dy="24">on the agent branch for bad</tspan>
+    <tspan x="886" dy="24">author or committer fields.</tspan>
   </text>
 
-  <rect class="good" x="766" y="352" width="290" height="132" rx="18"/>
-  <text class="label" x="790" y="392">Clean audit trail</text>
-  <text class="body" x="790" y="422">
-    <tspan x="790" dy="0">PR metadata and Git history</tspan>
-    <tspan x="790" dy="24">now agree that the change is</tspan>
-    <tspan x="790" dy="24">agent-authored.</tspan>
+  <rect class="good" x="862" y="352" width="290" height="132" rx="18"/>
+  <text class="label" x="886" y="392">Clean audit trail</text>
+  <text class="body" x="886" y="422">
+    <tspan x="886" dy="0">PR metadata and Git history</tspan>
+    <tspan x="886" dy="24">now agree that the change is</tspan>
+    <tspan x="886" dy="24">agent-authored.</tspan>
   </text>
 
-  <rect class="panel" x="1110" y="178" width="110" height="260" rx="18"/>
-  <text class="label" x="1165" y="226" text-anchor="middle">PR</text>
-  <text class="body" x="1165" y="262" text-anchor="middle">
-    <tspan x="1165" dy="0">Agent</tspan>
-    <tspan x="1165" dy="24">Metadata</tspan>
-    <tspan x="1165" dy="42">+</tspan>
-    <tspan x="1165" dy="42">Git</tspan>
-    <tspan x="1165" dy="24">identity</tspan>
+  <rect class="panel" x="1206" y="178" width="110" height="260" rx="18"/>
+  <text class="label" x="1261" y="226" text-anchor="middle">PR</text>
+  <text class="body" x="1261" y="262" text-anchor="middle">
+    <tspan x="1261" dy="0">Agent</tspan>
+    <tspan x="1261" dy="24">Metadata</tspan>
+    <tspan x="1261" dy="42">+</tspan>
+    <tspan x="1261" dy="42">Git</tspan>
+    <tspan x="1261" dy="24">identity</tspan>
   </text>
 
-  <path class="arrow" d="M324 206 H388"/>
-  <path class="arrow" d="M690 206 H754"/>
-  <path class="ok" d="M1056 418 H1098"/>
-  <path class="reject" d="M324 418 H388"/>
-  <path class="ok" d="M545 352 V324"/>
-  <path class="ok" d="M911 322 V340"/>
+  <path class="arrow" d="M324 206 H446"/>
+  <path class="arrow" d="M738 206 H860"/>
+  <path class="ok" d="M1152 418 H1204"/>
+  <path class="reject" d="M324 418 H446"/>
+  <path class="ok" d="M593 352 V324"/>
+  <path class="ok" d="M1007 322 V350"/>
 
-  <text class="small" x="356" y="194" text-anchor="middle">check config</text>
-  <text class="small" x="722" y="194" text-anchor="middle">check commits</text>
-  <text class="small" x="356" y="452" text-anchor="middle">reject</text>
-  <text class="small" x="584" y="344" text-anchor="middle">configure</text>
-  <text class="small" x="950" y="344" text-anchor="middle">allow</text>
+  <text class="small" x="386" y="194" text-anchor="middle">check config</text>
+  <text class="small" x="800" y="194" text-anchor="middle">check commits</text>
+  <text class="small" x="386" y="406" text-anchor="middle">reject</text>
+  <text class="small" x="640" y="344" text-anchor="middle">configure</text>
+  <text class="small" x="1041" y="344" text-anchor="middle">allow</text>
 </svg>

--- a/docs/source/diagrams/agilab_mission_decision_card.svg
+++ b/docs/source/diagrams/agilab_mission_decision_card.svg
@@ -15,7 +15,7 @@
       <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="#000000" flood-opacity="0.28"/>
     </filter>
     <style>
-      .label { font-family: "Aptos", "Segoe UI", sans-serif; fill: #dcefe9; }
+      .label { font-family: Arial, Helvetica, sans-serif; fill: #dcefe9; }
       .muted { fill: #9fc2ba; }
       .panel { fill: rgba(255,255,255,0.08); stroke: rgba(255,255,255,0.18); stroke-width: 1.5; }
       .step { fill: rgba(12,34,44,0.92); stroke: #35d0ba; stroke-width: 2; }
@@ -35,7 +35,7 @@
 
   <text x="110" y="142" class="label" font-size="34" font-weight="700">Decision Evidence Demo</text>
   <rect x="865" y="110" width="205" height="44" rx="22" class="chip"/>
-  <text x="890" y="139" class="label" font-size="20" font-weight="700">Public demo asset</text>
+  <text x="967.5" y="139" text-anchor="middle" class="label" font-size="20" font-weight="700">Public demo asset</text>
 
   <text x="110" y="232" class="label" font-size="66" font-weight="800">Autonomous Mission Data</text>
   <text x="110" y="298" class="label" font-size="66" font-weight="800">to Decision Evidence</text>
@@ -43,47 +43,48 @@
   <text x="110" y="377" class="label muted" font-size="27">A reproducible AGILAB path from raw mission signals</text>
   <text x="110" y="414" class="label muted" font-size="27">to an optimized, explainable operational decision.</text>
 
-  <text x="740" y="225" class="label" font-size="26" font-weight="700">Decision flow</text>
-  <text x="740" y="265" class="label muted" font-size="21">PROJECT -&gt; ORCHESTRATE -&gt; WORKFLOW -&gt; ANALYSIS</text>
+  <text x="800" y="276" class="label" font-size="26" font-weight="700">Decision flow</text>
+  <text x="800" y="306" class="label muted" font-size="21">PROJECT -&gt; ORCHESTRATE -&gt;</text>
+  <text x="800" y="333" class="label muted" font-size="21">WORKFLOW -&gt; ANALYSIS</text>
 
   <g transform="translate(110 470)">
-    <rect x="0" y="0" width="170" height="76" rx="18" class="step"/>
-    <text x="28" y="32" class="label" font-size="19" font-weight="700">1. Ingest</text>
-    <text x="28" y="57" class="label muted" font-size="16">mission data</text>
+    <rect x="0" y="0" width="160" height="76" rx="18" class="step"/>
+    <text x="24" y="32" class="label" font-size="19" font-weight="700">1. Ingest</text>
+    <text x="24" y="57" class="label muted" font-size="16">mission data</text>
 
-    <path d="M184 38 L232 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
-    <path d="M232 38 L220 30 M232 38 L220 46" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M165 38 L200 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M200 38 L190 31 M200 38 L190 45" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
 
-    <rect x="250" y="0" width="170" height="76" rx="18" class="step"/>
-    <text x="278" y="32" class="label" font-size="19" font-weight="700">2. Build</text>
-    <text x="278" y="57" class="label muted" font-size="16">dynamic DAG</text>
+    <rect x="205" y="0" width="160" height="76" rx="18" class="step"/>
+    <text x="229" y="32" class="label" font-size="19" font-weight="700">2. Build</text>
+    <text x="229" y="57" class="label muted" font-size="16">dynamic DAG</text>
 
-    <path d="M434 38 L482 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
-    <path d="M482 38 L470 30 M482 38 L470 46" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M370 38 L405 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M405 38 L395 31 M405 38 L395 45" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
 
-    <rect x="500" y="0" width="170" height="76" rx="18" class="step"/>
-    <text x="528" y="32" class="label" font-size="19" font-weight="700">3. Distribute</text>
-    <text x="528" y="57" class="label muted" font-size="16">workers scale</text>
+    <rect x="410" y="0" width="160" height="76" rx="18" class="step"/>
+    <text x="434" y="32" class="label" font-size="19" font-weight="700">3. Distribute</text>
+    <text x="434" y="57" class="label muted" font-size="16">workers scale</text>
 
-    <path d="M684 38 L732 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
-    <path d="M732 38 L720 30 M732 38 L720 46" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M575 38 L610 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M610 38 L600 31 M610 38 L600 45" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
 
-    <rect x="750" y="0" width="170" height="76" rx="18" class="step"/>
-    <text x="778" y="32" class="label" font-size="19" font-weight="700">4. Optimize</text>
-    <text x="778" y="57" class="label muted" font-size="16">ML + RL loop</text>
+    <rect x="615" y="0" width="160" height="76" rx="18" class="step"/>
+    <text x="639" y="32" class="label" font-size="19" font-weight="700">4. Optimize</text>
+    <text x="639" y="57" class="label muted" font-size="16">ML + RL loop</text>
 
-    <path d="M934 38 L982 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
-    <path d="M982 38 L970 30 M982 38 L970 46" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M780 38 L815 38" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
+    <path d="M815 38 L805 31 M815 38 L805 45" stroke="#9fc2ba" stroke-width="3" stroke-linecap="round"/>
 
-    <rect x="1000" y="0" width="170" height="76" rx="18" class="step"/>
-    <text x="1028" y="32" class="label" font-size="19" font-weight="700">5. Adapt</text>
-    <text x="1028" y="57" class="label muted" font-size="16">new decision</text>
+    <rect x="820" y="0" width="160" height="76" rx="18" class="step"/>
+    <text x="844" y="32" class="label" font-size="19" font-weight="700">5. Adapt</text>
+    <text x="844" y="57" class="label muted" font-size="16">new decision</text>
   </g>
 
-  <rect x="740" y="306" width="334" height="104" rx="22" fill="rgba(53,208,186,0.11)" stroke="rgba(53,208,186,0.35)" stroke-width="1.4"/>
-  <text x="770" y="345" class="label" font-size="23" font-weight="700">Failure injection</text>
-  <text x="770" y="376" class="label muted" font-size="20">bandwidth drop | node loss</text>
-  <text x="770" y="402" class="label muted" font-size="20">recompute | re-optimize</text>
+  <rect x="800" y="350" width="310" height="108" rx="22" fill="rgba(53,208,186,0.11)" stroke="rgba(53,208,186,0.35)" stroke-width="1.4"/>
+  <text x="830" y="389" class="label" font-size="23" font-weight="700">Failure injection</text>
+  <text x="830" y="420" class="label muted" font-size="20">bandwidth drop | node loss</text>
+  <text x="830" y="446" class="label muted" font-size="20">recompute | re-optimize</text>
 
   <text x="110" y="585" class="label" font-size="23" font-weight="700">Final output: selected strategy | latency down | cost down | reliability up</text>
 </svg>

--- a/docs/source/diagrams/agilab_pages.svg
+++ b/docs/source/diagrams/agilab_pages.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="430" viewBox="0 0 1120 430" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1140" height="430" viewBox="0 0 1140 430" role="img" aria-labelledby="title desc">
   <title id="title">AGILAB web interface page routing</title>
   <desc id="desc">Diagram showing agilab.py routing to the landing page, SETTINGS, PROJECT, ORCHESTRATE, WORKFLOW, ANALYSIS and optional analysis page bundles through agi_core.</desc>
   <defs>
@@ -24,7 +24,7 @@
     </marker>
   </defs>
 
-  <rect width="1120" height="430" fill="#f7fbff" rx="28" ry="28"/>
+  <rect width="1140" height="430" fill="#f7fbff" rx="28" ry="28"/>
 
   <g transform="translate(44,38)">
     <text class="title" x="0" y="0">AGILAB web interface routing</text>
@@ -39,37 +39,37 @@
     <text class="note" x="93" y="82" text-anchor="middle">loads navigation pages</text>
   </g>
 
-  <g id="core-pages" transform="translate(304,104)">
+  <g id="core-pages" transform="translate(320,104)">
     <text class="lane" x="0" y="-18">Core web pages</text>
     <rect class="card" width="492" height="200" fill="#eaf5ff"/>
     <text class="card-title" x="246" y="34" text-anchor="middle">Main navigation surface</text>
     <text class="body" x="246" y="58" text-anchor="middle">landing and operational pages stay distinct from the workflow pages</text>
 
     <text class="note" x="246" y="86" text-anchor="middle">entry + operations</text>
-    <rect class="pill" x="82" y="98" width="102" height="28" fill="#ffffff"/>
-    <text class="pill-text" x="133" y="117" text-anchor="middle">LANDING</text>
-    <rect class="pill" x="196" y="98" width="112" height="28" fill="#ffffff"/>
-    <text class="pill-text" x="252" y="117" text-anchor="middle">SETTINGS</text>
-    <rect class="pill" x="320" y="98" width="106" height="28" fill="#ffffff"/>
-    <text class="pill-text" x="373" y="117" text-anchor="middle">PROJECT</text>
+    <rect class="pill" x="74" y="98" width="102" height="28" fill="#ffffff"/>
+    <text class="pill-text" x="125" y="117" text-anchor="middle">LANDING</text>
+    <rect class="pill" x="188" y="98" width="112" height="28" fill="#ffffff"/>
+    <text class="pill-text" x="244" y="117" text-anchor="middle">SETTINGS</text>
+    <rect class="pill" x="312" y="98" width="106" height="28" fill="#ffffff"/>
+    <text class="pill-text" x="365" y="117" text-anchor="middle">PROJECT</text>
 
     <text class="note" x="246" y="148" text-anchor="middle">workflow pages</text>
-    <rect class="pill" x="38" y="160" width="132" height="28" fill="#fef3c7"/>
-    <text class="pill-text" x="104" y="179" text-anchor="middle">ORCHESTRATE</text>
-    <rect class="pill" x="184" y="160" width="112" height="28" fill="#fef3c7"/>
-    <text class="pill-text" x="240" y="179" text-anchor="middle">WORKFLOW</text>
-    <rect class="pill" x="310" y="160" width="104" height="28" fill="#fef3c7"/>
-    <text class="pill-text" x="362" y="179" text-anchor="middle">ANALYSIS</text>
+    <rect class="pill" x="58" y="160" width="132" height="28" fill="#fef3c7"/>
+    <text class="pill-text" x="124" y="179" text-anchor="middle">ORCHESTRATE</text>
+    <rect class="pill" x="204" y="160" width="112" height="28" fill="#fef3c7"/>
+    <text class="pill-text" x="260" y="179" text-anchor="middle">WORKFLOW</text>
+    <rect class="pill" x="330" y="160" width="104" height="28" fill="#fef3c7"/>
+    <text class="pill-text" x="382" y="179" text-anchor="middle">ANALYSIS</text>
   </g>
 
-  <g id="bundles" transform="translate(328,340)">
+  <g id="bundles" transform="translate(344,340)">
     <text class="lane" x="0" y="-16">Analysis extensions</text>
     <rect class="card" width="444" height="56" fill="#dcfce7"/>
     <text class="card-title" x="222" y="24" text-anchor="middle">Page bundles</text>
     <text class="body" x="222" y="43" text-anchor="middle">sidecar dashboards discovered from [pages].view_module</text>
   </g>
 
-  <g id="core" transform="translate(884,154)">
+  <g id="core" transform="translate(904,154)">
     <text class="lane" x="0" y="-18">Shared services</text>
     <rect class="card" width="192" height="114" fill="#fef3c7"/>
     <text class="card-title" x="96" y="36" text-anchor="middle">agi_core</text>
@@ -77,13 +77,13 @@
     <text class="body" x="96" y="82" text-anchor="middle">telemetry, lab_stages</text>
   </g>
 
-  <path class="arrow" d="M230 196 C258 196 270 196 304 196" marker-end="url(#arrowhead)"/>
-  <path class="arrow-soft" d="M230 230 C270 292 282 368 328 368" marker-end="url(#arrowhead-soft)"/>
-  <path class="arrow" d="M796 196 C826 196 848 202 884 206" marker-end="url(#arrowhead)"/>
-  <path class="arrow-soft" d="M772 368 C828 364 844 256 884 238" marker-end="url(#arrowhead-soft)"/>
+  <path class="arrow" d="M230 196 C262 196 280 196 320 196" marker-end="url(#arrowhead)"/>
+  <path class="arrow-soft" d="M230 230 C270 292 290 368 344 368" marker-end="url(#arrowhead-soft)"/>
+  <path class="arrow" d="M812 196 C842 196 866 202 904 206" marker-end="url(#arrowhead)"/>
+  <path class="arrow-soft" d="M788 368 C844 364 866 256 904 238" marker-end="url(#arrowhead-soft)"/>
 
-  <text class="note" x="248" y="183">navigation</text>
-  <text class="note" x="250" y="304">bundle discovery</text>
-  <text class="note" x="818" y="184">page calls</text>
-  <text class="note" x="812" y="342">embedded views</text>
+  <text class="note" x="275" y="183" text-anchor="middle">navigation</text>
+  <text class="note" x="152" y="304">bundle discovery</text>
+  <text class="note" x="858" y="184" text-anchor="middle">page calls</text>
+  <text class="note" x="848" y="342">embedded views</text>
 </svg>

--- a/docs/source/diagrams/agilab_readme_tour.svg
+++ b/docs/source/diagrams/agilab_readme_tour.svg
@@ -125,11 +125,11 @@
   </g>
 
   <g transform="translate(838,62)" filter="url(#shadow)">
-    <rect x="0" y="0" width="450" height="94" rx="26" ry="26" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.2"/>
+    <rect x="0" y="0" width="444" height="116" rx="26" ry="26" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.2"/>
     <rect x="20" y="22" width="124" height="34" rx="17" ry="17" class="pill-dark"/>
     <text class="chip-text" x="82" y="44" text-anchor="middle">Built-in</text>
-    <rect x="154" y="22" width="96" height="34" rx="17" ry="17" class="pill-accent"/>
-    <text class="chip-text" x="202" y="44" text-anchor="middle">3 minutes</text>
+    <rect x="154" y="22" width="108" height="34" rx="17" ry="17" class="pill-accent"/>
+    <text class="chip-text" x="208" y="44" text-anchor="middle">3 minutes</text>
     <text class="body" x="22" y="73">
       <tspan x="22" dy="0">Full-tour app from PROJECT</tspan>
       <tspan x="22" dy="22">to WORKFLOW to ANALYSIS</tspan>
@@ -204,8 +204,8 @@
     <text class="body" x="28" y="116">
       <tspan x="28" dy="0">Open plots, reports,</tspan>
       <tspan x="28" dy="24">or maps over exported</tspan>
-      <tspan x="28" dy="24">metrics and run</tspan>
-      <tspan x="28" dy="24">evidence.</tspan>
+      <tspan x="28" dy="24">metrics and</tspan>
+      <tspan x="28" dy="24">run evidence.</tspan>
     </text>
     <text class="mini" x="28" y="230">
       <tspan x="28" dy="0">The demo closes the loop with</tspan>
@@ -213,13 +213,13 @@
     </text>
   </g>
 
-  <line class="arrow" x1="352" y1="395" x2="376" y2="395"/>
-  <line class="arrow" x1="664" y1="395" x2="688" y2="395"/>
-  <line class="arrow" x1="976" y1="395" x2="1000" y2="395"/>
+  <line class="arrow" x1="346" y1="395" x2="382" y2="395"/>
+  <line class="arrow" x1="658" y1="395" x2="694" y2="395"/>
+  <line class="arrow" x1="970" y1="395" x2="1006" y2="395"/>
 
   <g transform="translate(72,596)">
     <text class="section-label" x="0" y="0" dominant-baseline="middle">What you leave with</text>
-    <line class="line" x1="230" y1="0" x2="1210" y2="0"/>
+    <line class="line" x1="240" y1="0" x2="1210" y2="0"/>
   </g>
 
   <g transform="translate(72,628)" filter="url(#shadow)">
@@ -243,7 +243,7 @@
   </g>
 
   <g transform="translate(900,628)" filter="url(#shadow)">
-    <rect x="0" y="0" width="370" height="172" rx="28" ry="28" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.4"/>
+    <rect x="0" y="0" width="382" height="172" rx="28" ry="28" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.4"/>
     <text class="benefit-title" x="28" y="46">Visible, repeatable evidence</text>
     <text class="benefit-body" x="28" y="84">
       <tspan x="28" dy="0">The path stays inspectable and ends</tspan>
@@ -252,12 +252,12 @@
     </text>
   </g>
 
-  <line class="soft-arrow" x1="265" y1="546" x2="265" y2="612"/>
-  <line class="soft-arrow" x1="679" y1="546" x2="679" y2="612"/>
-  <line class="soft-arrow" x1="1085" y1="546" x2="1085" y2="612"/>
+  <line class="soft-arrow" x1="330" y1="538" x2="330" y2="626"/>
+  <line class="soft-arrow" x1="679" y1="538" x2="679" y2="626"/>
+  <line class="soft-arrow" x1="1091" y1="538" x2="1091" y2="626"/>
 
   <g transform="translate(72,838)" filter="url(#shadow)">
-    <rect x="0" y="0" width="1198" height="54" rx="24" ry="24" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.2"/>
+    <rect x="0" y="0" width="1210" height="54" rx="24" ry="24" fill="#ffffff" stroke="#d7e2ee" stroke-width="2.2"/>
     <text class="benefit-title" x="28" y="35">AGILAB promise</text>
     <text class="benefit-body" x="232" y="35">Move from app selection to visible evidence quickly, with far less orchestration overhead than ad hoc scripts.</text>
   </g>

--- a/docs/source/diagrams/agilab_social_card.svg
+++ b/docs/source/diagrams/agilab_social_card.svg
@@ -31,7 +31,7 @@
     <filter id="shadow" x="-12%" y="-12%" width="124%" height="134%">
       <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.13"/>
     </filter>
-    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="9" markerHeight="9" orient="auto">
+    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="13" markerHeight="13" markerUnits="userSpaceOnUse" orient="auto">
       <path d="M 1 1 L 11 6 L 1 11 Z" fill="#31485f"/>
     </marker>
     <style>
@@ -69,23 +69,23 @@
     <tspan x="62" dy="31">distributed execution, and health-gated services.</tspan>
   </text>
 
-  <g transform="translate(755 72)">
-    <rect class="panel" x="0" y="0" width="370" height="196" rx="28"/>
+  <g transform="translate(755 54)">
+    <rect class="panel" x="0" y="0" width="383" height="254" rx="28"/>
     <text class="card-label" x="30" y="40">Runtime map</text>
-    <g transform="translate(31 65)">
+    <g transform="translate(30 65)">
       <rect class="soft" x="0" y="0" width="88" height="46" rx="14"/>
       <rect class="soft" x="0" y="66" width="88" height="46" rx="14"/>
       <text class="note" x="44" y="29" text-anchor="middle">UI</text>
       <text class="note" x="44" y="95" text-anchor="middle">CLI</text>
-      <path class="arrow" d="M 98 23 L 154 57"/>
-      <path class="arrow" d="M 98 89 L 154 67"/>
-      <rect x="164" y="32" width="104" height="48" rx="16" fill="#e8fbf1" stroke="#0f766e" stroke-width="1.3"/>
-      <text class="note" x="216" y="61" text-anchor="middle">workers</text>
-      <path class="arrow" d="M 278 56 L 318 56"/>
-      <circle cx="336" cy="56" r="20" fill="#fff3e6" stroke="#bf5a24" stroke-width="1.4"/>
-      <path d="M 327 56 L 334 63 L 346 48" stroke="#bf5a24" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+      <path class="arrow" d="M 88 23 L 143 50"/>
+      <path class="arrow" d="M 88 89 L 143 62"/>
+      <rect x="144" y="32" width="104" height="48" rx="16" fill="#e8fbf1" stroke="#0f766e" stroke-width="1.3"/>
+      <text class="note" x="196" y="61" text-anchor="middle">workers</text>
+      <path class="arrow" d="M 248 56 L 283 56"/>
+      <circle cx="304" cy="56" r="20" fill="#fff3e6" stroke="#bf5a24" stroke-width="1.4"/>
+      <path d="M 295 56 L 302 63 L 314 48" stroke="#bf5a24" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <text class="card-body" x="30" y="164">
+    <text class="card-body" x="30" y="204">
       <tspan x="30" dy="0">Same project path from entrypoint</tspan>
       <tspan x="30" dy="22">to worker outputs and evidence.</tspan>
     </text>
@@ -124,12 +124,12 @@
     </text>
   </g>
 
-  <path class="arrow" d="M 392 418 L 423 418"/>
-  <path class="arrow" d="M 765 418 L 796 418"/>
+  <path class="arrow" d="M 392 418 L 434 418"/>
+  <path class="arrow" d="M 765 418 L 807 418"/>
 
   <rect x="62" y="552" width="1076" height="84" rx="26" fill="#10243d" filter="url(#shadow)"/>
   <text class="footer-title" x="92" y="586">Best fit: experimentation and validation teams</text>
   <text class="footer-body" x="92" y="615">Use AGILAB when you need less manual orchestration and more replayable proof around AI/ML work.</text>
-  <rect x="930" y="574" width="178" height="38" rx="19" fill="#f8fbff" opacity="0.96"/>
+  <rect x="922" y="574" width="194" height="38" rx="19" fill="#f8fbff" opacity="0.96"/>
   <text x="1019" y="598" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="800" fill="#10243d">PROJECT to ANALYSIS</text>
 </svg>

--- a/docs/source/diagrams/app_manager_worker.svg
+++ b/docs/source/diagrams/app_manager_worker.svg
@@ -81,8 +81,8 @@
   <path class="arrow-soft" d="M992 158 C992 170 992 171 992 182" marker-end="url(#arrowhead-soft)"/>
   <path class="arrow-soft" d="M992 256 C992 268 992 269 992 280" marker-end="url(#arrowhead-soft)"/>
 
-  <text class="note" x="274" y="174">work plan</text>
-  <text class="note" x="578" y="174">dispatch</text>
-  <text class="note" x="856" y="128">tasks</text>
-  <text class="note" x="858" y="232">tasks</text>
+  <text class="note" x="289" y="174" text-anchor="middle">work plan</text>
+  <text class="note" x="597" y="174" text-anchor="middle">dispatch</text>
+  <text class="note" x="865" y="124" text-anchor="middle">tasks</text>
+  <text class="note" x="867" y="232" text-anchor="middle">tasks</text>
 </svg>

--- a/docs/source/diagrams/dag_dual_concept.svg
+++ b/docs/source/diagrams/dag_dual_concept.svg
@@ -28,14 +28,14 @@
       .trace { stroke: #738987; stroke-width: 2.1; stroke-dasharray: 8 8; fill: none; }
       .divider { stroke: #c7d1d2; stroke-width: 1.4; stroke-dasharray: 5 7; }
     </style>
-    <marker id="arrowConcept" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
-      <path d="M 0 0 L 12 6 L 0 12 z" fill="#2d6f9f"/>
+    <marker id="arrowConcept" markerUnits="userSpaceOnUse" markerWidth="18" markerHeight="16" refX="18" refY="8" orient="auto">
+      <path d="M 0 0 L 18 8 L 0 16 z" fill="#2d6f9f"/>
     </marker>
-    <marker id="arrowExecution" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
-      <path d="M 0 0 L 12 6 L 0 12 z" fill="#8b6724"/>
+    <marker id="arrowExecution" markerUnits="userSpaceOnUse" markerWidth="18" markerHeight="16" refX="18" refY="8" orient="auto">
+      <path d="M 0 0 L 18 8 L 0 16 z" fill="#8b6724"/>
     </marker>
-    <marker id="arrowSource" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
-      <path d="M 0 0 L 12 6 L 0 12 z" fill="#60727a"/>
+    <marker id="arrowSource" markerUnits="userSpaceOnUse" markerWidth="18" markerHeight="16" refX="18" refY="8" orient="auto">
+      <path d="M 0 0 L 18 8 L 0 16 z" fill="#60727a"/>
     </marker>
   </defs>
 
@@ -88,17 +88,17 @@
     </text>
     <text class="small" x="892" y="326">Example: queue_metrics</text>
 
-    <rect class="concept-node" x="1121" y="228" width="200" height="116" rx="16" ry="16"/>
+    <rect class="concept-node" x="1113" y="228" width="216" height="116" rx="16" ry="16"/>
     <text class="box-title" x="1221" y="260" text-anchor="middle">Review map</text>
-    <text class="body" x="1145" y="288">
-      <tspan x="1145" dy="0">Clear graph for design,</tspan>
-      <tspan x="1145" dy="21">QA, and documentation.</tspan>
+    <text class="body" x="1137" y="288">
+      <tspan x="1137" dy="0">Clear graph for design,</tspan>
+      <tspan x="1137" dy="21">QA, and documentation.</tspan>
     </text>
-    <text class="small" x="1145" y="326">No runner side effects</text>
+    <text class="small" x="1137" y="326">No runner side effects</text>
 
-    <path class="concept-arrow" d="M 562 286 L 600 286"/>
-    <path class="concept-arrow" d="M 815 286 L 853 286"/>
-    <path class="concept-arrow" d="M 1068 286 L 1106 286"/>
+    <path class="concept-arrow" d="M 562 286 L 615 286"/>
+    <path class="concept-arrow" d="M 815 286 L 868 286"/>
+    <path class="concept-arrow" d="M 1068 286 L 1113 286"/>
   </g>
 
   <g id="projection-bridge">
@@ -110,10 +110,10 @@
     <path class="trace" d="M 715 344 L 715 418"/>
     <path class="trace" d="M 968 344 L 968 418"/>
     <path class="trace" d="M 1221 344 L 1221 418"/>
-    <path class="trace" d="M 462 484 L 462 600"/>
-    <path class="trace" d="M 715 484 L 715 600"/>
-    <path class="trace" d="M 968 484 L 968 600"/>
-    <path class="trace" d="M 1221 484 L 1221 600"/>
+    <path class="trace" d="M 462 484 L 462 500"/>
+    <path class="trace" d="M 715 484 L 715 500"/>
+    <path class="trace" d="M 968 484 L 968 500"/>
+    <path class="trace" d="M 1221 484 L 1221 500"/>
   </g>
 
   <g id="execution-view">
@@ -145,41 +145,41 @@
     </text>
     <text class="small" x="892" y="706">auditable state</text>
 
-    <rect class="execution-node" x="1121" y="608" width="200" height="116" rx="16" ry="16"/>
+    <rect class="execution-node" x="1113" y="608" width="216" height="116" rx="16" ry="16"/>
     <text class="box-title" x="1221" y="640" text-anchor="middle">Operator UI</text>
-    <text class="body" x="1145" y="668">
-      <tspan x="1145" dy="0">Status, dependency view,</tspan>
-      <tspan x="1145" dy="21">retry, and partial rerun.</tspan>
+    <text class="body" x="1137" y="668">
+      <tspan x="1137" dy="0">Status, dependency view,</tspan>
+      <tspan x="1137" dy="21">retry, and partial rerun.</tspan>
     </text>
-    <text class="small" x="1145" y="706">actionable controls</text>
+    <text class="small" x="1137" y="706">actionable controls</text>
 
-    <path class="execution-arrow" d="M 562 666 L 600 666"/>
-    <path class="execution-arrow" d="M 815 666 L 853 666"/>
-    <path class="execution-arrow" d="M 1068 666 L 1106 666"/>
+    <path class="execution-arrow" d="M 562 666 L 615 666"/>
+    <path class="execution-arrow" d="M 815 666 L 868 666"/>
+    <path class="execution-arrow" d="M 1068 666 L 1113 666"/>
   </g>
 
   <g id="source-projections">
-    <path class="source-arrow" d="M 260 392 C 302 392 294 286 348 286"/>
-    <rect class="label-pill" x="268" y="318" width="86" height="28" rx="12" ry="12"/>
+    <path class="source-arrow" d="M 260 392 C 302 392 294 286 330 286"/>
+    <rect class="label-pill" x="265" y="318" width="92" height="28" rx="12" ry="12"/>
     <text class="label-text" x="311" y="336" text-anchor="middle">review view</text>
 
-    <path class="source-arrow" d="M 260 504 C 302 504 294 666 348 666"/>
-    <rect class="label-pill" x="268" y="574" width="86" height="28" rx="12" ry="12"/>
+    <path class="source-arrow" d="M 260 504 C 302 504 294 666 330 666"/>
+    <rect class="label-pill" x="265" y="574" width="92" height="28" rx="12" ry="12"/>
     <text class="label-text" x="311" y="592" text-anchor="middle">runner view</text>
   </g>
 
   <g id="footer">
     <line class="divider" x1="56" y1="806" x2="1344" y2="806"/>
-    <rect class="chip" x="182" y="828" width="262" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="313" y="854" text-anchor="middle">one contract, no duplicate graph</text>
+    <rect class="chip" x="133" y="828" width="262" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="264" y="854" text-anchor="middle">one contract, no duplicate graph</text>
 
-    <rect class="chip" x="486" y="828" width="248" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="610" y="854" text-anchor="middle">conceptual view explains intent</text>
+    <rect class="chip" x="437" y="828" width="248" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="561" y="854" text-anchor="middle">conceptual view explains intent</text>
 
-    <rect class="chip" x="776" y="828" width="238" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="895" y="854" text-anchor="middle">execution view drives state</text>
+    <rect class="chip" x="727" y="828" width="238" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="846" y="854" text-anchor="middle">execution view drives state</text>
 
-    <rect class="chip" x="1056" y="828" width="260" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="1186" y="854" text-anchor="middle">provenance links them together</text>
+    <rect class="chip" x="1007" y="828" width="260" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="1137" y="854" text-anchor="middle">provenance links them together</text>
   </g>
 </svg>

--- a/docs/source/diagrams/execution_mode_families.svg
+++ b/docs/source/diagrams/execution_mode_families.svg
@@ -1,77 +1,80 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1260" height="700" viewBox="0 0 1260 700" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1320" height="700" viewBox="0 0 1320 700" role="img" aria-labelledby="title desc">
   <title id="title">Execution benchmark families</title>
   <desc id="desc">Compact benchmark summary showing three execution families for execution_pandas_project and execution_polars_project on two Macs. Lower time is better.</desc>
 
-  <rect width="1260" height="700" fill="#f5f8fc"/>
+  <rect width="1320" height="700" fill="#f5f8fc"/>
 
-  <rect x="52" y="36" width="620" height="112" rx="26" fill="#ffffff" stroke="#d7e1ec" stroke-width="2"/>
+  <rect x="52" y="36" width="660" height="112" rx="26" fill="#ffffff" stroke="#d7e1ec" stroke-width="2"/>
   <text x="84" y="77" font-family="Arial, Helvetica, sans-serif" font-size="32" font-weight="700" fill="#10243e">3 execution families, 2 different winners</text>
   <text x="84" y="108" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#496580">Same workload, same orchestration, but clearly different winning paths.</text>
   <text x="84" y="133" font-family="Arial, Helvetica, sans-serif" font-size="16" fill="#6b829a">Lower is better. Read rows 0-7; RAPIDS rows stay CPU-only on these Macs.</text>
 
-  <rect x="700" y="36" width="508" height="136" rx="26" fill="#10243e"/>
-  <text x="714" y="76" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" fill="#ffffff">How to read it in 10 seconds</text>
-  <text x="714" y="104" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">1. Start from the grey local baseline.</text>
-  <text x="714" y="126" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">
-    <tspan x="714" dy="0">2. Compare the teal local pool family and the blue</tspan>
-    <tspan x="714" dy="18">2-node Dask family.</tspan>
+  <rect x="760" y="36" width="508" height="142" rx="26" fill="#10243e"/>
+  <text x="774" y="76" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" fill="#ffffff">How to read it in 10 seconds</text>
+  <text x="774" y="104" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">1. Start from the grey local baseline.</text>
+  <text x="774" y="126" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">
+    <tspan x="774" dy="0">2. Compare the teal local pool family</tspan>
+    <tspan x="774" dy="18">and the blue 2-node Dask family.</tspan>
   </text>
-  <text x="714" y="158" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">3. The winner chip tells you which execution model actually pays off.</text>
+  <text x="774" y="164" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#d2deea">3. The winner chip tells you which execution model actually pays off.</text>
 
   <rect x="52" y="188" width="532" height="420" rx="30" fill="#ffffff" stroke="#d7e1ec" stroke-width="2"/>
-  <rect x="676" y="188" width="532" height="420" rx="30" fill="#ffffff" stroke="#d7e1ec" stroke-width="2"/>
+  <rect x="736" y="188" width="532" height="420" rx="30" fill="#ffffff" stroke="#d7e1ec" stroke-width="2"/>
 
-  <rect x="84" y="216" width="170" height="34" rx="17" fill="#edf4fb"/>
+  <rect x="84" y="216" width="252" height="34" rx="17" fill="#edf4fb"/>
   <text x="108" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#21476d">execution_pandas_project</text>
-  <rect x="364" y="216" width="180" height="34" rx="17" fill="#e9efff"/>
-  <text x="391" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#2f50c9">Winner: _d__  -39%</text>
+  <rect x="354" y="216" width="190" height="34" rx="17" fill="#e9efff"/>
+  <text x="377" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#2f50c9">Winner: _d__  -39%</text>
   <text x="84" y="280" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#496580">Dask wins, but only slightly ahead of the local pool family.</text>
 
   <text x="84" y="336" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local baseline</text>
   <text x="84" y="356" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">modes 0-2</text>
   <rect x="216" y="327" width="282" height="38" rx="12" fill="#99a8b8"/>
-  <text x="514" y="352" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#17324f">0.885s</text>
+  <text x="512" y="352" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#17324f">0.885s</text>
   <text x="84" y="392" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local pool / process</text>
   <text x="84" y="412" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode __cp</text>
   <rect x="260" y="383" width="143" height="38" rx="12" fill="#11a5b7"/>
-  <rect x="420" y="383" width="74" height="30" rx="15" fill="#d9f5f9"/>
-  <text x="438" y="404" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#0b7a88">-35%</text>
+  <rect x="420" y="387" width="74" height="30" rx="15" fill="#d9f5f9"/>
+  <text x="438" y="408" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#0b7a88">-35%</text>
   <text x="84" y="448" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">2-node Dask</text>
   <text x="84" y="468" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode _d__</text>
   <rect x="260" y="439" width="134" height="38" rx="12" fill="#3d63ff"/>
-  <rect x="411" y="439" width="74" height="30" rx="15" fill="#dde4ff"/>
-  <text x="429" y="460" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#3150cb">-39%</text>
+  <rect x="411" y="443" width="74" height="30" rx="15" fill="#dde4ff"/>
+  <text x="429" y="464" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#3150cb">-39%</text>
 
   <rect x="84" y="510" width="460" height="72" rx="18" fill="#f6f9fd" stroke="#e3ebf4" stroke-width="2"/>
   <text x="108" y="539" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#496580">Family split</text>
   <text x="108" y="565" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" fill="#17324f">0.885 → 0.575 → 0.540</text>
-  <text x="520" y="565" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">baseline → pool → Dask</text>
+  <text x="532" y="565" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">baseline → pool → Dask</text>
 
-  <rect x="708" y="216" width="166" height="34" rx="17" fill="#edf4fb"/>
-  <text x="732" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#21476d">execution_polars_project</text>
-  <rect x="988" y="216" width="186" height="34" rx="17" fill="#e9efff"/>
-  <text x="1015" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#2f50c9">Winner: _d_p  -70%</text>
-  <text x="708" y="280" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#496580">The 2-node Dask family separates very clearly from the local baseline.</text>
+  <rect x="768" y="216" width="243" height="34" rx="17" fill="#edf4fb"/>
+  <text x="792" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#21476d">execution_polars_project</text>
+  <rect x="1038" y="216" width="190" height="34" rx="17" fill="#e9efff"/>
+  <text x="1060" y="239" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#2f50c9">Winner: _d_p  -70%</text>
+  <text x="768" y="280" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#496580">
+    <tspan x="768" dy="0">The 2-node Dask family separates very clearly</tspan>
+    <tspan x="768" dy="22">from the local baseline.</tspan>
+  </text>
 
-  <text x="708" y="336" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local baseline</text>
-  <text x="708" y="356" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">modes 0-2</text>
-  <rect x="840" y="327" width="282" height="38" rx="12" fill="#99a8b8"/>
-  <text x="1138" y="352" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#17324f">0.885s</text>
-  <text x="708" y="392" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local pool / process</text>
-  <text x="708" y="412" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode ___p</text>
-  <rect x="884" y="383" width="107" height="38" rx="12" fill="#11a5b7"/>
-  <rect x="1008" y="383" width="74" height="30" rx="15" fill="#d9f5f9"/>
-  <text x="1026" y="404" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#0b7a88">-51%</text>
-  <text x="708" y="448" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">2-node Dask</text>
-  <text x="708" y="468" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode _d_p</text>
-  <rect x="884" y="439" width="65" height="38" rx="12" fill="#3d63ff"/>
-  <rect x="966" y="439" width="74" height="30" rx="15" fill="#dde4ff"/>
-  <text x="984" y="460" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#3150cb">-70%</text>
+  <text x="768" y="336" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local baseline</text>
+  <text x="768" y="356" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">modes 0-2</text>
+  <rect x="900" y="327" width="282" height="38" rx="12" fill="#99a8b8"/>
+  <text x="1196" y="352" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#17324f">0.885s</text>
+  <text x="768" y="392" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">Local pool / process</text>
+  <text x="768" y="412" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode ___p</text>
+  <rect x="944" y="383" width="107" height="38" rx="12" fill="#11a5b7"/>
+  <rect x="1068" y="387" width="74" height="30" rx="15" fill="#d9f5f9"/>
+  <text x="1086" y="408" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#0b7a88">-51%</text>
+  <text x="768" y="448" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#17324f">2-node Dask</text>
+  <text x="768" y="468" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">best mode _d_p</text>
+  <rect x="944" y="439" width="65" height="38" rx="12" fill="#3d63ff"/>
+  <rect x="1026" y="443" width="74" height="30" rx="15" fill="#dde4ff"/>
+  <text x="1044" y="464" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#3150cb">-70%</text>
 
-  <rect x="708" y="510" width="460" height="72" rx="18" fill="#f6f9fd" stroke="#e3ebf4" stroke-width="2"/>
-  <text x="732" y="539" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#496580">Family split</text>
-  <text x="732" y="565" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" fill="#17324f">0.885 → 0.430 → 0.262</text>
-  <text x="1144" y="565" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">baseline → pool → Dask</text>
+  <rect x="768" y="510" width="460" height="72" rx="18" fill="#f6f9fd" stroke="#e3ebf4" stroke-width="2"/>
+  <text x="792" y="539" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#496580">Family split</text>
+  <text x="792" y="565" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" fill="#17324f">0.885 → 0.430 → 0.262</text>
+  <text x="1216" y="565" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-size="14" fill="#6b829a">baseline → pool → Dask</text>
 
   <rect x="52" y="644" width="18" height="18" rx="5" fill="#99a8b8"/>
   <text x="82" y="658" font-family="Arial, Helvetica, sans-serif" font-size="15" fill="#5b728b">Local Python/Cython baseline</text>

--- a/docs/source/diagrams/parallel_runtime_modes.svg
+++ b/docs/source/diagrams/parallel_runtime_modes.svg
@@ -19,7 +19,7 @@
     <filter id="shadow" x="-12%" y="-12%" width="124%" height="134%">
       <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#0f172a" flood-opacity="0.12"/>
     </filter>
-    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="9" markerHeight="9" orient="auto">
+    <marker id="arrow" viewBox="0 0 12 12" refX="11" refY="6" markerUnits="userSpaceOnUse" markerWidth="21" markerHeight="21" orient="auto">
       <path d="M 1 1 L 11 6 L 1 11 Z" fill="#3f5870"/>
     </marker>
     <style>
@@ -62,7 +62,7 @@
     </text>
     <text class="note" x="96" y="294">No workers start from the file alone.</text>
 
-    <path class="arrow" d="M 384 222 L 438 222"/>
+    <path class="arrow" d="M 375 222 L 448 222"/>
 
     <rect class="panel" x="448" y="138" width="305" height="168" rx="22"/>
     <circle cx="480" cy="170" r="18" fill="#1d4ed8"/>
@@ -70,7 +70,7 @@
     <text class="step-label" x="510" y="166">Partition plan</text>
     <text class="step-title" x="510" y="193">Create work units</text>
     <rect class="soft" x="478" y="216" width="245" height="58" rx="14"/>
-    <g transform="translate(498 232)">
+    <g transform="translate(488 232)">
       <rect class="partition" x="0" y="0" width="37" height="26" rx="7"/>
       <rect class="partition" x="47" y="0" width="37" height="26" rx="7"/>
       <rect class="partition" x="94" y="0" width="37" height="26" rx="7"/>
@@ -79,7 +79,7 @@
     </g>
     <text class="note" x="478" y="294">Partitions, not files, are scheduled.</text>
 
-    <path class="arrow" d="M 762 222 L 816 222"/>
+    <path class="arrow" d="M 753 222 L 826 222"/>
 
     <rect class="panel" x="826" y="138" width="305" height="168" rx="22"/>
     <circle cx="858" cy="170" r="18" fill="#d97706"/>
@@ -99,7 +99,7 @@
 
   <g id="mode-cards">
     <g transform="translate(65 420)">
-      <rect class="card" x="0" y="0" width="200" height="224" rx="20"/>
+      <rect class="card" x="0" y="0" width="200" height="248" rx="20"/>
       <text class="mode-label" x="24" y="34">Preview</text>
       <text class="card-title" x="24" y="63">Plan only</text>
       <text class="body" x="24" y="96">
@@ -109,12 +109,12 @@
         <tspan x="24" dy="21">contract and</tspan>
         <tspan x="24" dy="21">estimates partitions.</tspan>
       </text>
-      <line class="muted-line" x1="24" y1="184" x2="176" y2="184"/>
-      <text class="note" x="24" y="207">Output: preview JSON</text>
+      <line class="muted-line" x1="24" y1="198" x2="176" y2="198"/>
+      <text class="note" x="24" y="224">Output: preview JSON</text>
     </g>
 
     <g transform="translate(295 420)">
-      <rect class="card" x="0" y="0" width="200" height="224" rx="20"/>
+      <rect class="card" x="0" y="0" width="200" height="248" rx="20"/>
       <text class="mode-label" x="24" y="34">Local</text>
       <text class="card-title" x="24" y="63">Dispatcher pool</text>
       <text class="body" x="24" y="96">
@@ -124,12 +124,12 @@
         <tspan x="24" dy="21">run partitions on</tspan>
         <tspan x="24" dy="21">one machine.</tspan>
       </text>
-      <line class="muted-line" x1="24" y1="184" x2="176" y2="184"/>
-      <text class="note" x="24" y="207">No Dask dashboard</text>
+      <line class="muted-line" x1="24" y1="198" x2="176" y2="198"/>
+      <text class="note" x="24" y="224">No Dask dashboard</text>
     </g>
 
     <g transform="translate(525 420)">
-      <rect class="card" x="0" y="0" width="200" height="224" rx="20"/>
+      <rect class="card" x="0" y="0" width="200" height="248" rx="20"/>
       <text class="mode-label" x="24" y="34">Dask</text>
       <text class="card-title" x="24" y="63">Outer scheduler</text>
       <g transform="translate(24 88)">
@@ -143,11 +143,11 @@
         <tspan x="24" dy="21">coarse AGILAB</tspan>
         <tspan x="24" dy="21">work-plan tasks.</tspan>
       </text>
-      <text class="note" x="24" y="207">Nested inner work is opaque</text>
+      <text class="note" x="24" y="224">Nested inner work is opaque</text>
     </g>
 
     <g transform="translate(755 420)">
-      <rect class="card" x="0" y="0" width="200" height="224" rx="20"/>
+      <rect class="card" x="0" y="0" width="200" height="248" rx="20"/>
       <text class="mode-label" x="24" y="34">Service</text>
       <text class="card-title" x="24" y="63">Persistent workers</text>
       <text class="body" x="24" y="96">
@@ -157,12 +157,12 @@
         <tspan x="24" dy="21">Health gates decide</tspan>
         <tspan x="24" dy="21">if work proceeds.</tspan>
       </text>
-      <line class="muted-line" x1="24" y1="184" x2="176" y2="184"/>
-      <text class="note" x="24" y="207">Best for repeated runs</text>
+      <line class="muted-line" x1="24" y1="198" x2="176" y2="198"/>
+      <text class="note" x="24" y="224">Best for repeated runs</text>
     </g>
 
     <g transform="translate(985 420)">
-      <rect class="card" x="0" y="0" width="200" height="224" rx="20"/>
+      <rect class="card" x="0" y="0" width="200" height="248" rx="20"/>
       <text class="mode-label" x="24" y="34">Inside worker</text>
       <text class="card-title" x="24" y="63">Library threads</text>
       <rect class="inner" x="24" y="86" width="150" height="42" rx="12"/>
@@ -172,7 +172,7 @@
         <tspan x="24" dy="21">not separate</tspan>
         <tspan x="24" dy="21">AGILAB tasks.</tspan>
       </text>
-      <text class="note" x="24" y="207">Avoid over-stacking workers</text>
+      <text class="note" x="24" y="224">Avoid over-stacking workers</text>
     </g>
   </g>
 

--- a/docs/source/diagrams/pipeline_mlflow_tracking.svg
+++ b/docs/source/diagrams/pipeline_mlflow_tracking.svg
@@ -13,13 +13,14 @@
       .muted { fill: #334155; }
       .arrow { stroke: #0f172a; stroke-width: 2.2; fill: none; marker-end: url(#arrow); }
       .soft-arrow { stroke: #475569; stroke-width: 2; fill: none; marker-end: url(#arrow-soft); }
+      .line { stroke: #0f172a; stroke-width: 2.2; fill: none; }
       .pill { fill: #ffffff; stroke: #94a3b8; stroke-width: 1.2; rx: 12; ry: 12; }
     </style>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
-      <path d="M0,0 L10,5 L0,10 z" fill="#0f172a" />
+    <marker id="arrow" markerWidth="17" markerHeight="17" refX="16" refY="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L16,8 L0,16 z" fill="#0f172a" />
     </marker>
-    <marker id="arrow-soft" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto" markerUnits="strokeWidth">
-      <path d="M0,0 L9,4.5 L0,9 z" fill="#475569" />
+    <marker id="arrow-soft" markerWidth="15" markerHeight="15" refX="14" refY="7" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L14,7 L0,14 z" fill="#475569" />
     </marker>
   </defs>
 
@@ -41,11 +42,11 @@
     <text class="body" x="134" y="92" text-anchor="middle">prompt, model, engine, runtime</text>
   </g>
 
-  <g transform="translate(48,528)">
-    <rect class="box" width="268" height="122" fill="#e2e8f0" />
+  <g transform="translate(48,589)">
+    <rect class="box" width="268" height="114" fill="#e2e8f0" />
     <text class="caption" x="134" y="36" text-anchor="middle">Execution paths</text>
-    <text class="body" x="134" y="70" text-anchor="middle">runpy in the managed env</text>
-    <text class="body" x="134" y="92" text-anchor="middle">or subprocess in a selected venv</text>
+    <text class="body" x="134" y="68" text-anchor="middle">runpy in the managed env</text>
+    <text class="body" x="134" y="90" text-anchor="middle">or subprocess in a selected venv</text>
   </g>
 
   <!-- Center column -->
@@ -91,10 +92,10 @@
 
   <g transform="translate(392,589)">
     <rect class="box" width="560" height="114" fill="#e0f2fe" />
-    <text class="caption" x="280" y="38" text-anchor="middle">Shared runtime contract</text>
-    <text class="body" x="280" y="72" text-anchor="middle">
+    <text class="caption" x="280" y="36" text-anchor="middle">Shared runtime contract</text>
+    <text class="body" x="280" y="68" text-anchor="middle">
       <tspan x="280" dy="0">runpy and subprocess stages both receive</tspan>
-      <tspan x="280" dy="18">the same MLFLOW_TRACKING_URI</tspan>
+      <tspan x="280" dy="22">the same MLFLOW_TRACKING_URI</tspan>
     </text>
   </g>
 
@@ -111,9 +112,9 @@
 
   <g transform="translate(1064,591)">
     <rect class="box" width="208" height="112" fill="#bae6fd" />
-    <text class="caption" x="104" y="38" text-anchor="middle">MLflow UI</text>
-    <text class="body" x="104" y="72" text-anchor="middle">sidebar Open UI link</text>
-    <text class="body" x="104" y="94" text-anchor="middle">reads the same store</text>
+    <text class="caption" x="104" y="36" text-anchor="middle">MLflow UI</text>
+    <text class="body" x="104" y="68" text-anchor="middle">sidebar Open UI link</text>
+    <text class="body" x="104" y="90" text-anchor="middle">reads the same store</text>
   </g>
 
   <!-- Orthogonal flow arrows -->

--- a/docs/source/diagrams/repo_split.svg
+++ b/docs/source/diagrams/repo_split.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="550" viewBox="0 0 1120 550" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="550" viewBox="0 0 1160 550" role="img" aria-labelledby="title desc">
   <title id="title">AGILAB repository and installable payload split</title>
   <desc id="desc">Diagram showing AGILAB repository runtime layers, built-in app seeds, page bundles, and installable PyPI app and page payloads.</desc>
   <defs>
@@ -23,7 +23,7 @@
     </marker>
   </defs>
 
-  <rect width="1120" height="550" fill="#f8fbff" rx="30" ry="30"/>
+  <rect width="1160" height="550" fill="#f8fbff" rx="30" ry="30"/>
 
   <g transform="translate(44,38)">
     <text class="title" x="0" y="0">Repository and payload split</text>
@@ -35,9 +35,9 @@
     <text class="zone-title" x="240" y="36" text-anchor="middle">AGILAB repository / base wheel</text>
 
     <rect class="card" x="34" y="66" width="412" height="76" fill="#dbeafe"/>
-    <text class="card-title" x="240" y="94" text-anchor="middle">agilab UI</text>
-    <text class="body" x="240" y="116" text-anchor="middle">LANDING · SETTINGS · PROJECT</text>
-    <text class="body" x="240" y="134" text-anchor="middle">ORCHESTRATE · WORKFLOW · ANALYSIS</text>
+    <text class="card-title" x="240" y="88" text-anchor="middle">agilab UI</text>
+    <text class="body" x="240" y="110" text-anchor="middle">LANDING · SETTINGS · PROJECT</text>
+    <text class="body" x="240" y="128" text-anchor="middle">ORCHESTRATE · WORKFLOW · ANALYSIS</text>
 
     <rect class="card" x="34" y="168" width="190" height="64" fill="#ede9fe"/>
     <text class="card-title" x="129" y="194" text-anchor="middle">agi-core</text>
@@ -53,13 +53,13 @@
 
     <rect class="card" x="256" y="260" width="190" height="64" fill="#ffedd5"/>
     <text class="card-title" x="351" y="286" text-anchor="middle">built-in app seeds</text>
-    <text class="note" x="351" y="307" text-anchor="middle">src/agilab/apps/builtin</text>
+    <text class="note" x="351" y="308" text-anchor="middle">src/agilab/apps/builtin</text>
 
     <rect class="card" x="34" y="350" width="412" height="44" fill="#fce7f3"/>
     <text class="card-title" x="240" y="376" text-anchor="middle">page bundles · src/agilab/apps-pages</text>
   </g>
 
-  <g id="payloads" transform="translate(650,100)">
+  <g id="payloads" transform="translate(690,100)">
     <rect class="zone" width="430" height="410" fill="#ffffff"/>
     <text class="zone-title" x="215" y="36" text-anchor="middle">Installable app/page payloads</text>
 
@@ -76,13 +76,14 @@
     <text class="body" x="215" y="322" text-anchor="middle">catalog for ANALYSIS sidecar dashboards</text>
   </g>
 
-  <path class="arrow" d="M520 206 C570 184 594 168 650 166" marker-end="url(#arrowhead)"/>
-  <path class="arrow" d="M520 292 C570 266 594 222 650 208" marker-end="url(#arrowhead)"/>
-  <path class="arrow-soft" d="M520 472 C586 454 598 390 650 370" marker-end="url(#arrowhead-soft)"/>
-  <path class="arrow-soft" d="M650 404 C596 376 582 324 520 318" marker-end="url(#arrowhead-soft)"/>
+  <path class="arrow" d="M520 204 C575 197 630 194 690 194" marker-end="url(#arrowhead)"/>
+  <path class="arrow" d="M520 300 C575 290 620 240 690 226" marker-end="url(#arrowhead)"/>
+  <path class="arrow-soft" d="M520 472 C580 462 620 442 690 422" marker-end="url(#arrowhead-soft)"/>
+  <path class="arrow-soft" d="M690 390 C630 384 580 384 520 392" marker-end="url(#arrowhead-soft)"/>
 
-  <text class="note" x="550" y="166">runtime depends on</text>
-  <text class="note" x="548" y="250">app payloads expose</text>
-  <text class="note" x="552" y="450">page discovery</text>
-  <text class="note" x="546" y="344">source seeds can be packaged</text>
+  <text class="note" x="605" y="178" text-anchor="middle">runtime depends on</text>
+  <text class="note" x="605" y="218" text-anchor="middle">app payloads expose</text>
+  <text class="note" x="605" y="352" text-anchor="middle">source seeds</text>
+  <text class="note" x="605" y="368" text-anchor="middle">can be packaged</text>
+  <text class="note" x="605" y="422" text-anchor="middle">page discovery</text>
 </svg>

--- a/docs/source/diagrams/same_api_local_vs_distributed.svg
+++ b/docs/source/diagrams/same_api_local_vs_distributed.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="360" viewBox="0 0 1040 360" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="394" viewBox="0 0 1040 394" role="img" aria-labelledby="title desc">
   <title id="title">Same AGI.run API from local to distributed</title>
   <desc id="desc">Comparison showing that local and distributed AGILAB runs share the same AGI.run call shape while distributed execution adds scheduler and worker fields.</desc>
   <defs>
@@ -19,9 +19,12 @@
     <filter id="shadow" x="-12%" y="-12%" width="124%" height="134%">
       <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#0f172a" flood-opacity="0.12"/>
     </filter>
-    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="9" markerHeight="9" orient="auto">
+    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="16" markerHeight="16" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 11 6 L 1 11 Z" fill="#315c7a"/>
     </marker>
+    <clipPath id="canvasClip">
+      <rect x="0" y="0" width="1040" height="394" rx="26"/>
+    </clipPath>
     <style>
       text { font-family: Arial, Helvetica, sans-serif; fill: #14283f; }
       .title { font-size: 26px; font-weight: 800; letter-spacing: -0.015em; fill: #10243d; }
@@ -33,7 +36,7 @@
       .chip { font-size: 12.5px; font-weight: 800; fill: #ffffff; }
       .note-title { font-size: 15px; font-weight: 800; fill: #ffffff; }
       .note-body { font-size: 13.5px; font-weight: 400; fill: #dcecff; }
-      .frame { fill: #ffffff; stroke: #c8d8e7; stroke-width: 1.5; filter: url(#shadow); }
+      .frame { stroke: #c8d8e7; stroke-width: 1.5; filter: url(#shadow); }
       .codebox { fill: #ffffff; stroke: #c3d5e5; stroke-width: 1.2; }
       .pill-blue { fill: #315c7a; }
       .pill-orange { fill: #bf5a24; }
@@ -42,54 +45,62 @@
     </style>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1040" height="360" rx="26"/>
-  <circle cx="930" cy="38" r="112" fill="#dbeafe" opacity="0.45"/>
-  <circle cx="90" cy="330" r="92" fill="#fde6c8" opacity="0.45"/>
+  <rect class="bg" x="0" y="0" width="1040" height="394" rx="26" fill="url(#bg)"/>
+  <g clip-path="url(#canvasClip)">
+    <circle cx="930" cy="38" r="112" fill="#dbeafe" opacity="0.45"/>
+    <circle cx="90" cy="364" r="92" fill="#fde6c8" opacity="0.45"/>
+  </g>
 
   <text class="title" x="46" y="44">Same API, local first, distributed when needed</text>
   <text class="subtitle" x="46" y="68">Read distributed snippets as the same AGI.run(...) shape with scheduler and workers added.</text>
 
   <g transform="translate(46 96)">
-    <rect class="frame" x="0" y="0" width="380" height="186" rx="24" fill="url(#localGrad)"/>
+    <rect class="frame" x="0" y="0" width="380" height="220" rx="24" fill="url(#localGrad)"/>
     <text class="label" x="28" y="34">Local mental model</text>
     <text class="card-title" x="28" y="62">Run on one machine</text>
-    <text class="body" x="28" y="86">No scheduler. No worker map. Prove the app path first.</text>
-    <rect class="codebox" x="28" y="104" width="324" height="58" rx="14"/>
-    <text class="code" x="48" y="127">
+    <text class="body" x="28" y="86">
+      <tspan x="28" dy="0">No scheduler. No worker map.</tspan>
+      <tspan x="28" dy="18">Prove the app path first.</tspan>
+    </text>
+    <rect class="codebox" x="28" y="122" width="324" height="72" rx="14"/>
+    <text class="code" x="48" y="145">
       <tspan x="48" dy="0">result = await AGI.run(</tspan>
-      <tspan x="48" dy="18">    app_env, request=request</tspan>
+      <tspan x="80" dy="18">app_env, request=request</tspan>
       <tspan x="48" dy="18">)</tspan>
     </text>
   </g>
 
   <g transform="translate(614 96)">
-    <rect class="frame" x="0" y="0" width="380" height="186" rx="24" fill="url(#distGrad)"/>
+    <rect class="frame" x="0" y="0" width="380" height="220" rx="24" fill="url(#distGrad)"/>
     <text class="label" x="28" y="34">Distributed variant</text>
     <text class="card-title" x="28" y="62">Same call, cluster fields</text>
-    <text class="body" x="28" y="86">Add scheduler and workers, then choose a distributed mode.</text>
-    <rect class="codebox" x="28" y="104" width="324" height="58" rx="14"/>
-    <text class="code" x="48" y="127">
+    <text class="body" x="28" y="86">
+      <tspan x="28" dy="0">Add scheduler and workers,</tspan>
+      <tspan x="28" dy="18">then choose a distributed mode.</tspan>
+    </text>
+    <rect class="codebox" x="28" y="122" width="324" height="72" rx="14"/>
+    <text class="code" x="48" y="145">
       <tspan x="48" dy="0">request = RunRequest(</tspan>
-      <tspan x="48" dy="18">    scheduler=host, workers=workers</tspan>
+      <tspan x="80" dy="18">scheduler=host, workers=workers</tspan>
       <tspan x="48" dy="18">)</tspan>
     </text>
   </g>
 
-  <path class="connector" d="M 434 171 L 593 171"/>
-  <rect class="pill-blue" x="455" y="125" width="122" height="34" rx="17"/>
-  <text class="chip" x="516" y="147" text-anchor="middle">same AGI.run</text>
-  <rect class="pill-orange" x="442" y="190" width="148" height="34" rx="17"/>
-  <text class="chip" x="516" y="212" text-anchor="middle">add cluster fields</text>
+  <path class="connector" d="M 426 178 L 612.5 178"/>
+  <rect class="pill-blue" x="459" y="131" width="122" height="34" rx="17"/>
+  <text class="chip" x="520" y="153" text-anchor="middle">same AGI.run</text>
+  <rect class="pill-orange" x="446" y="191" width="148" height="34" rx="17"/>
+  <text class="chip" x="520" y="213" text-anchor="middle">add cluster fields</text>
 
-  <g transform="translate(442 244)">
+  <g transform="translate(446 245)">
     <rect class="ghost" x="0" y="0" width="148" height="36" rx="18"/>
-    <circle cx="27" cy="18" r="8" fill="#315c7a"/>
-    <circle cx="61" cy="18" r="8" fill="#0f766e"/>
-    <circle cx="95" cy="18" r="8" fill="#bf5a24"/>
+    <circle cx="24" cy="18" r="8" fill="#315c7a"/>
+    <circle cx="56" cy="18" r="8" fill="#0f766e"/>
+    <circle cx="88" cy="18" r="8" fill="#bf5a24"/>
     <text class="body" x="122" y="23" text-anchor="middle">tasks</text>
   </g>
 
-  <rect x="46" y="302" width="948" height="42" rx="21" fill="#10243d" filter="url(#shadow)"/>
-  <text class="note-title" x="76" y="328">Rule:</text>
-  <text class="note-body" x="126" y="328">start local to verify behavior, then distribute by adding cluster fields without changing the API shape.</text>
+  <rect x="46" y="336" width="948" height="42" rx="21" fill="#10243d" filter="url(#shadow)"/>
+  <text class="note-title" x="76" y="362">Rule:</text>
+  <text class="note-body" x="126" y="362">start local to verify behavior, then distribute by adding cluster fields without changing the API shape.</text>
 </svg>

--- a/docs/source/needs-algos-set.svg
+++ b/docs/source/needs-algos-set.svg
@@ -21,10 +21,10 @@
   <text class="title" x="480" y="56" text-anchor="middle">Complex problems need an algorithm set</text>
   <text class="t" x="480" y="82" text-anchor="middle">Example: communications planning under constraints, uncertainty, and scale.</text>
 
-  <rect class="center" x="330" y="210" rx="18" ry="18" width="300" height="148"/>
-  <text class="h" x="480" y="248" text-anchor="middle">System objective</text>
-  <text class="t" x="480" y="278" text-anchor="middle">Decisions, allocations, and KPIs</text>
-  <text class="t" x="480" y="306" text-anchor="middle">must satisfy constraints</text>
+  <rect class="center" x="330" y="224" rx="18" ry="18" width="300" height="148"/>
+  <text class="h" x="480" y="272" text-anchor="middle">System objective</text>
+  <text class="t" x="480" y="302" text-anchor="middle">Decisions, allocations, and KPIs</text>
+  <text class="t" x="480" y="330" text-anchor="middle">must satisfy constraints</text>
 
   <rect class="box" x="80" y="120" rx="14" ry="14" width="220" height="84"/>
   <text class="h" x="190" y="150" text-anchor="middle">Simulation</text>
@@ -34,13 +34,13 @@
   <text class="h" x="770" y="150" text-anchor="middle">Optimization</text>
   <text class="t" x="770" y="174" text-anchor="middle">ILP / heuristics</text>
 
-  <rect class="box" x="80" y="250" rx="14" ry="14" width="220" height="84"/>
-  <text class="h" x="190" y="280" text-anchor="middle">Data pipelines</text>
-  <text class="t" x="190" y="304" text-anchor="middle">cleaning, features</text>
+  <rect class="box" x="80" y="256" rx="14" ry="14" width="220" height="84"/>
+  <text class="h" x="190" y="286" text-anchor="middle">Data pipelines</text>
+  <text class="t" x="190" y="310" text-anchor="middle">cleaning, features</text>
 
-  <rect class="box" x="660" y="250" rx="14" ry="14" width="220" height="84"/>
-  <text class="h" x="770" y="280" text-anchor="middle">Learning</text>
-  <text class="t" x="770" y="304" text-anchor="middle">ML / RL policies</text>
+  <rect class="box" x="660" y="256" rx="14" ry="14" width="220" height="84"/>
+  <text class="h" x="770" y="286" text-anchor="middle">Learning</text>
+  <text class="t" x="770" y="310" text-anchor="middle">ML / RL policies</text>
 
   <rect class="box" x="80" y="392" rx="14" ry="14" width="220" height="84"/>
   <text class="h" x="190" y="422" text-anchor="middle">Verification</text>
@@ -50,12 +50,12 @@
   <text class="h" x="770" y="422" text-anchor="middle">Visualisation</text>
   <text class="t" x="770" y="446" text-anchor="middle">maps, KPIs, reports</text>
 
-  <line class="arrow" x1="300" y1="162" x2="330" y2="240"/>
-  <line class="arrow" x1="660" y1="162" x2="630" y2="240"/>
-  <line class="arrow" x1="300" y1="292" x2="330" y2="284"/>
-  <line class="arrow" x1="660" y1="292" x2="630" y2="284"/>
-  <line class="arrow" x1="300" y1="434" x2="330" y2="322"/>
-  <line class="arrow" x1="660" y1="434" x2="630" y2="322"/>
+  <line class="arrow" x1="300" y1="162" x2="330" y2="254"/>
+  <line class="arrow" x1="660" y1="162" x2="630" y2="254"/>
+  <line class="arrow" x1="300" y1="298" x2="330" y2="298"/>
+  <line class="arrow" x1="660" y1="298" x2="630" y2="298"/>
+  <line class="arrow" x1="300" y1="434" x2="330" y2="342"/>
+  <line class="arrow" x1="660" y1="434" x2="630" y2="342"/>
 
   <text class="t" x="480" y="545" text-anchor="middle">AGILab orchestrates these components into repeatable, scalable experiments.</text>
 </svg>


### PR DESCRIPTION
## Summary
Mirror sync of the full hand-authored SVG quality pass (canonical: thales_agilab `ab94a82`). All 17 hand-authored docs SVGs were audited against the svg-diagram-tuning checklist; 15 carry fixes (overflow, arrow/label collisions, markerUnits arrowhead traps, missing gutters, unbalanced wraps, connector anchoring, baseline alignment). The 19 graphviz-generated `classes_*`/`packages_*` diagrams were intentionally left to their generator.

## Verification
- Every changed file re-rendered at 1600px (rsvg-convert) and visually inspected — zero overflow/collision/crowding defects
- XML parse clean across all docs SVGs
- `sync_docs_source.py --verify-stamp` → target integrity + canonical source verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)