### PR TITLE
fix(ui): recover stale runtime symbols without restart

### DIFF
--- a/src/agilab/app_management/app_surface.py
+++ b/src/agilab/app_management/app_surface.py
@@ -325,17 +325,19 @@ def app_editable_import_roots(
             "The installed AGILAB UI runtime cannot inspect manager editables. "
             "Upgrade the aligned AGILAB packages and restart Streamlit."
         ) from exc
-    editable_roots = getattr(
-        import_layout_support,
-        "hosted_editable_source_import_roots",
-        None,
-    )
-    if not callable(editable_roots):
+    try:
+        from agi_env.runtime.hot_source_support import aligned_module_callable
+
+        editable_roots = aligned_module_callable(
+            import_layout_support,
+            "hosted_editable_source_import_roots",
+        )
+    except (ImportError, RuntimeError) as exc:
         raise RuntimeError(
             "The installed AGILAB UI runtime is stale: agi_env does not expose "
             "hosted editable import support. Upgrade the aligned AGILAB packages "
             "and restart Streamlit."
-        )
+        ) from exc
 
     return tuple(
         dict.fromkeys((app_source, *editable_roots(app_path / ".venv")))

--- a/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
+++ b/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
@@ -98,17 +98,19 @@ def _manager_editable_import_roots(active_app: Path) -> tuple[Path, ...]:
             "The installed AGILAB UI runtime cannot inspect manager editables. "
             "Upgrade the aligned AGILAB packages and restart Streamlit."
         ) from exc
-    resolver = getattr(
-        import_layout_support,
-        "hosted_editable_source_import_roots",
-        None,
-    )
-    if not callable(resolver):
+    try:
+        from agi_env.runtime.hot_source_support import aligned_module_callable
+
+        resolver = aligned_module_callable(
+            import_layout_support,
+            "hosted_editable_source_import_roots",
+        )
+    except (ImportError, RuntimeError) as exc:
         raise RuntimeError(
             "The installed AGILAB UI runtime is stale: agi_env does not expose "
             "hosted editable import support. Upgrade the aligned AGILAB packages "
             "and restart Streamlit."
-        )
+        ) from exc
     return resolver(active_app / ".venv")
 
 

--- a/src/agilab/core/agi-env/src/agi_env/runtime/hot_source_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/hot_source_support.py
@@ -1,0 +1,123 @@
+"""Recover additive runtime symbols from an aligned source update."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+
+class StaleRuntimeModuleError(RuntimeError):
+    """Raised when a stale runtime module cannot be refreshed safely."""
+
+
+_AGI_ENV_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+_LOAD_LOCK = threading.RLock()
+_MODULE_CACHE_LIMIT = 16
+_MODULE_CACHE: OrderedDict[tuple[Path, str], ModuleType] = OrderedDict()
+
+
+def aligned_module_callable(module: ModuleType, attribute: str) -> Callable[..., Any]:
+    """Return a callable from ``module`` or its current aligned source file.
+
+    A long-lived Streamlit process can retain a module object loaded before an
+    additive source update.  This helper does not reload or mutate that shared
+    module.  It executes the current source under an isolated name, and only
+    when the source remains inside the active ``agi_env`` package root.
+    """
+
+    candidate = getattr(module, attribute, None)
+    if callable(candidate):
+        return candidate
+
+    origin = _aligned_module_origin(module)
+    try:
+        source = origin.read_bytes()
+    except OSError as exc:
+        raise StaleRuntimeModuleError(
+            f"Cannot read the aligned source for stale module {module.__name__!r}."
+        ) from exc
+    refreshed = _load_aligned_module(origin, source)
+    candidate = getattr(refreshed, attribute, None)
+    if not callable(candidate):
+        raise StaleRuntimeModuleError(
+            f"The current aligned source for {module.__name__!r} does not expose "
+            f"callable {attribute!r}."
+        )
+    return candidate
+
+
+def _aligned_module_origin(module: ModuleType) -> Path:
+    raw_origin = getattr(module, "__file__", None)
+    if not isinstance(raw_origin, str) or not raw_origin:
+        raise StaleRuntimeModuleError(
+            f"Stale module {module.__name__!r} has no verifiable source file."
+        )
+    try:
+        origin = Path(raw_origin).expanduser().resolve(strict=True)
+        origin.relative_to(_AGI_ENV_PACKAGE_ROOT)
+    except (OSError, ValueError) as exc:
+        raise StaleRuntimeModuleError(
+            f"Refusing to refresh stale module {module.__name__!r} outside the "
+            f"active agi_env package root {_AGI_ENV_PACKAGE_ROOT}."
+        ) from exc
+    if not origin.is_file():
+        raise StaleRuntimeModuleError(
+            f"Aligned source for stale module {module.__name__!r} is not a file: {origin}."
+        )
+    return origin
+
+
+def _load_aligned_module(
+    origin: Path,
+    source: bytes,
+) -> ModuleType:
+    source_digest = hashlib.sha256(source).hexdigest()
+    cache_key = (origin, source_digest)
+    identity_digest = hashlib.sha256(
+        f"{origin}\0{source_digest}".encode("utf-8")
+    ).hexdigest()[:24]
+    synthetic_name = f"agi_env.runtime._hot_source_{identity_digest}"
+    with _LOAD_LOCK:
+        cached = _MODULE_CACHE.get(cache_key)
+        if cached is not None:
+            _MODULE_CACHE.move_to_end(cache_key)
+            return cached
+        spec = importlib.util.spec_from_file_location(synthetic_name, origin)
+        if spec is None or spec.loader is None:
+            raise StaleRuntimeModuleError(
+                f"Unable to load aligned runtime source at {origin}."
+            )
+        refreshed = importlib.util.module_from_spec(spec)
+        sys.modules[synthetic_name] = refreshed
+        try:
+            exec(compile(source, str(origin), "exec"), refreshed.__dict__)
+        # Boundary: convert arbitrary aligned module execution failures into
+        # the stable stale-runtime contract after removing partial state.
+        except Exception as exc:
+            if sys.modules.get(synthetic_name) is refreshed:
+                sys.modules.pop(synthetic_name, None)
+            raise StaleRuntimeModuleError(
+                f"Unable to execute aligned runtime source at {origin}."
+            ) from exc
+        _MODULE_CACHE[cache_key] = refreshed
+        while len(_MODULE_CACHE) > _MODULE_CACHE_LIMIT:
+            _old_key, old_module = _MODULE_CACHE.popitem(last=False)
+            if sys.modules.get(old_module.__name__) is old_module:
+                sys.modules.pop(old_module.__name__, None)
+        return refreshed
+
+
+def _clear_aligned_module_cache() -> None:
+    """Clear isolated hot-source modules; used by focused regression tests."""
+
+    with _LOAD_LOCK:
+        for module in _MODULE_CACHE.values():
+            if sys.modules.get(module.__name__) is module:
+                sys.modules.pop(module.__name__, None)
+        _MODULE_CACHE.clear()

--- a/src/agilab/core/agi-env/test/test_hot_source_support.py
+++ b/src/agilab/core/agi-env/test/test_hot_source_support.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from agi_env.runtime import hot_source_support
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hot_source_cache():
+    hot_source_support._clear_aligned_module_cache()
+    yield
+    hot_source_support._clear_aligned_module_cache()
+
+
+def test_aligned_module_callable_returns_existing_callable() -> None:
+    module = ModuleType("agi_env.runtime.current")
+
+    def existing() -> str:
+        return "current"
+
+    module.existing = existing
+
+    assert hot_source_support.aligned_module_callable(module, "existing") is existing
+
+
+def test_aligned_module_callable_loads_current_aligned_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "agi_env"
+    source = package_root / "runtime" / "stale.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def added():\n    return 'fresh'\n", encoding="utf-8")
+    stale = ModuleType("agi_env.runtime.stale")
+    stale.__file__ = str(source)
+    monkeypatch.setattr(hot_source_support, "_AGI_ENV_PACKAGE_ROOT", package_root)
+    hot_source_support._clear_aligned_module_cache()
+
+    resolved = hot_source_support.aligned_module_callable(stale, "added")
+
+    assert resolved() == "fresh"
+
+
+def test_aligned_module_callable_rejects_external_source_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "agi_env"
+    package_root.mkdir()
+    external = tmp_path / "external.py"
+    external.write_text(
+        "raise AssertionError('external source must not execute')\n",
+        encoding="utf-8",
+    )
+    stale = ModuleType("agi_env.runtime.stale")
+    stale.__file__ = str(external)
+    monkeypatch.setattr(hot_source_support, "_AGI_ENV_PACKAGE_ROOT", package_root)
+
+    with pytest.raises(
+        hot_source_support.StaleRuntimeModuleError,
+        match="outside the active agi_env package root",
+    ):
+        hot_source_support.aligned_module_callable(stale, "added")
+
+
+def test_failed_aligned_source_load_does_not_leave_partial_module(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "agi_env"
+    source = package_root / "runtime" / "broken.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("raise RuntimeError('broken source')\n", encoding="utf-8")
+    stale = ModuleType("agi_env.runtime.broken")
+    stale.__file__ = str(source)
+    monkeypatch.setattr(hot_source_support, "_AGI_ENV_PACKAGE_ROOT", package_root)
+    hot_source_support._clear_aligned_module_cache()
+    before = set(sys.modules)
+
+    with pytest.raises(
+        hot_source_support.StaleRuntimeModuleError,
+        match="Unable to execute aligned runtime source",
+    ):
+        hot_source_support.aligned_module_callable(stale, "added")
+
+    assert not {
+        name for name in set(sys.modules) - before if name.startswith("agi_env.runtime._hot_source_")
+    }
+
+
+def test_aligned_module_cache_uses_source_content_not_file_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "agi_env"
+    source = package_root / "runtime" / "stale.py"
+    source.parent.mkdir(parents=True)
+    stale = ModuleType("agi_env.runtime.stale")
+    stale.__file__ = str(source)
+    monkeypatch.setattr(hot_source_support, "_AGI_ENV_PACKAGE_ROOT", package_root)
+    hot_source_support._clear_aligned_module_cache()
+    source.write_text("def added():\n    return 'first'\n", encoding="utf-8")
+    initial_stat = source.stat()
+
+    first = hot_source_support.aligned_module_callable(stale, "added")
+    source.write_text("def added():\n    return 'other'\n", encoding="utf-8")
+    os.utime(source, ns=(initial_stat.st_atime_ns, initial_stat.st_mtime_ns))
+    second = hot_source_support.aligned_module_callable(stale, "added")
+
+    assert first() == "first"
+    assert second() == "other"
+
+
+def test_identical_sources_at_different_paths_keep_distinct_module_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "agi_env"
+    sources = [
+        package_root / "runtime" / "first.py",
+        package_root / "runtime" / "second.py",
+    ]
+    for source in sources:
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("def added():\n    return __name__\n", encoding="utf-8")
+    modules = [ModuleType(f"agi_env.runtime.{source.stem}") for source in sources]
+    for module, source in zip(modules, sources, strict=True):
+        module.__file__ = str(source)
+    monkeypatch.setattr(hot_source_support, "_AGI_ENV_PACKAGE_ROOT", package_root)
+
+    resolved = [
+        hot_source_support.aligned_module_callable(module, "added")
+        for module in modules
+    ]
+
+    assert resolved[0]() != resolved[1]()

--- a/src/agilab/security/import_guard.py
+++ b/src/agilab/security/import_guard.py
@@ -4,13 +4,41 @@ import importlib
 import importlib.util
 import shlex
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Iterable, Mapping, MutableMapping
 
-
 class MixedCheckoutImportError(ImportError):
     """Raised when AGILAB code is imported from a different checkout."""
+
+
+_PROCESS_STATE_MODULE_NAME = "_agilab_import_guard_process_state"
+
+
+def _process_state() -> ModuleType:
+    existing = sys.modules.get(_PROCESS_STATE_MODULE_NAME)
+    if isinstance(existing, ModuleType):
+        state = existing
+    else:
+        candidate = ModuleType(_PROCESS_STATE_MODULE_NAME)
+        candidate.fallback_load_lock = threading.RLock()
+        candidate.missing_module = object()
+        state = sys.modules.setdefault(_PROCESS_STATE_MODULE_NAME, candidate)
+    lock = getattr(state, "fallback_load_lock", None)
+    if (
+        not isinstance(state, ModuleType)
+        or not callable(getattr(lock, "acquire", None))
+        or not callable(getattr(lock, "release", None))
+        or "missing_module" not in state.__dict__
+    ):
+        raise RuntimeError("Invalid AGILAB import-guard process state")
+    return state
+
+
+_PROCESS_STATE = _process_state()
+FALLBACK_LOAD_LOCK = _PROCESS_STATE.fallback_load_lock
+MISSING_MODULE = _PROCESS_STATE.missing_module
 
 
 def _resolve_path(value: str | Path) -> Path:
@@ -289,13 +317,23 @@ def assert_python_environment_alignment(current_file: str | Path, package_name: 
 def _load_module_from_path(module_name: str, fallback_path: str | Path, fallback_name: str | None = None) -> ModuleType:
     module_path = _resolve_path(fallback_path)
     synthetic_name = fallback_name or f"{module_name.replace('.', '_')}_fallback"
-    spec = importlib.util.spec_from_file_location(synthetic_name, module_path)
-    if spec is None or spec.loader is None:
-        raise ModuleNotFoundError(f"Unable to load local fallback module at {module_path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[synthetic_name] = module
-    spec.loader.exec_module(module)
-    return module
+    with FALLBACK_LOAD_LOCK:
+        spec = importlib.util.spec_from_file_location(synthetic_name, module_path)
+        if spec is None or spec.loader is None:
+            raise ModuleNotFoundError(f"Unable to load local fallback module at {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        previous = sys.modules.get(synthetic_name, MISSING_MODULE)
+        sys.modules[synthetic_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            if sys.modules.get(synthetic_name) is module:
+                if previous is MISSING_MODULE:
+                    sys.modules.pop(synthetic_name, None)
+                else:
+                    sys.modules[synthetic_name] = previous
+            raise
+        return module
 
 
 def _should_fallback_module_not_found(exc: ModuleNotFoundError, module_name: str, package_name: str) -> bool:
@@ -373,7 +411,14 @@ def import_agilab_symbols(
     fallback_path: str | Path,
     fallback_name: str | None = None,
 ) -> ModuleType:
-    """Compatibility helper for legacy call sites that mutate globals()."""
+    """Compatibility helper for legacy call sites that mutate globals().
+
+    Long-lived Streamlit processes can retain a compatibility shim whose
+    classified target predates an additive source update.  When that shim is
+    the only reason a requested symbol is absent, reload the already-aligned
+    local fallback under its isolated synthetic name.  Ordinary modules and
+    genuinely missing symbols keep the existing fail-closed behavior.
+    """
     module = import_agilab_module(
         module_name,
         current_file=current_file,
@@ -384,6 +429,44 @@ def import_agilab_symbols(
         binding_items = list(bindings.items())
     else:
         binding_items = [(name, name) for name in bindings]
+    missing_attributes = [
+        attribute_name
+        for attribute_name, _target_name in binding_items
+        if not hasattr(module, attribute_name)
+    ]
+    compat_target = getattr(module, "_AGILAB_COMPAT_TARGET_MODULE", None)
+    if missing_attributes and isinstance(compat_target, ModuleType):
+        expected_root = resolve_package_root(current_file)
+        fallback_origin = _resolve_path(fallback_path)
+        outside = _paths_outside_expected((fallback_origin,), expected_root)
+        if outside:
+            raise MixedCheckoutImportError(
+                _mixed_checkout_message(
+                    current_file=current_file,
+                    expected_root=expected_root,
+                    actual_paths=outside,
+                    module_name=module_name,
+                )
+            )
+        refreshed = _load_module_from_path(
+            module_name,
+            fallback_path,
+            fallback_name=fallback_name,
+        )
+        refreshed_outside = _paths_outside_expected(
+            _module_origin_paths(refreshed),
+            expected_root,
+        )
+        if refreshed_outside:
+            raise MixedCheckoutImportError(
+                _mixed_checkout_message(
+                    current_file=current_file,
+                    expected_root=expected_root,
+                    actual_paths=refreshed_outside,
+                    module_name=module_name,
+                )
+            )
+        module = refreshed
     for attribute_name, target_name in binding_items:
         try:
             target_globals[target_name] = getattr(module, attribute_name)

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -80,7 +80,7 @@ def test_base_app_surface_import_does_not_require_optional_agi_env(
         module._isolated_import_process_state()
 
 
-def test_app_editable_import_roots_reports_stale_agi_env(
+def test_app_editable_import_roots_refreshes_stale_agi_env_from_aligned_source(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -92,8 +92,9 @@ def test_app_editable_import_roots_reports_stale_agi_env(
         "hosted_editable_source_import_roots",
     )
 
-    with pytest.raises(RuntimeError, match="AGILAB UI runtime is stale"):
-        module.app_editable_import_roots(tmp_path / "demo_project")
+    app = tmp_path / "demo_project"
+
+    assert module.app_editable_import_roots(app) == (app.resolve() / "src",)
 
 
 def test_app_editable_import_roots_reports_missing_import_layout_module(

--- a/test/test_app_ui.py
+++ b/test/test_app_ui.py
@@ -21,7 +21,7 @@ def _load_module():
     return module
 
 
-def test_app_ui_reports_stale_agi_env_import_layout(
+def test_app_ui_refreshes_stale_agi_env_import_layout_from_aligned_source(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -33,8 +33,7 @@ def test_app_ui_reports_stale_agi_env_import_layout(
         "hosted_editable_source_import_roots",
     )
 
-    with pytest.raises(RuntimeError, match="AGILAB UI runtime is stale"):
-        module._manager_editable_import_roots(tmp_path / "demo_project")
+    assert module._manager_editable_import_roots(tmp_path / "demo_project") == ()
 
 
 def test_app_ui_resolves_project_scoped_entrypoint(tmp_path: Path) -> None:

--- a/test/test_import_guard.py
+++ b/test/test_import_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import sys
+import threading
 import types
 
 import pytest
@@ -18,6 +19,14 @@ if _IMPORT_GUARD_SPEC is None or _IMPORT_GUARD_SPEC.loader is None:
     raise ModuleNotFoundError(f"Unable to load import_guard.py from {_IMPORT_GUARD_PATH}")
 import_guard = importlib.util.module_from_spec(_IMPORT_GUARD_SPEC)
 _IMPORT_GUARD_SPEC.loader.exec_module(import_guard)
+
+
+def _load_independent_import_guard(name: str):
+    spec = importlib.util.spec_from_file_location(name, _IMPORT_GUARD_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_repo_src_root_is_not_a_python_package() -> None:
@@ -91,6 +100,222 @@ def test_import_agilab_symbols_remains_backward_compatible() -> None:
 
     assert module.VALUE == 11
     assert target_globals["loaded_value"] == 11
+
+
+def test_fallback_load_restores_previous_module_after_failure(tmp_path: Path) -> None:
+    fallback_name = "agilab_broken_fallback_test"
+    previous = types.ModuleType(fallback_name)
+    broken = tmp_path / "broken.py"
+    broken.write_text("raise RuntimeError('broken fallback')\n", encoding="utf-8")
+    sys.modules[fallback_name] = previous
+    try:
+        with pytest.raises(RuntimeError, match="broken fallback"):
+            import_guard._load_module_from_path(
+                "agilab.broken",
+                broken,
+                fallback_name=fallback_name,
+            )
+        assert sys.modules[fallback_name] is previous
+    finally:
+        sys.modules.pop(fallback_name, None)
+
+
+def test_independent_import_guards_serialize_fallback_execution(tmp_path: Path) -> None:
+    first_guard = _load_independent_import_guard("agilab_import_guard_concurrency_one")
+    second_guard = _load_independent_import_guard("agilab_import_guard_concurrency_two")
+    assert first_guard.FALLBACK_LOAD_LOCK is second_guard.FALLBACK_LOAD_LOCK
+
+    state_name = "agilab_import_guard_concurrency_state"
+    fallback_name = "agilab_import_guard_concurrency_fallback"
+    state = types.ModuleType(state_name)
+    state.counter_lock = threading.Lock()
+    state.active = 0
+    state.maximum = 0
+    fallback = tmp_path / "concurrent.py"
+    fallback.write_text(
+        "\n".join(
+            [
+                "import time",
+                f"import {state_name} as state",
+                "with state.counter_lock:",
+                "    state.active += 1",
+                "    state.maximum = max(state.maximum, state.active)",
+                "try:",
+                "    time.sleep(0.05)",
+                "finally:",
+                "    with state.counter_lock:",
+                "        state.active -= 1",
+                "VALUE = True",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    start = threading.Barrier(2)
+    failures: list[BaseException] = []
+
+    def _load(guard) -> None:
+        try:
+            start.wait(timeout=2.0)
+            guard._load_module_from_path(
+                "agilab.concurrent",
+                fallback,
+                fallback_name=fallback_name,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below.
+            failures.append(exc)
+
+    sys.modules[state_name] = state
+    try:
+        threads = [
+            threading.Thread(target=_load, args=(guard,))
+            for guard in (first_guard, second_guard)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2.0)
+        assert not any(thread.is_alive() for thread in threads)
+        assert failures == []
+        assert state.maximum == 1
+    finally:
+        sys.modules.pop(state_name, None)
+        sys.modules.pop(fallback_name, None)
+
+
+def test_import_guard_bootstraps_before_rejecting_foreign_agilab_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign_package = tmp_path / "foreign" / "agilab"
+    foreign_package.mkdir(parents=True)
+    (foreign_package / "__init__.py").write_text("", encoding="utf-8")
+    foreign = types.ModuleType("agilab")
+    foreign.__file__ = str(foreign_package / "__init__.py")
+    foreign.__path__ = [str(foreign_package)]
+    monkeypatch.setitem(sys.modules, "agilab", foreign)
+
+    guard = _load_independent_import_guard("agilab_import_guard_foreign_bootstrap")
+
+    with pytest.raises(guard.MixedCheckoutImportError, match="Mixed AGILAB checkout"):
+        guard.assert_agilab_checkout_alignment(_IMPORT_GUARD_PATH)
+
+
+def test_import_guard_rejects_invalid_process_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "_agilab_import_guard_process_state",
+        types.ModuleType("_agilab_import_guard_process_state"),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid AGILAB import-guard process state"):
+        _load_independent_import_guard("agilab_import_guard_invalid_process_state")
+
+
+def test_import_agilab_symbols_refreshes_stale_compat_shim_from_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_target = types.ModuleType("agilab.classified_stale")
+    stale_target.VALUE = "stale"
+    stale_shim = types.ModuleType("agilab.legacy_stale")
+    stale_shim.VALUE = "stale"
+    stale_shim._AGILAB_COMPAT_TARGET_MODULE = stale_target
+    refreshed = types.ModuleType("agilab_stale_fallback")
+    refreshed.__file__ = str(_SRC_ROOT / "agilab" / "app_surface.py")
+    refreshed.VALUE = "fresh"
+    refreshed.ADDED = "available"
+    fallback_calls: list[tuple[str, Path, str | None]] = []
+
+    monkeypatch.setattr(
+        import_guard,
+        "import_agilab_module",
+        lambda *_args, **_kwargs: stale_shim,
+    )
+
+    def _load_fallback(module_name, fallback_path, fallback_name=None):
+        fallback_calls.append((module_name, Path(fallback_path), fallback_name))
+        return refreshed
+
+    monkeypatch.setattr(import_guard, "_load_module_from_path", _load_fallback)
+    target_globals: dict[str, object] = {}
+
+    loaded = import_guard.import_agilab_symbols(
+        target_globals,
+        "agilab.legacy_stale",
+        {"VALUE": "value", "ADDED": "added"},
+        current_file=_SRC_ROOT / "agilab" / "pages" / "2_ORCHESTRATE.py",
+        fallback_path=_SRC_ROOT / "agilab" / "app_surface.py",
+        fallback_name="agilab_app_surface_fallback",
+    )
+
+    assert loaded is refreshed
+    assert target_globals == {"value": "fresh", "added": "available"}
+    assert fallback_calls == [
+        (
+            "agilab.legacy_stale",
+            _SRC_ROOT / "agilab" / "app_surface.py",
+            "agilab_app_surface_fallback",
+        )
+    ]
+
+
+def test_import_agilab_symbols_rejects_external_compat_refresh_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    stale_target = types.ModuleType("agilab.classified_stale")
+    stale_shim = types.ModuleType("agilab.legacy_stale")
+    stale_shim._AGILAB_COMPAT_TARGET_MODULE = stale_target
+    external_fallback = tmp_path / "outside.py"
+    external_fallback.write_text(
+        "raise AssertionError('external fallback must not execute')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        import_guard,
+        "import_agilab_module",
+        lambda *_args, **_kwargs: stale_shim,
+    )
+
+    with pytest.raises(import_guard.MixedCheckoutImportError, match="Mixed AGILAB"):
+        import_guard.import_agilab_symbols(
+            {},
+            "agilab.legacy_stale",
+            ["ADDED"],
+            current_file=_SRC_ROOT / "agilab" / "pages" / "2_ORCHESTRATE.py",
+            fallback_path=external_fallback,
+        )
+
+
+def test_import_agilab_symbols_recovers_stale_shim_and_stale_agi_env_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agi_env.runtime import import_layout_support
+    import agilab.app_surface as stale_shim
+
+    monkeypatch.delattr(stale_shim, "app_editable_import_roots")
+    monkeypatch.delattr(
+        import_layout_support,
+        "hosted_editable_source_import_roots",
+    )
+    app = tmp_path / "demo_project"
+    target_globals: dict[str, object] = {}
+
+    import_guard.import_agilab_symbols(
+        target_globals,
+        "agilab.app_surface",
+        ["app_editable_import_roots"],
+        current_file=_SRC_ROOT / "agilab" / "pages" / "2_ORCHESTRATE.py",
+        fallback_path=_SRC_ROOT / "agilab" / "app_surface.py",
+        fallback_name="agilab_app_surface_hot_refresh_test",
+    )
+
+    recovered = target_globals["app_editable_import_roots"]
+    assert callable(recovered)
+    assert recovered(app) == (app.resolve() / "src",)
 
 
 def test_python_environment_alignment_rejects_other_source_root(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary\n\n- recover additive AGILAB symbols in a long-lived Streamlit process without requiring a restart\n- recover the aligned agi-env import-layout callable from current source without mutating the stale shared module\n- serialize fallback execution across independently loaded page guards and bound isolated hot-source module state\n- apply the same recovery contract to the app_ui page bundle\n\n## Repro\n\n1. Keep Streamlit running from before PR #916.\n2. Update the source tree so ORCHESTRATE requests app_editable_import_roots.\n3. Open ORCHESTRATE for routing_training_project.\n4. The page raises cannot import name app_editable_import_roots; refreshing only app_surface then exposes the next stale agi-env failure.\n\nThe focused regression removes both new symbols from their cached modules and calls the recovered function against routing_training_project. Before this change the chain still required a process restart.\n\n## Root Cause\n\nStreamlit reruns page code but Python retains compatibility-shim targets and agi-env modules loaded before an additive source update. The import guard could load the current local shim, but its recovered function still referenced the stale cached agi-env dependency. Independently loaded page guards also could not safely coordinate a shared synthetic fallback module.\n\n## Regression Test\n\n- dual-stale app_surface plus agi-env recovery calls the recovered function end to end\n- foreign fallback and foreign-checkout bootstrap remain fail-closed\n- two independent import-guard instances prove fallback execution is process-serialized\n- failed loads restore or remove partial sys.modules state\n- hot-source cache is content-addressed, bounded, and distinguishes identical bytes at different origins\n- app_surface and app_ui both recover the aligned callable\n\n## Validation\n\n- 54 focused impact tests passed\n- full agi-env suite: 1022 passed, 1 skipped\n- agi-gui workflow parity: 3829 tests passed, with expected skips\n- real browser ORCHESTRATE validation: 77 widgets, 75 probed, 0 failures; browser error capture enabled\n- exact dual-stale routing_training_project reproduction confirmed sb3_trainer source visibility\n- Ruff, diff check, scope guard, provenance guard, and pre-push guards passed\n- first Windows CI run identified one unclassified defensive exception boundary; the boundary was classified and the exact hygiene plus loader regressions pass locally\n- final GitHub CI rerun passed all required checks, including root-tests in 11m57s and windows-core-tests in 5m13s\n\nThe first agi-gui run used mismatched canonical/public docs revisions and failed only docs_canonical_alignment. It passed in full after pinning the canonical docs snapshot matching the branch. The branch was then rebased onto the merged docs sync PR #917.\n\n## Shared Core Approval and Blast Radius\n\nThe user explicitly requested the shared installer/runtime dependency fix after ORCHESTRATE reported missing sb3_trainer. This follow-up touches agi-env runtime support, the generic app-surface caller, and its app_ui sibling. It does not modify owner-protected agi-core. The three classified scopes are one atomic recovery chain; the mixed-scope push exception was limited to this PR.\n\n## Review Evidence\n\n- reviewer: Codex sub-agent hot_shim_review, inherited GPT-5, review only, no file edits\n- result: initial dual-stale, concurrency, and bootstrap-boundary findings were addressed\n- final result: clean, no blockers\n\n## Agent Metadata\n\n- Tokki: 1.0.41\n- agent/runtime: Codex, version unavailable\n- model: GPT-5\n- reasoning effort: unknown\n- /fast mode: not used