### PR TITLE
chore(tokki): route the read-only validation surface model-free

### DIFF
--- a/.tokki/model-free-commands
+++ b/.tokki/model-free-commands
@@ -6,6 +6,11 @@ exact ./dev impact
 exact ./dev --print-only impact
 exact ./dev test
 exact ./dev lint
+exact ./dev typing
+exact ./dev regress
+exact ./dev robust
+exact ./dev perf-startup
+exact ./dev clean
 exact ./dev --print-only docs
 exact ./dev release
 exact ./dev --print-only release
@@ -31,6 +36,8 @@ exact python3 tools/sync_agent_skills.py --check
 exact uv --preview-features extra-build-dependencies run python tools/agent_context_router.py --check
 exact uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact
 exact uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
+exact uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-target-integrity --quiet
+exact uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --skip-missing-source
 template ./dev impact --files <safe-file>
 template ./dev test <safe-file>
 template ./dev flow <safe-component>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ Use this runbook whenever you:
   apps are symlinked into `src/agilab/apps/`. Before concluding an app does not
   exist, list `src/agilab/apps/` (the symlink targets reveal the apps repo) and
   search `$APPS_REPOSITORY/apps/`. Note that `.tokki/scope` may exclude apps
-  from Tokki repo maps, so a Tokki-first search will not see them.
+  from Tokki repo maps; check it before trusting a Tokki-first search to have
+  covered them (the checked-in scope currently declares no exclusions).
 - **uv everywhere**: Invoke Python entry points through `uv` (`uv --preview-features extra-build-dependencies run python …`,
   `uv --preview-features extra-build-dependencies run --extra ui streamlit …` for source UI launches) so dependencies resolve inside the managed environments that
   ship with AGILab.


### PR DESCRIPTION
## Summary
Audited the Tokki integration against the current repo (tokki 1.0.41). The main finding: a chunk of AGILAB's deterministic validation surface still costs a model call because it was never allowlisted.

**Allowlist additions** — each verified read-only by reading what the underlying tool actually writes:
| Command | Underlying | Write behaviour |
|---|---|---|
| `./dev typing` | `workflow_parity --profile ty-typing` | none |
| `./dev regress` | `ga_regression_selector --staged --run` | test-index cache only (same class as allowlisted `./dev test`) |
| `./dev robust` | `robustness_matrix` | temp dirs only |
| `./dev perf-startup` | `perf_smoke` | none (subprocess timing) |
| `./dev clean` | `clean_local_artifacts` | dry-run listing; `--apply` deliberately **not** allowlisted |
| `sync_docs_source.py --verify-target-integrity --quiet` | — | read-only verification |
| `sync_docs_source.py --check --delete --skip-missing-source` | — | `--check` is mutually exclusive with `--apply`; plan is printed, never applied |

The two `sync_docs_source` routes are the ones `agent-context-rules.json` already tells agents to run for docs work — every routed docs check was paying for a model call the allowlist could have avoided.

**Doc correction**: `AGENTS.md` warned that `.tokki/scope` excludes apps from Tokki repo maps so "a Tokki-first search will not see them". The checked-in scope declares **zero** exclusions (comments only), so that steered agents away from a search path that works. Reworded to check scope rather than assume.

**Deliberately not changed**: `./dev docs`, `task-worktree`, `parallel-stage`, `publish-testpypi` stay off the allowlist (they sync-delete, create branches/worktrees, or publish). `.tokki/rules` re-verified against current tooling — its `./dev docs` ban is still accurate (`--apply --delete`), `--profile tokki` still resolves, and the docs-routing guidance survived the #908/#909 mirror-evidence rework.

## Validation
- Each added command executed locally; working tree still clean afterwards
- `test_sync_agent_skills.py` (pins the allowlist shape), `test_agent_context_router.py`, `test_agent_instruction_contract.py`, `test_agent_workflows.py` → 46 passed
- `tools/sync_agent_skills.py --check` → no drift, Tokki sees all 33 skills
- `./dev impact --files …` → no further validations required

🤖 Generated with [Claude Code](https://claude.com/claude-code)