### PR TITLE
docs(diagrams): refresh agi-env map for the new hot-source module

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "5bee4250964fcbb8c1b0b2646c80338e01248a08f599e90b26681b22b54e6617",
     "release-proof.rst": "fa2c88ad0a60cd30d6cca2899d0defaca43c3345209663c3907bfa3dc36ce084"
   },
-  "source_digest_sha256": "58ed764af9ff694967ac955661e9a5c24ed36d2d865a9cbfb108923d197066eb",
+  "source_digest_sha256": "d4861f20271202c233c4533e46c636ec770209e0298acebaba424ebc02f10ef6",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "58ed764af9ff694967ac955661e9a5c24ed36d2d865a9cbfb108923d197066eb"
+  "target_digest_sha256": "d4861f20271202c233c4533e46c636ec770209e0298acebaba424ebc02f10ef6"
 }

--- a/docs/source/diagrams/packages_agi_env.svg
+++ b/docs/source/diagrams/packages_agi_env.svg
@@ -56,13 +56,13 @@
   <text class="member" x="66" y="435">+12 more</text>
   <rect x="384" y="302" width="316" height="176" rx="18" ry="18" fill="#ffdbe2" stroke="#0e223f" stroke-width="2" />
   <text class="card-title" x="404" y="332">Runtime and workers</text>
-  <text class="count" x="680" y="332" text-anchor="end">10 modules</text>
+  <text class="count" x="680" y="332" text-anchor="end">11 modules</text>
   <text class="card-note" x="404" y="354">Worker packaging and process</text>
   <text class="card-note" x="404" y="374">execution.</text>
   <text class="member" x="404" y="398">worker_runtime_support</text>
   <text class="member" x="404" y="417">host_runtime_support</text>
   <text class="member" x="404" y="436">runtime_bootstrap_support</text>
-  <text class="member" x="404" y="455">+7 more</text>
+  <text class="member" x="404" y="455">+8 more</text>
   <rect x="722" y="302" width="316" height="176" rx="18" ry="18" fill="#e6ecf5" stroke="#0e223f" stroke-width="2" />
   <text class="card-title" x="742" y="332">Support services</text>
   <text class="count" x="1018" y="332" text-anchor="end">5 modules</text>
@@ -71,5 +71,5 @@
   <text class="member" x="742" y="397">source_analysis_ast</text>
   <text class="member" x="742" y="416">source_analysis_support</text>
   <text class="member" x="742" y="435">+1 more</text>
-  <text class="footer" x="46" y="510">59 modules · groups are curated in tools/render_package_maps.py; members are read from the package source</text>
+  <text class="footer" x="46" y="510">60 modules · groups are curated in tools/render_package_maps.py; members are read from the package source</text>
 </svg>


### PR DESCRIPTION
## Summary
The package-map freshness guard added in #920 fired on its first run against main: #918 added `agi_env/runtime/hot_source_support.py`, taking the package from 59 to 60 modules, so the checked-in figure no longer matched a fresh render.

This is the re-render the guard asked for — the "Runtime and workers" group picks up the new module (10 → 11) and the footer total moves to 60. No spec or renderer changes; the curated groups already covered it.

Canonical-first: thales_agilab `a6e6bb1`, mirror synced with a verified stamp.

## Validation
- `tools/render_package_maps.py --check` → fresh
- `test/test_render_package_maps.py` → 25 passed
- Figure re-rendered at 1500px and visually inspected
- `sync_docs_source.py --verify-stamp` → target integrity + canonical source verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)