### PR TITLE
fix(badges): refresh the stale coverage, stars, and activity badges

### DIFF
--- a/badges/commit-activity.svg
+++ b/badges/commit-activity.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="188" height="20" role="img" aria-label="commit activity: 214/month">
+<svg xmlns="http://www.w3.org/2000/svg" width="188" height="20" role="img" aria-label="commit activity: 248/month">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">commit activity</text>
   <text x="57.5" y="14">commit activity</text>
-  <text x="151.5" y="15" fill="#010101" fill-opacity=".3">214/month</text>
-  <text x="151.5" y="14">214/month</text>
+  <text x="151.5" y="15" fill="#010101" fill-opacity=".3">248/month</text>
+  <text x="151.5" y="14">248/month</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="143" height="20" role="img" aria-label="agi-env coverage: 94%">
+<svg xmlns="http://www.w3.org/2000/svg" width="143" height="20" role="img" aria-label="agi-env coverage: 93%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="55.5" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="55.5" y="14">agi-env coverage</text>
-  <text x="127.0" y="15" fill="#010101" fill-opacity=".3">94%</text>
-  <text x="127.0" y="14">94%</text>
+  <text x="127.0" y="15" fill="#010101" fill-opacity=".3">93%</text>
+  <text x="127.0" y="14">93%</text>
 </g>
 </svg>

--- a/badges/github-stars.svg
+++ b/badges/github-stars.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="69" height="20" role="img" aria-label="stars: 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="69" height="20" role="img" aria-label="stars: 18">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="22.5" y="15" fill="#010101" fill-opacity=".3">stars</text>
   <text x="22.5" y="14">stars</text>
-  <text x="57.0" y="15" fill="#010101" fill-opacity=".3">16</text>
-  <text x="57.0" y="14">16</text>
+  <text x="57.0" y="15" fill="#010101" fill-opacity=".3">18</text>
+  <text x="57.0" y="14">18</text>
 </g>
 </svg>


### PR DESCRIPTION
## Why
The `coverage` workflow has been **failing on main** since #922 (two consecutive runs). Its "Verify committed badges are up to date" step runs `git diff --exit-code -- badges/`, and `coverage-agi-env.svg` still claimed 94% while CI recomputed 93%.

The drop is real, not noise: #918 added `agi_env/runtime/hot_source_support.py` at **84.9% line rate**, which pulls the component down a point.

Regenerated with `tools/generate_component_coverage_badges.py` fed from **that failing run's own coverage artifacts** (`gh run download 30567984285`), so the committed badge matches exactly what CI recomputes — no local-coverage drift. Every other component badge regenerated byte-identical, confirming agi-env was the only stale one.

## Also fixed — same failure class
`github-stars.svg` and `commit-activity.svg` have no generator; they only move when a human notices, and both had drifted:

| Badge | Committed | Live |
|---|---|---|
| stars | 16 | **18** (`gh api repos/ThalesGroup/agilab`) |
| commit activity | 214/month | **248** (last 4 weeks, `/stats/participation`) |

## Validation
- `test/test_coverage_badge_guard.py` → 16 passed
- All three SVGs XML-valid
- `./dev impact` → no further validations required
- The real proof is CI: this PR's `coverage` job should now pass the badge-verify step that main is failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)