### PR TITLE
feat(badges): generate the GitHub stat badges instead of hand-editing them

### DIFF
--- a/test/test_refresh_repo_stat_badges.py
+++ b/test/test_refresh_repo_stat_badges.py
@@ -1,0 +1,106 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Guards for the hand-maintained GitHub stat badges."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import re
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "refresh_repo_stat_badges", REPO_ROOT / "tools" / "refresh_repo_stat_badges.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+
+@pytest.mark.parametrize("badge", MODULE.BADGES, ids=lambda b: b.slug)
+def test_renderer_reproduces_the_committed_badge(badge) -> None:
+    """The renderer must be a faithful generator, not a reformatter.
+
+    If this drifts, `--apply` would rewrite geometry or styling as a side
+    effect of refreshing a number.
+    """
+
+    committed = badge.path.read_text(encoding="utf-8")
+    value = MODULE.committed_value(badge)
+    assert value is not None, f"{badge.slug} has no aria-label value"
+    raw = value.removesuffix("/month")
+    assert MODULE.render_badge(badge, raw) == committed
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [("stars", 45), ("commit activity", 115), ("18", 24), ("248/month", 73)],
+)
+def test_width_model_matches_the_committed_geometry(text: str, expected: int) -> None:
+    assert MODULE.side_width(text) == expected
+
+
+@pytest.mark.parametrize("value", [7, 18, 100, 1234])
+def test_geometry_stays_consistent_across_digit_counts(value: int) -> None:
+    """A value that changes digit count must still render correct geometry."""
+
+    svg = MODULE.render_badge(MODULE.STARS, value)
+    total = int(re.search(r'<svg[^>]*width="(\d+)"', svg).group(1))
+    left = MODULE.side_width(MODULE.STARS.label)
+    right = MODULE.side_width(str(value))
+    assert total == left + right
+    # The value text is centred in the right-hand rectangle.
+    value_x = float(re.findall(r'<text x="([\d.]+)" y="14">', svg)[-1])
+    assert value_x == pytest.approx(left + right / 2)
+    assert f'aria-label="stars: {value}"' in svg
+
+
+def test_drift_report_degrades_when_github_is_unreachable(monkeypatch) -> None:
+    """Offline must report "not checked", never a wrong or guessed value."""
+
+    monkeypatch.setattr(MODULE, "live_values", lambda: None)
+    report = MODULE.drift_report()
+    assert report["available"] is False
+    assert report["drifted"] == []
+
+
+def test_drift_report_flags_a_behind_badge() -> None:
+    report = MODULE.drift_report({MODULE.STARS.slug: 999999})
+    assert report["available"] is True
+    assert [entry["badge"] for entry in report["drifted"]] == [MODULE.STARS.slug]
+    assert report["drifted"][0]["live"] == "999999"
+
+
+def test_drift_report_is_quiet_when_badges_match() -> None:
+    values = {}
+    for badge in MODULE.BADGES:
+        raw = MODULE.committed_value(badge).removesuffix("/month")
+        values[badge.slug] = int(raw)
+    assert MODULE.drift_report(values)["drifted"] == []
+
+
+def test_check_without_strict_never_fails_on_drift(monkeypatch, capsys) -> None:
+    """A new star must not turn CI red."""
+
+    monkeypatch.setattr(MODULE, "live_values", lambda: {MODULE.STARS.slug: 999999})
+    assert MODULE.main(["--check"]) == 0
+    assert MODULE.main(["--check", "--strict"]) == 1
+    capsys.readouterr()
+
+
+def test_apply_refuses_without_live_stats(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(MODULE, "live_values", lambda: None)
+    assert MODULE.main(["--apply"]) == 1
+    assert "refusing to rewrite" in capsys.readouterr().err

--- a/tools/maintenance_dashboard.py
+++ b/tools/maintenance_dashboard.py
@@ -542,6 +542,67 @@ def _coverage_percent(svg_text: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def check_stat_badge_freshness(repo_root: Path) -> Check:
+    """Report drift in the hand-maintained GitHub stat badges.
+
+    These have no generator, so they rot silently: stars sat two behind and
+    commit activity thirty-four behind before anyone noticed. Drift is a
+    warning and never a failure, because a single new star would otherwise
+    turn this red. Offline runs report "not checked" rather than guessing.
+    """
+
+    refresher = _load_tool(
+        repo_root, "tools/refresh_repo_stat_badges.py", "maintenance_stat_badges"
+    )
+    try:
+        report = refresher.drift_report()
+    except Exception as exc:  # pragma: no cover - defensive
+        return _check(
+            "stat_badge_freshness",
+            "GitHub stat badge freshness",
+            True,
+            f"stat badge drift not checked: {exc}",
+            status="warn",
+            evidence=("tools/refresh_repo_stat_badges.py",),
+        )
+
+    evidence = ("badges/github-stars.svg", "badges/commit-activity.svg")
+    if not report["available"]:
+        return _check(
+            "stat_badge_freshness",
+            "GitHub stat badge freshness",
+            True,
+            "GitHub stats unavailable; stat badge drift NOT CHECKED",
+            status="pass",
+            evidence=evidence,
+            details={"checked": False},
+        )
+    drifted = report["drifted"]
+    if drifted:
+        summary = "; ".join(
+            f"{entry['badge']} committed {entry['committed']} vs live {entry['live']}"
+            for entry in drifted
+        )
+        return _check(
+            "stat_badge_freshness",
+            "GitHub stat badge freshness",
+            True,
+            f"stat badges behind GitHub: {summary}; "
+            "refresh with `python tools/refresh_repo_stat_badges.py --apply`",
+            status="warn",
+            evidence=evidence,
+            details={"checked": True, "drifted": drifted},
+        )
+    return _check(
+        "stat_badge_freshness",
+        "GitHub stat badge freshness",
+        True,
+        "stat badges match live GitHub values",
+        evidence=evidence,
+        details={"checked": True, "drifted": []},
+    )
+
+
 def check_coverage_badges(repo_root: Path) -> Check:
     badge = repo_root / "badges/coverage-agilab.svg"
     percent = _coverage_percent(_read(badge)) if badge.is_file() else None
@@ -589,6 +650,7 @@ def build_report(
         check_shared_core_guardrails(repo_root),
         check_generated_artifact_hygiene(repo_root),
         check_coverage_badges(repo_root),
+        check_stat_badge_freshness(repo_root),
     ]
     if include_app_contracts:
         checks.insert(4, check_app_contracts(repo_root))

--- a/tools/refresh_repo_stat_badges.py
+++ b/tools/refresh_repo_stat_badges.py
@@ -1,0 +1,219 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Refresh the hand-maintained GitHub stat badges.
+
+``badges/github-stars.svg`` and ``badges/commit-activity.svg`` have no
+generator: they only move when a human notices, so they drift silently. Stars
+sat at 16 against 18 live, and commit activity at 214/month against 248.
+
+This renders them from the live GitHub API. Drift is deliberately **not** a
+blocking condition anywhere: a star arriving would otherwise turn CI red, so
+``--check`` reports drift and still exits 0 unless ``--strict`` is passed, and
+the maintenance dashboard surfaces it as a warning.
+
+Usage::
+
+    python tools/refresh_repo_stat_badges.py --check
+    python tools/refresh_repo_stat_badges.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BADGES_DIR = REPO_ROOT / "badges"
+REPO_SLUG = "ThalesGroup/agilab"
+
+# Both checked-in badges follow shields' geometry exactly: each side is
+# 7px per character plus 10px of padding, and the value text is centred in the
+# right-hand rectangle. Verified against the committed SVGs before use, so a
+# value that changes digit count still renders correct geometry.
+CHAR_W = 7
+SIDE_PAD = 10
+
+
+def side_width(text: str) -> int:
+    return CHAR_W * len(text) + SIDE_PAD
+
+
+@dataclass(frozen=True)
+class StatBadge:
+    slug: str
+    label: str
+    #: Renders the API value into the badge's display string.
+    fmt: str = "{value}"
+
+    @property
+    def path(self) -> Path:
+        return BADGES_DIR / f"{self.slug}.svg"
+
+    def display(self, value: int | str) -> str:
+        return self.fmt.format(value=value)
+
+
+STARS = StatBadge("github-stars", "stars")
+COMMIT_ACTIVITY = StatBadge("commit-activity", "commit activity", "{value}/month")
+BADGES = (STARS, COMMIT_ACTIVITY)
+
+
+def render_badge(badge: StatBadge, value: int | str) -> str:
+    """Render the badge SVG, matching the committed format byte for byte."""
+
+    display = badge.display(value)
+    left = side_width(badge.label)
+    right = side_width(display)
+    total = left + right
+    label_x = left / 2
+    value_x = left + right / 2
+
+    def coord(number: float) -> str:
+        return f"{number:.1f}"
+
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" role="img" aria-label="{badge.label}: {display}">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+  <stop offset=".1" stop-opacity=".1"/>
+  <stop offset=".9" stop-opacity=".3"/>
+  <stop offset="1" stop-opacity=".5"/>
+</linearGradient>
+<mask id="a">
+  <rect width="{total}" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="{left}" height="20" fill="#555"/>
+  <rect x="{left}" width="{right}" height="20" fill="#007ec6"/>
+  <rect width="{total}" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="{coord(label_x)}" y="15" fill="#010101" fill-opacity=".3">{badge.label}</text>
+  <text x="{coord(label_x)}" y="14">{badge.label}</text>
+  <text x="{coord(value_x)}" y="15" fill="#010101" fill-opacity=".3">{display}</text>
+  <text x="{coord(value_x)}" y="14">{display}</text>
+</g>
+</svg>
+"""
+
+
+def committed_value(badge: StatBadge) -> str | None:
+    """Read the value currently rendered in the checked-in badge."""
+
+    if not badge.path.is_file():
+        return None
+    match = re.search(
+        rf'aria-label="{re.escape(badge.label)}: ([^"]*)"',
+        badge.path.read_text(encoding="utf-8"),
+    )
+    return match.group(1) if match else None
+
+
+def _gh_api(path: str) -> object | None:
+    try:
+        completed = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def live_values() -> dict[str, int] | None:
+    """Fetch live stats, or None when GitHub is unreachable.
+
+    Offline is a normal state for this tool: it degrades to "unknown" rather
+    than guessing or failing, because a wrong badge is worse than a stale one.
+    """
+
+    repo = _gh_api(f"repos/{REPO_SLUG}")
+    if not isinstance(repo, dict) or "stargazers_count" not in repo:
+        return None
+    values = {STARS.slug: int(repo["stargazers_count"])}
+
+    participation = _gh_api(f"repos/{REPO_SLUG}/stats/participation")
+    if isinstance(participation, dict) and isinstance(participation.get("all"), list):
+        weekly = [int(week) for week in participation["all"][-4:]]
+        values[COMMIT_ACTIVITY.slug] = sum(weekly)
+    return values
+
+
+def drift_report(values: dict[str, int] | None = None) -> dict[str, object]:
+    """Compare committed badges against live stats."""
+
+    if values is None:
+        values = live_values()
+    if values is None:
+        return {"available": False, "drifted": [], "checked": []}
+
+    drifted: list[dict[str, object]] = []
+    checked: list[str] = []
+    for badge in BADGES:
+        if badge.slug not in values:
+            continue
+        checked.append(badge.slug)
+        want = badge.display(values[badge.slug])
+        have = committed_value(badge)
+        if have != want:
+            drifted.append({"badge": badge.slug, "committed": have, "live": want})
+    return {"available": True, "drifted": drifted, "checked": checked}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="Report drift (exit 0 unless --strict).")
+    mode.add_argument("--apply", action="store_true", help="Rewrite the badges from live stats.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="With --check, exit 1 on drift. Off by default: a new star must not fail CI.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    args = parser.parse_args(argv)
+
+    values = live_values()
+    report = drift_report(values)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif not report["available"]:
+        print("GitHub stats unavailable (offline or gh not authenticated); badges left untouched")
+    elif not report["drifted"]:
+        print(f"stat badges up to date: {', '.join(report['checked'])}")
+    else:
+        for entry in report["drifted"]:
+            print(f"{entry['badge']}: committed {entry['committed']!r}, live {entry['live']!r}")
+
+    if args.apply:
+        if not report["available"]:
+            print("refusing to rewrite badges without live stats", file=sys.stderr)
+            return 1
+        for badge in BADGES:
+            if badge.slug in values:
+                badge.path.write_text(render_badge(badge, values[badge.slug]), encoding="utf-8")
+                print(f"wrote {badge.path}")
+        return 0
+
+    if args.strict and report["available"] and report["drifted"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why
`badges/github-stars.svg` and `badges/commit-activity.svg` have **no generator** — they only move when a human notices. They had drifted to 16 stars against 18 live, and 214 commits/month against 248.

#924 corrected those numbers by hand, which buys nothing against the next drift. This removes the manual step.

## What
`tools/refresh_repo_stat_badges.py` renders both from the live GitHub API (`repos/{slug}` for stars, `stats/participation` summed over the last 4 weeks).

The width model — **7px per character plus 10px padding per side** — was derived from the committed SVGs rather than guessed, and a test asserts the renderer reproduces both badges **byte-for-byte**. That matters twice: refreshing a number can't quietly restyle the badge, and a value that changes digit count (18 → 100) still lays out correctly instead of overflowing its rectangle.

**Drift is deliberately never fatal.** A single new star would otherwise turn CI red:
- `--check` reports drift and exits 0; `--strict` opts into a non-zero exit
- the maintenance dashboard surfaces drift as a **warning**, alongside the existing coverage-badge signal
- offline reports "stat badge drift NOT CHECKED" rather than guessing, and `--apply` refuses to write without live stats — a confidently wrong badge is worse than a stale one

## Validation
- `test/test_refresh_repo_stat_badges.py` → 15 passed (byte-identical render, width model, digit-count geometry, offline degradation, drift detection, non-fatal `--check`)
- `test/test_maintenance_dashboard.py` → 12 passed
- Dashboard run against live GitHub: `stat_badge_freshness: pass — stat badges match live GitHub values`
- `./dev impact` → no further validations required

🤖 Generated with [Claude Code](https://claude.com/claude-code)