### PR TITLE
fix(ci): ignore descriptive compatibility text

### DIFF
--- a/test/test_compat_shim_inventory.py
+++ b/test/test_compat_shim_inventory.py
@@ -45,3 +45,21 @@ def test_compat_shim_inventory_cli_fails_on_growth() -> None:
 
     assert result.returncode == 1
     assert "exceeds cap" in result.stderr
+
+
+def test_compat_shim_marker_must_be_a_declaration(tmp_path: Path) -> None:
+    ordinary_module = tmp_path / "ordinary_module.py"
+    ordinary_module.write_text(
+        '"""Render a package map.\n\n'
+        "Compatibility shims are collapsed in the generated diagram.\n"
+        '"""\n',
+        encoding="utf-8",
+    )
+    shim_module = tmp_path / "shim_module.py"
+    shim_module.write_text(
+        '"""Compatibility shim for a historical import path."""\n',
+        encoding="utf-8",
+    )
+
+    assert not compat_shim_inventory.is_compat_shim(ordinary_module)
+    assert compat_shim_inventory.is_compat_shim(shim_module)

--- a/tools/compat_shim_inventory.py
+++ b/tools/compat_shim_inventory.py
@@ -25,6 +25,11 @@ SHIM_MARKERS = (
     "Compatibility shim",
     "Compatibility import",
 )
+SHIM_DECLARATION_PREFIXES = tuple(
+    f"{leader}{marker}"
+    for leader in ('"""', "'''", "# ")
+    for marker in SHIM_MARKERS
+)
 
 
 def _tracked_python_files(repo_root: Path) -> list[Path]:
@@ -43,7 +48,10 @@ def is_compat_shim(path: Path) -> bool:
         prefix = path.read_text(encoding="utf-8").splitlines()[:12]
     except UnicodeDecodeError:
         return False
-    return any(marker in "\n".join(prefix) for marker in SHIM_MARKERS)
+    return any(
+        line.lstrip().startswith(SHIM_DECLARATION_PREFIXES)
+        for line in prefix
+    )
 
 
 def _area_for(path: Path, repo_root: Path) -> str:


### PR DESCRIPTION
## Summary

- require compatibility inventory markers to be explicit module declarations
- stop descriptive prose such as the package-map generator docstring from consuming the shim budget

## Repro

`uv --preview-features extra-build-dependencies run --extra dev pytest -q -o addopts="" test/test_compat_shim_inventory.py` reported `257 <= 256` after PR #923 merged.

## Root Cause

`is_compat_shim()` matched marker text anywhere in the first 12 lines. The package-map generator describes how compatibility shims are displayed, but it is not itself a shim.

## Regression Test

A focused test now proves descriptive marker text is ignored while an explicit `Compatibility shim` module declaration remains inventoried.

## Validation

- exact fast repository contract slice: 42 passed
- compatibility inventory: 256 / 256
- Ruff: pass
- scope and agent provenance guards: pass

## Review Evidence

- no sub-agents were used
- no separate model review was used

## Agent Metadata

- Tokki version: unavailable (protected runtime/source mismatch)
- agent/runtime: OpenAI Codex, version unavailable
- model: GPT-5 Codex
- reasoning effort: unknown
- `/fast` mode: not used