### PR TITLE
fix(guards): stop counting prose about shims as a compat shim

### DIFF
--- a/test/test_compat_shim_inventory.py
+++ b/test/test_compat_shim_inventory.py
@@ -28,6 +28,37 @@ def test_compat_shim_inventory_is_capped() -> None:
     assert inventory["files"] == sorted(inventory["files"])
 
 
+def test_prose_about_shims_is_not_counted_as_a_shim(tmp_path: Path) -> None:
+    """Documentation may say "compatibility shim" without becoming one.
+
+    Regression: a docstring in tools/render_package_maps.py explaining that it
+    collapses compatibility shims was itself counted, pushing the inventory one
+    over its cap and turning main red.
+    """
+
+    prose = tmp_path / "renderer.py"
+    prose.write_text(
+        '"""Render maps.\n\n'
+        "Members are read from the filesystem. Compatibility shims are collapsed\n"
+        'into their canonical module responsibility.\n"""\n',
+        encoding="utf-8",
+    )
+    assert not compat_shim_inventory.is_compat_shim(prose)
+
+
+def test_real_shim_banners_are_still_detected(tmp_path: Path) -> None:
+    for index, body in enumerate(
+        (
+            '"""Compatibility shim for agi_env.legacy."""\n',
+            '"""Legacy entrypoint.\n\nCompatibility shim retained for downstream imports.\n"""\n',
+            "# Compatibility import for the classified layout\n",
+        )
+    ):
+        path = tmp_path / f"shim_{index}.py"
+        path.write_text(body, encoding="utf-8")
+        assert compat_shim_inventory.is_compat_shim(path), body
+
+
 def test_compat_shim_inventory_cli_fails_on_growth() -> None:
     inventory = compat_shim_inventory.build_inventory()
 

--- a/tools/compat_shim_inventory.py
+++ b/tools/compat_shim_inventory.py
@@ -39,11 +39,28 @@ def _tracked_python_files(repo_root: Path) -> list[Path]:
 
 
 def is_compat_shim(path: Path) -> bool:
+    """Detect a real compatibility shim by its leading banner line.
+
+    A shim announces itself: its docstring or header *starts* a line with
+    "Compatibility shim"/"Compatibility import". Matching the phrase anywhere
+    in the first twelve lines also caught prose that merely discusses shims —
+    tools/render_package_maps.py tripped the cap that way and turned main red
+    with a file that is a renderer, not a shim. Anchoring to the start of a
+    line keeps every real shim detected while letting documentation say the
+    words.
+    """
+
     try:
         prefix = path.read_text(encoding="utf-8").splitlines()[:12]
     except UnicodeDecodeError:
         return False
-    return any(marker in "\n".join(prefix) for marker in SHIM_MARKERS)
+    for line in prefix:
+        # Strip docstring quotes and comment markers so a banner still matches
+        # whether it opens a docstring, follows one, or sits in a comment.
+        stripped = line.strip().lstrip("\"'# ")
+        if any(stripped.startswith(marker) for marker in SHIM_MARKERS):
+            return True
+    return False
 
 
 def _area_for(path: Path, repo_root: Path) -> str:


### PR DESCRIPTION
## Why
**main is red.** Since #923 the compat-shim inventory reports **257 against a cap of 256**, failing `Validate fast repository contracts` in the `local-only-policy` job. Main's CI was green at `91c6a8c` (#922) and failing at `6b89cd2`, which brackets the cause to #923 — the PR that merged with only a secret-scan check because its `[skip ci]` suppressed the suite.

## Root cause
The 257th "shim" is `tools/render_package_maps.py` — a renderer, not a shim.

`is_compat_shim` matched the phrase `"Compatibility shim"` **anywhere** in a file's first twelve lines. #923 rewrote that module's docstring to explain that it *collapses compatibility shims into their canonical module responsibility* — line 10. Prose about shims got counted as a shim.

## Fix
Anchor the marker to the **start of a line**, after stripping docstring quotes and comment markers so real banners still match whether they open a docstring, follow one, or sit in a comment.

Verified against the tracked tree rather than assumed: the tightened detector finds **exactly the same 256 real shims** and drops only the false positive, so the cap keeps its meaning and no genuine shim escapes the guard.

Rewording the docstring would also have gone green — and left a landmine where documentation cannot name the thing it documents.

## Validation
- `test_compat_shim_inventory.py` → 4 passed, including two new regressions: prose mentioning shims is not counted, and real shim banners (docstring-leading, docstring-body, comment) still are
- Full fast-contract set (`package_split`, `pypi_publish_workflow`, `compat_shim_inventory`, `github_actions_node_runtime`) → 43 passed
- Inventory now reports `total=256 max=256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)