### PR TITLE
feat(guards): refuse skip-ci directives on commits that change code

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,6 +16,13 @@ cat > "$push_spec_file"
 run_guard_python tools/agent_commit_provenance_guard.py \
   --pre-push-spec "$push_spec_file"
 
+if [[ "${AGILAB_ALLOW_SKIP_CI:-}" == "1" ]]; then
+  echo "[agilab pre-push] AGILAB_ALLOW_SKIP_CI=1; skipping the skip-ci scope guard." >&2
+else
+  run_guard_python tools/skip_ci_scope_guard.py \
+    --pre-push-spec "$push_spec_file"
+fi
+
 guard_state="$(
   run_guard_python tools/pre_push_changed_files.py \
     --pre-push-spec "$push_spec_file"

--- a/test/test_skip_ci_scope_guard.py
+++ b/test/test_skip_ci_scope_guard.py
@@ -1,0 +1,123 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Guards for the pre-push skip-ci scope check."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "skip_ci_scope_guard", REPO_ROOT / "tools" / "skip_ci_scope_guard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch):
+    """A throwaway git repo the guard can inspect."""
+
+    def run(*args: str) -> None:
+        subprocess.run(args, cwd=tmp_path, check=True, capture_output=True)
+
+    run("git", "init", "-q", ".")
+    run("git", "config", "user.email", "guard@test")
+    run("git", "config", "user.name", "guard")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "docs" / "a.md").write_text("base\n", encoding="utf-8")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "base")
+    monkeypatch.setattr(MODULE, "REPO_ROOT", tmp_path)
+
+    def commit(message: str, path: str, content: str) -> str:
+        target = tmp_path / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        run("git", "add", "-A")
+        run("git", "commit", "-qm", message)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    return commit
+
+
+def test_docs_only_skip_is_allowed(repo) -> None:
+    """A pure docs refresh is exactly what [skip ci] is for."""
+
+    sha = repo("docs: refresh [skip ci]", "docs/a.md", "changed\n")
+    assert MODULE.find_offences([sha]) == []
+
+
+@pytest.mark.parametrize(
+    "path", ["tools/thing.py", "src/agilab/thing.py", "test/test_thing.py", ".github/workflows/ci.yml"]
+)
+def test_code_change_with_skip_is_blocked(repo, path: str) -> None:
+    sha = repo(f"chore: touch {path} [skip ci]", path, "print('x')\n")
+    offences = MODULE.find_offences([sha])
+    assert [offence.code_files for offence in offences] == [(path,)]
+
+
+@pytest.mark.parametrize("directive", ["[skip ci]", "[ci skip]", "[no ci]", "[skip actions]"])
+def test_every_github_skip_directive_is_recognised(repo, directive: str) -> None:
+    sha = repo(f"chore: tweak {directive}", "tools/thing.py", "print('x')\n")
+    assert MODULE.find_offences([sha])
+
+
+def test_directive_matching_is_case_insensitive(repo) -> None:
+    sha = repo("chore: tweak [SKIP CI]", "tools/thing.py", "print('x')\n")
+    assert MODULE.find_offences([sha])
+
+
+def test_code_change_without_skip_is_allowed(repo) -> None:
+    sha = repo("fix: real change with CI", "tools/thing.py", "print('x')\n")
+    assert MODULE.find_offences([sha]) == []
+
+
+@pytest.mark.parametrize("path", ["tools/README.md", "src/agilab/notes.rst", "test/fixture.svg"])
+def test_inert_files_under_code_paths_may_skip(repo, path: str) -> None:
+    """Docs and assets living beside code should not force a full matrix."""
+
+    sha = repo(f"docs: {path} [skip ci]", path, "text\n")
+    assert MODULE.find_offences([sha]) == []
+
+
+def test_pre_push_spec_ignores_branch_deletions() -> None:
+    zero = "0" * 40
+    spec = f"refs/heads/gone {zero} refs/heads/gone abc123\n"
+    assert MODULE._parse_pre_push_spec(spec) == []
+
+
+def test_pre_push_spec_parses_a_normal_push() -> None:
+    spec = "refs/heads/topic aaa111 refs/heads/topic bbb222\n"
+    assert MODULE._parse_pre_push_spec(spec) == [("bbb222", "aaa111")]
+
+
+def test_render_names_the_offending_files() -> None:
+    offence = MODULE.Offence(
+        commit="abc123def456",
+        subject="chore: tweak [skip ci]",
+        directive="[skip ci]",
+        code_files=("tools/thing.py",),
+    )
+    rendered = MODULE.render([offence])
+    assert "tools/thing.py" in rendered
+    assert "[skip ci]" in rendered
+    assert "AGILAB_ALLOW_SKIP_CI=1" in rendered

--- a/tools/skip_ci_scope_guard.py
+++ b/tools/skip_ci_scope_guard.py
@@ -1,0 +1,202 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Reject ``[skip ci]`` on commits that change executable code.
+
+GitHub honours ``[skip ci]`` by not scheduling workflows at all, so no CI job
+can police it — by the time a workflow could object, it has already been
+skipped. The only place left to enforce it is before the push.
+
+This exists because of a concrete outage: #923 carried ``[skip ci]`` on a
+branch that changed ``tools/`` and ``test/`` alongside a docs refresh. Only the
+secret scan ran, the branch merged on that single check, and a false positive
+it introduced took ``main`` red and blocked an unrelated PR until it was
+diagnosed and fixed.
+
+``[skip ci]`` is fine for a pure docs or asset refresh. It is not fine when the
+same commit range touches code the suite is meant to protect.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: GitHub's documented skip directives, matched case-insensitively.
+SKIP_DIRECTIVES = (
+    "[skip ci]",
+    "[ci skip]",
+    "[no ci]",
+    "[skip actions]",
+    "[actions skip]",
+)
+
+#: Paths whose behaviour the suite is meant to protect. A commit touching any
+#: of these must not suppress CI.
+CODE_PREFIXES = (
+    "src/",
+    "test/",
+    "tools/",
+    ".github/workflows/",
+    ".githooks/",
+)
+
+#: Extensions that are inert even under a code prefix (docs and assets living
+#: beside code should not force a full matrix).
+INERT_SUFFIXES = (".md", ".rst", ".svg", ".png", ".jpg", ".jpeg", ".gif", ".txt")
+
+
+@dataclass(frozen=True)
+class Offence:
+    commit: str
+    subject: str
+    directive: str
+    code_files: tuple[str, ...]
+
+
+def _run(args: Sequence[str]) -> str:
+    completed = subprocess.run(
+        args, cwd=REPO_ROOT, text=True, capture_output=True, check=False
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout
+
+
+def commit_range(base: str, head: str) -> list[str]:
+    out = _run(["git", "rev-list", f"{base}..{head}"])
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _message(commit: str) -> str:
+    return _run(["git", "log", "-1", "--format=%B", commit])
+
+
+def _subject(commit: str) -> str:
+    return _run(["git", "log", "-1", "--format=%s", commit]).strip()
+
+
+def _changed_files(commit: str) -> list[str]:
+    out = _run(["git", "show", "--name-only", "--format=", commit])
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def skip_directive_in(message: str) -> str | None:
+    lowered = message.lower()
+    for directive in SKIP_DIRECTIVES:
+        if directive in lowered:
+            return directive
+    return None
+
+
+def is_code_path(path: str) -> bool:
+    if not any(path.startswith(prefix) for prefix in CODE_PREFIXES):
+        return False
+    return not path.lower().endswith(INERT_SUFFIXES)
+
+
+def find_offences(commits: Sequence[str]) -> list[Offence]:
+    offences: list[Offence] = []
+    for commit in commits:
+        directive = skip_directive_in(_message(commit))
+        if directive is None:
+            continue
+        code_files = tuple(path for path in _changed_files(commit) if is_code_path(path))
+        if code_files:
+            offences.append(
+                Offence(
+                    commit=commit[:12],
+                    subject=_subject(commit),
+                    directive=directive,
+                    code_files=code_files,
+                )
+            )
+    return offences
+
+
+def render(offences: Sequence[Offence]) -> str:
+    lines = [
+        "[agilab pre-push] refusing to skip CI on commits that change code.",
+        "",
+    ]
+    for offence in offences:
+        lines.append(f"  {offence.commit} {offence.subject}")
+        lines.append(f"    carries {offence.directive} and changes:")
+        for path in offence.code_files[:6]:
+            lines.append(f"      {path}")
+        if len(offence.code_files) > 6:
+            lines.append(f"      ... and {len(offence.code_files) - 6} more")
+    lines += [
+        "",
+        "  GitHub skips the whole workflow set for these commits, so nothing",
+        "  downstream can catch a regression in them.",
+        "",
+        "  Drop the skip directive, or split the docs-only part into its own commit.",
+        "  Override with AGILAB_ALLOW_SKIP_CI=1 and an explicit reason.",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_pre_push_spec(text: str) -> list[tuple[str, str]]:
+    """Parse git's pre-push stdin: `<local ref> <local sha> <remote ref> <remote sha>`."""
+
+    ranges: list[tuple[str, str]] = []
+    zero = re.compile(r"^0+$")
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) != 4:
+            continue
+        _local_ref, local_sha, _remote_ref, remote_sha = fields
+        if zero.match(local_sha):
+            continue  # branch deletion
+        base = remote_sha if not zero.match(remote_sha) else "origin/main"
+        ranges.append((base, local_sha))
+    return ranges
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="Base ref when not reading a pre-push spec.")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument(
+        "--pre-push-spec",
+        type=Path,
+        help="File holding git's pre-push stdin payload.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.pre_push_spec is not None:
+        try:
+            spec = args.pre_push_spec.read_text(encoding="utf-8")
+        except OSError:
+            spec = ""
+        ranges = _parse_pre_push_spec(spec)
+    elif args.base:
+        ranges = [(args.base, args.head)]
+    else:
+        ranges = [("origin/main", args.head)]
+
+    commits: list[str] = []
+    for base, head in ranges:
+        for commit in commit_range(base, head):
+            if commit not in commits:
+                commits.append(commit)
+
+    offences = find_offences(commits)
+    if not offences:
+        return 0
+
+    print(render(offences), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why
PR #923 carried a skip-ci directive on a branch that changed `tools/` and `test/` alongside a docs refresh. GitHub skipped **every** workflow, only the secret scan reported, the PR merged on that single check — and a false positive it introduced took `main` red and blocked an unrelated PR (#926) until it was diagnosed and fixed (#927).

**No CI job can prevent this.** GitHub honours the directive by never scheduling the workflows, so by the time anything downstream could object, it has already been skipped. Pre-push is the only remaining enforcement point.

## What
`tools/skip_ci_scope_guard.py` blocks a push when a commit **both** carries a skip directive **and** touches `src/`, `test/`, `tools/`, `.github/workflows/`, or `.githooks/`.

Deliberately narrow so it doesn't become noise:
- all four GitHub directives recognised (`skip ci`, `ci skip`, `no ci`, `skip actions`), case-insensitively
- docs and assets living *beside* code stay skippable — a `tools/README.md` or `test/fixture.svg` refresh must not drag in a full matrix
- `AGILAB_ALLOW_SKIP_CI=1` overrides, matching the existing mixed-scope escape hatch

Verified against the commit that caused the outage: blocked, naming `tools/render_package_maps.py` and `test/test_render_package_maps.py`.

## The guard caught its own author
The first attempt to push this branch was **rejected by the guard itself** — the commit message quoted the bracketed directive while explaining it, and GitHub matches that string anywhere in a message, so the commit really would have suppressed its own CI. That is the guard working, not a false positive; the message now describes the directive without spelling it.

## Validation
- `test/test_skip_ci_scope_guard.py` → 17 passed: docs-only allowed, each code path blocked, all four directives, case-insensitivity, code-without-skip allowed, inert files under code paths allowed, branch-deletion spec lines ignored, normal push spec parsed, and the message naming offending files
- `test_pre_push_changed_files.py` + `test_agent_commit_provenance_guard.py` → 25 passed (sibling hook guards unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)