### PR TITLE
fix(release): refresh proof inventory from exact tag

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,7 +2,7 @@
   "file_count": 273,
   "format_version": 3,
   "managed_target": "docs/source",
-  "public_owned_digest_sha256": "a64f05aa37a19bfd3c1121b461f14bcfcc5d95ecf4f4778ed0b9a3b0472dc5a4",
+  "public_owned_digest_sha256": "83b307ed4444e233583833d6d07bb5171e079267138e6546223354af3c8bfb7a",
   "public_owned_exclusions": [
     "data/release_proof.toml",
     "data/ui_robot_evidence.json",
@@ -10,7 +10,7 @@
   ],
   "public_owned_file_count": 3,
   "public_owned_files_sha256": {
-    "data/release_proof.toml": "fbb329dc77be389fa1cee50fd9c3da71c17b950375f9d194b9b4c6621f3aedee",
+    "data/release_proof.toml": "a1be888918077b7133fca6396a94a04d9f25d96c05cefc2a50f8b520e5cc203c",
     "data/ui_robot_evidence.json": "5bee4250964fcbb8c1b0b2646c80338e01248a08f599e90b26681b22b54e6617",
     "release-proof.rst": "17ead42a60ae2be117bcc46aeeed57e91964e7de52bf37756c74dd2f3d3cd69e"
   },

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -6,7 +6,7 @@ intro = [
 proof_bullets = [
   "The pinned GitHub Actions rows record successful repository, documentation, coverage, and release-publication workflows at their exact commits. A successful workflow is not presented as proof for jobs that the workflow skipped.",
   "The release proof records the hosted Hugging Face Space URL and commit. Live public-demo availability is checked only when a public-demo-smoke run is pinned or supplied separately.",
-  "The checked-in ``docs/source/data/ui_robot_evidence.json`` records a successful historical UI robot baseline. It is not release-bound UI proof for this release because its commit and 10-app inventory predate the 15-app release inventory. Use ``tools/ui_robot_coverage_contract.py --json`` and the local ``ui-robot-matrix`` profile to verify the current checkout.",
+  "The checked-in ``docs/source/data/ui_robot_evidence.json`` records a successful historical UI robot baseline. It is not release-bound UI proof for this release because its commit and 10-app inventory predate the {expected_app_count}-app release inventory. Use ``tools/ui_robot_coverage_contract.py --json`` and the local ``ui-robot-matrix`` profile to verify the current checkout.",
   "The public demo scope includes the lightweight ``flight_telemetry_project`` and ``weather_forecast_project`` routes documented in :doc:`agilab-demo` and aligned with the packaged examples catalog.",
   "The release tag, PyPI package, public documentation, and hosted demo point to the same public product story: browser preview, local first proof, then source-checkout expansion.",
 ]

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -149,6 +149,11 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
         "_local_tag_commit",
         lambda _repo_root, _tag: "test-release-commit",
     )
+    monkeypatch.setattr(
+        module,
+        "_local_release_app_count",
+        lambda _repo_root, _tag: 14,
+    )
     docs_source = tmp_path / "docs" / "source"
     data_dir = docs_source / "data"
     data_dir.mkdir(parents=True)
@@ -178,6 +183,7 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     assert refreshed["release"]["github_release_tag"] == "v2026.05.01-2"
     assert refreshed["release"]["github_release_url"].endswith("/releases/tag/v2026.05.01-2")
     assert refreshed["release"]["github_release_commit"] == "test-release-commit"
+    assert refreshed["ui_robot"]["expected_app_count"] == 14
     dataset_release_tag = refreshed["release"]["dataset_release_tag"]
     assert dataset_release_tag.startswith("datasets-")
     assert refreshed["release"]["dataset_release_url"].endswith(
@@ -185,7 +191,9 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     )
     assert refreshed["release"]["dataset_count"] > 0
     assert refreshed["release"]["hf_space_commit"] == "test-hf-commit"
-    assert (docs_source / "release-proof.rst").read_text(encoding="utf-8") == module.render_release_proof(
+    rendered = (docs_source / "release-proof.rst").read_text(encoding="utf-8")
+    assert "14-app release inventory" in " ".join(rendered.split())
+    assert rendered == module.render_release_proof(
         refreshed,
         ui_robot_evidence_path=data_dir / "ui_robot_evidence.json",
     )

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -150,6 +150,9 @@ def _template_context(manifest: Mapping[str, Any]) -> dict[str, Any]:
     release = manifest.get("release", {})
     if not isinstance(release, Mapping):
         raise TypeError("[release] must be a table")
+    ui_robot = manifest.get("ui_robot", {})
+    if not isinstance(ui_robot, Mapping):
+        raise TypeError("[ui_robot] must be a table")
     package_name = str(release.get("package_name", ""))
     package_version = str(release.get("package_version", ""))
     package_extras = release.get("package_extras", []) or []
@@ -160,6 +163,7 @@ def _template_context(manifest: Mapping[str, Any]) -> dict[str, Any]:
     return {
         **{str(key): value for key, value in release.items()},
         "package_spec": f"{package_spec_name}=={package_version}",
+        "expected_app_count": ui_robot.get("expected_app_count"),
     }
 
 
@@ -813,6 +817,9 @@ def refresh_manifest_from_local(
     release = refreshed.get("release")
     if not isinstance(release, dict):
         raise TypeError("[release] must be a table")
+    ui_robot = refreshed.get("ui_robot")
+    if not isinstance(ui_robot, dict):
+        raise TypeError("[ui_robot] must be a table")
 
     package_version = _load_project_version(repo_root) or str(release.get("package_version", ""))
     if package_version:
@@ -832,6 +839,9 @@ def refresh_manifest_from_local(
             release["github_release_commit"] = tag_commit
         elif tag != previous_tag:
             release.pop("github_release_commit", None)
+        release_app_count = _local_release_app_count(repo_root, tag)
+        if release_app_count is not None:
+            ui_robot["expected_app_count"] = release_app_count
     elif github_release_url:
         release["github_release_url"] = github_release_url
 


### PR DESCRIPTION
## Summary

- derive `ui_robot.expected_app_count` from the exact Git release tag during release-proof refresh
- render the historical-baseline explanation from that refreshed count instead of hard-coding it
- refresh the generated public-owned docs integrity stamp

## Repro

The `sync-hf-space` job in release workflow run `30616241713` deployed the Space successfully, then failed while refreshing release proof. The manifest retained the previous release count of 15 apps, while `v2026.07.31:src/agilab/apps/builtin` contains 14 directories.

## Root Cause

`refresh_manifest_from_local()` updated the release tag, release commit, package version, and Hugging Face commit, but did not refresh `ui_robot.expected_app_count`. The nearby proof prose also embedded `15` directly, so changing the structured value alone would have left stale rendered wording.

## Regression Test

The focused refresh test now supplies an exact-tag inventory of 14, asserts that the refreshed manifest records 14, and asserts that the rendered proof says `14-app release inventory`. An additional local simulation against the real `v2026.07.31` tag confirmed 14 apps and release commit `3e88def4dda5be155d8d9a91537a671c00851c83`.

## Validation

- focused release-proof tests: 21 passed
- exact-tag refresh simulation: passed
- release-proof manifest check: passed for the currently recorded release
- docs workflow parity and Sphinx build: passed
- staged scope, impact, docs integrity, provenance, diff, and pre-push guards: passed
- final PR CI: 11 checks passed, 1 intentionally skipped, 0 failed; root tests passed in 9m15s and Windows core tests passed in 4m37s

## Review Evidence

- no sub-agents were used
- no separate model review was used
- findings from the failed production workflow were addressed in this PR

## Agent Metadata

- Tokki version: 1.0.42
- agent/runtime: OpenAI Codex, version unavailable
- model: GPT-5 Codex
- reasoning effort: unknown
- `/fast` mode: not used