### PR TITLE
fix(ui-robot): make 14-app evidence bounded and exact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,18 @@ jobs:
           set -euo pipefail
           uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" python -m playwright install --with-deps chromium
 
+      - name: Validate widget layout visibility collector
+        env:
+          AGILAB_REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION: "1"
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run \
+            --extra dev \
+            --extra ui \
+            --with "playwright==${{ steps.playwright-version.outputs.version }}" \
+            python -m pytest -q -o addopts='' \
+            test/test_agilab_widget_robot.py::test_layout_integrity_collector_uses_painted_geometry_for_expander_content
+
       - name: Save Playwright browser cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -26,44 +26,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  plan_ui_robot_matrix:
+    name: ui-robot-matrix plan
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      expected_shards: ${{ steps.plan.outputs.expected_shards }}
+      expected_apps: ${{ steps.plan.outputs.expected_apps }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.13"
+
+      - name: Plan bounded UI robot shards
+        id: plan
+        env:
+          INPUT_APPS: ${{ github.event.inputs.apps }}
+        run: |
+          set -euo pipefail
+          mkdir -p test-results/ui-robot-matrix-plan
+          python3 tools/ui_robot_matrix_plan.py \
+            --apps "${INPUT_APPS:-all}" \
+            --output test-results/ui-robot-matrix-plan/plan.json \
+            --github-output \
+            --compact \
+            | tee test-results/ui-robot-matrix-plan/plan.txt
+
   ui-robot-matrix:
-    name: ui-robot-matrix (${{ matrix.shard }})
+    name: ui-robot-matrix (${{ matrix.shard }}, ~${{ matrix.estimated_pages }} pages)
+    needs: plan_ui_robot_matrix
     runs-on: ubuntu-latest
     timeout-minutes: 50
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - shard: core
-            scenarios: >-
-              isolated-core-pages
-              isolated-entry-and-app-pages
-              isolated-project-page
-              isolated-project-editor-page
-              isolated-project-notebook-import
-              isolated-project-import-sidebar
-              isolated-project-rename-sidebar
-              isolated-settings-page
-              isolated-all-builtins-orchestrate-smoke
-              isolated-execution-pandas-orchestrate-pool-executor
-              isolated-all-builtins-core-render-smoke
-          - shard: state
-            scenarios: >-
-              isolated-fresh-session-core-pages
-              isolated-browser-history
-          - shard: quality
-            scenarios: >-
-              isolated-browser-error-core-pages
-              isolated-pytorch-playground-analysis
-              isolated-release-evidence
-              isolated-above-fold-core-pages
-              isolated-keyboard-focus-core-pages
-              isolated-accessibility-core-pages
-          - shard: layout
-            scenarios: >-
-              isolated-layout-integrity-desktop
-              isolated-mobile-core-pages
-              isolated-layout-integrity-mobile
+      matrix: ${{ fromJSON(needs.plan_ui_robot_matrix.outputs.matrix) }}
     env:
       AGILAB_DISABLE_BACKGROUND_SERVICES: "1"
       OPENAI_API_KEY: "sk-test-ui-robot-000000000000"
@@ -106,7 +106,7 @@ jobs:
           uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" python -m playwright install --with-deps chromium
 
       - name: Save Playwright browser cache
-        if: steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core'
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core-01'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
@@ -114,9 +114,9 @@ jobs:
 
       - name: Run UI robot matrix shard
         env:
-          INPUT_APPS: ${{ github.event.inputs.apps }}
           INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
           INPUT_WIDGET_TIMEOUT: ${{ github.event.inputs.widget_timeout }}
+          ROBOT_APPS: ${{ matrix.apps }}
           ROBOT_SCENARIOS: ${{ matrix.scenarios }}
           ROBOT_SHARD: ${{ matrix.shard }}
         run: |
@@ -131,7 +131,7 @@ jobs:
             "${failure_artifact_dir}/traces" \
             "${failure_artifact_dir}/har" \
             "${failure_artifact_dir}/video"
-          robot_apps="${INPUT_APPS:-all}"
+          robot_apps="${ROBOT_APPS}"
           robot_timeout="${INPUT_TIMEOUT:-90}"
           robot_widget_timeout="${INPUT_WIDGET_TIMEOUT:-3}"
           scenario_args=()
@@ -304,7 +304,9 @@ jobs:
   aggregate-ui-robot-matrix:
     name: ui-robot-matrix aggregate
     runs-on: ubuntu-latest
-    needs: ui-robot-matrix
+    needs:
+      - plan_ui_robot_matrix
+      - ui-robot-matrix
     if: always()
     steps:
       - name: Checkout
@@ -328,12 +330,20 @@ jobs:
           path: test-results/ui-robot-matrix-artifacts
 
       - name: Aggregate UI robot matrix shards
+        env:
+          EXPECTED_APPS: ${{ needs.plan_ui_robot_matrix.outputs.expected_apps }}
+          EXPECTED_SHARDS: ${{ needs.plan_ui_robot_matrix.outputs.expected_shards }}
         run: |
+          if [ -z "${EXPECTED_APPS}" ] || [ -z "${EXPECTED_SHARDS}" ]; then
+            echo "UI robot matrix plan outputs are missing" >&2
+            exit 2
+          fi
           set +e
           mkdir -p test-results/ui-robot-matrix-aggregate
           uv --preview-features extra-build-dependencies run python tools/ui_robot_matrix_aggregate.py \
             --root test-results/ui-robot-matrix-artifacts \
-            --expected-shards core,state,quality,layout \
+            --expected-shards "${EXPECTED_SHARDS}" \
+            --expected-apps "${EXPECTED_APPS}" \
             --output test-results/ui-robot-matrix-aggregate/aggregate.json \
             --summary-markdown test-results/ui-robot-matrix-aggregate/summary.md \
             | tee test-results/ui-robot-matrix-aggregate/aggregate.txt

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p test-results/ui-robot-matrix-plan
-          python3 tools/ui_robot_matrix_plan.py \
+          python3 tools/testing/ui_robot_matrix_plan.py \
             --apps "${INPUT_APPS:-all}" \
             --output test-results/ui-robot-matrix-plan/plan.json \
             --github-output \

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-31T07:47:14Z",
+  "generated_at_utc": "2026-07-31T13:27:33Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -22,7 +22,7 @@
     "package_count": 36,
     "public_app_count": 14,
     "agent_skill_count": 33,
-    "evidence_schema_count": 236,
+    "evidence_schema_count": 237,
     "catalog_file_count": 12
   },
   "cli_commands": [
@@ -2455,6 +2455,12 @@
       "sources": [
         "tools/ui_robot_evidence.py",
         "tools/ui_robot_matrix_aggregate.py"
+      ]
+    },
+    {
+      "schema": "agilab.ui_robot_matrix_plan.v1",
+      "sources": [
+        "tools/testing/ui_robot_matrix_plan.py"
       ]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]
 offline = ["agilab[local-llm]==2026.07.31"]
-dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<1", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
+dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<0.16", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
 
 [dependency-groups]
 dev = [

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import sys
 import time
 from pathlib import Path
 
+import pytest
 
 MODULE_PATH = Path("tools/agilab_widget_robot.py").resolve()
+REAL_HOME = Path.home().resolve()
+REAL_PLAYWRIGHT_BROWSERS_PATH = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "")
+REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION_ENV = "AGILAB_REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION"
 
 
 def _load_module():
@@ -651,6 +656,99 @@ def test_layout_integrity_result_probe_accepts_clean_geometry() -> None:
 
     assert probe.status == "interacted"
     assert "no obvious overflow" in probe.detail
+
+
+def test_layout_integrity_collector_uses_painted_geometry_for_expander_content(
+    monkeypatch,
+) -> None:
+    require_browser = os.environ.get(REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION_ENV) == "1"
+    try:
+        from playwright import sync_api
+    except ModuleNotFoundError:
+        if require_browser:
+            pytest.fail("Playwright is required by the layout-regression gate", pytrace=False)
+        pytest.skip("Playwright is not installed")
+    module = _load_module()
+
+    cache_candidates = [
+        Path(REAL_PLAYWRIGHT_BROWSERS_PATH) if REAL_PLAYWRIGHT_BROWSERS_PATH else None,
+        REAL_HOME / "Library" / "Caches" / "ms-playwright",
+        REAL_HOME / ".cache" / "ms-playwright",
+        REAL_HOME / "AppData" / "Local" / "ms-playwright",
+    ]
+    cache_root = next(
+        (path for path in cache_candidates if path is not None and path.is_dir()), None
+    )
+    if cache_root is not None:
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(cache_root))
+
+    try:
+        with sync_api.sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            try:
+                page = browser.new_page(viewport={"width": 1000, "height": 700})
+                page.set_content(
+                    """
+                    <style>
+                      .expander-content {
+                        position: fixed;
+                        inset: 20px auto auto 20px;
+                        width: 240px;
+                        height: 0;
+                        overflow: hidden;
+                      }
+                      .expander-content button,
+                      .actual-overlap button {
+                        position: absolute;
+                        inset: 0 auto auto 0;
+                        width: 200px;
+                        height: 40px;
+                      }
+                      .actual-overlap {
+                        position: fixed;
+                        inset: 100px auto auto 400px;
+                        width: 200px;
+                        height: 40px;
+                      }
+                    </style>
+                    <details open>
+                      <summary>Preview distribution workplan</summary>
+                      <div class="expander-content">
+                        <button>CHECK distribute</button>
+                      </div>
+                    </details>
+                    <details open>
+                      <summary>Advanced benchmark options</summary>
+                      <div class="expander-content">
+                        <button>Benchmark modes</button>
+                      </div>
+                    </details>
+                    <div class="actual-overlap">
+                      <button>Visible primary</button>
+                      <button>Visible secondary</button>
+                    </div>
+                    """
+                )
+
+                issues = page.evaluate(module.LAYOUT_INTEGRITY_COLLECTOR_JS)
+            finally:
+                browser.close()
+    except sync_api.Error as exc:
+        if require_browser:
+            pytest.fail(f"Chromium is required by the layout-regression gate: {exc}", pytrace=False)
+        pytest.skip(f"Chromium is unavailable for layout collector regression: {exc}")
+
+    overlap_details = [
+        f"{issue.get('label', '')} {issue.get('detail', '')}"
+        for issue in issues
+        if issue.get("kind") == "control_overlap"
+    ]
+    assert any(
+        "Visible primary" in detail and "Visible secondary" in detail
+        for detail in overlap_details
+    )
+    assert all("CHECK distribute" not in detail for detail in overlap_details)
+    assert all("Benchmark modes" not in detail for detail in overlap_details)
 
 
 def test_layout_integrity_result_probe_ignores_framework_artifacts() -> None:
@@ -2737,9 +2835,19 @@ def test_summarize_counts_interactions_and_failures() -> None:
         )
     ]
 
-    summary = module.summarize(pages, app_count=1, target_seconds=10.0)
+    summary = module.summarize(
+        pages,
+        app_count=99,
+        target_seconds=10.0,
+        apps=["weather_forecast_project", "flight_telemetry_project"],
+    )
 
     assert summary.success is False
+    assert summary.app_count == 2
+    assert summary.apps == ["flight_telemetry_project", "weather_forecast_project"]
+    assert summary.covered_apps == ["flight_telemetry_project"]
+    assert summary.missing_apps == ["weather_forecast_project"]
+    assert summary.unexpected_apps == []
     assert summary.widget_count == 3
     assert summary.main_widget_count == 2
     assert summary.sidebar_widget_count == 1
@@ -2953,7 +3061,7 @@ def test_streamlit_health_failure_detail_handles_running_process() -> None:
     assert "output tail: tail" in detail
 
 
-def test_write_summary_json_includes_page_status(tmp_path) -> None:
+def test_write_summary_json_includes_page_status_and_exact_app_coverage(tmp_path) -> None:
     module = _load_module()
     page = module.PageSweep(
         app="flight_telemetry_project",
@@ -2971,12 +3079,72 @@ def test_write_summary_json_includes_page_status(tmp_path) -> None:
         status="passed",
     )
     output = tmp_path / "summary.json"
+    weather_page = module.PageSweep(
+        app="weather_forecast_project",
+        page="PROJECT",
+        success=True,
+        duration_seconds=1.0,
+        widget_count=1,
+        interacted_count=1,
+        probed_count=0,
+        skipped_count=0,
+        failed_count=0,
+        url="http://demo",
+        failures=[],
+        skips=[],
+        status="passed",
+    )
 
-    module.write_summary_json(output, [page], app_count=1, target_seconds=10.0)
+    module.write_summary_json(
+        output,
+        [page, weather_page],
+        app_count=2,
+        target_seconds=10.0,
+        apps=["weather_forecast_project", "flight_telemetry_project"],
+    )
 
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["success"] is True
+    assert payload["app_count"] == 2
+    assert payload["apps"] == ["flight_telemetry_project", "weather_forecast_project"]
+    assert payload["covered_apps"] == ["flight_telemetry_project", "weather_forecast_project"]
+    assert payload["missing_apps"] == []
+    assert payload["unexpected_apps"] == []
     assert payload["pages"][0]["status"] == "passed"
+
+
+def test_summarize_fails_when_a_selected_app_has_no_completed_page() -> None:
+    module = _load_module()
+    page = module.PageSweep(
+        app="flight_telemetry_project",
+        page="PROJECT",
+        success=True,
+        duration_seconds=1.0,
+        widget_count=1,
+        interacted_count=1,
+        probed_count=0,
+        skipped_count=0,
+        failed_count=0,
+        url="http://demo",
+        failures=[],
+        skips=[],
+        status="passed",
+    )
+
+    summary = module.summarize(
+        [page],
+        app_count=2,
+        target_seconds=10.0,
+        apps=["weather_forecast_project", "flight_telemetry_project"],
+    )
+
+    assert summary.success is False
+    assert summary.within_target is False
+    assert summary.failed_count == 0
+    assert summary.apps == ["flight_telemetry_project", "weather_forecast_project"]
+    assert summary.covered_apps == ["flight_telemetry_project"]
+    assert summary.missing_apps == ["weather_forecast_project"]
+    assert summary.unexpected_apps == []
 
 
 def test_page_watchdog_helper_raises_when_deadline_expired() -> None:
@@ -4748,6 +4916,7 @@ def test_render_human_reports_sidebar_widget_counts() -> None:
     report = module.render_human(summary)
 
     assert "widgets=3 main=2 sidebar=1" in report
+    assert "coverage: covered=flight_telemetry_project missing=- unexpected=-" in report
     assert "combinations: space=2 executed=2" in report
     assert "flight_telemetry_project/PROJECT: FAIL status=failed widgets=3 main=2 sidebar=1" in report
     assert "combinations=2/2" in report

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -1625,6 +1625,8 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
                     "probed_count": 2,
                     "skipped_count": 0,
                     "failed_count": 0,
+                    "apps": ["flight_telemetry_project"],
+                    "pages": [{"app": "flight_telemetry_project"}],
                 }
             ),
             encoding="utf-8",
@@ -1657,12 +1659,153 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
     ]
     assert summary["success"] is True
     assert summary["scenario_count"] == 13
+    assert summary["app_count"] == 1
+    assert summary["apps"] == ["flight_telemetry_project"]
     assert summary["page_count"] == 26
     assert summary["widget_count"] == 65
     assert summary["interacted_count"] == 39
     assert summary["probed_count"] == 26
     assert summary["failed_scenarios"] == []
     assert summary["failure_samples"] == []
+
+
+def test_summarize_matrix_preserves_complete_app_inventory_with_focused_override(tmp_path) -> None:
+    module = _load_module()
+    app_names = [
+        "data_quality_gate_project",
+        "execution_pandas_project",
+        "execution_polars_project",
+        "flight_telemetry_project",
+        "minimal_app_project",
+        "mission_decision_project",
+        "multi_app_dag_project",
+        "pytorch_playground_project",
+        "r_runtime_bridge_project",
+        "sklearn_pipeline_project",
+        "tescia_diagnostic_project",
+        "uav_queue_project",
+        "uav_relay_queue_project",
+        "weather_forecast_project",
+    ]
+
+    def _result(scenario_name: str, summary: dict) -> module.ScenarioResult:
+        scenario = module.ALL_SCENARIOS[scenario_name]
+        return module.ScenarioResult(
+            scenario=scenario,
+            argv=["robot"],
+            returncode=0,
+            duration_seconds=1.0,
+            summary_path=tmp_path / f"{scenario_name}.json",
+            progress_path=tmp_path / f"{scenario_name}.ndjson",
+            summary={
+                "success": True,
+                "page_count": len(summary["pages"]),
+                "widget_count": 0,
+                "interacted_count": 0,
+                "probed_count": 0,
+                "skipped_count": 0,
+                "failed_count": 0,
+                **summary,
+            },
+            output="",
+        )
+
+    all_apps = _result(
+        "isolated-all-builtins-core-render-smoke",
+        {
+            "app_count": len(app_names),
+            "apps": app_names,
+            "pages": [{"app": app_name} for app_name in reversed(app_names)],
+        },
+    )
+    focused = _result(
+        "isolated-pytorch-playground-analysis",
+        {
+            "app_count": 1,
+            "apps": ["pytorch_playground_project"],
+            "pages": [{"app": "pytorch_playground_project"}],
+        },
+    )
+
+    summary = module.summarize_matrix([all_apps, focused])
+
+    assert summary["success"] is True
+    assert summary["app_count"] == 14
+    assert summary["apps"] == app_names
+    assert summary["inventory_errors"] == []
+    assert summary["scenarios"][0]["app_count"] == 14
+    assert summary["scenarios"][0]["apps"] == app_names
+    assert summary["scenarios"][1]["app_count"] == 1
+    assert summary["scenarios"][1]["apps"] == ["pytorch_playground_project"]
+
+    other_focused = _result(
+        "isolated-execution-pandas-orchestrate-pool-executor",
+        {
+            "app_count": 1,
+            "apps": ["execution_pandas_project"],
+            "pages": [{"app": "execution_pandas_project"}],
+        },
+    )
+    focused_summary = module.summarize_matrix([focused, other_focused])
+
+    assert focused_summary["app_count"] == 2
+    assert focused_summary["apps"] == [
+        "execution_pandas_project",
+        "pytorch_playground_project",
+    ]
+
+
+def test_summarize_matrix_fails_closed_on_malformed_exact_app_inventory(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.ALL_SCENARIOS["isolated-core-pages"]
+    cases = [
+        (
+            ["weather_forecast_project", "flight_telemetry_project"],
+            2,
+            "sorted, unique",
+        ),
+        (
+            ["flight_telemetry_project", "flight_telemetry_project"],
+            2,
+            "sorted, unique",
+        ),
+        (["flight_telemetry_project", 7], 2, "non-empty strings"),
+        ("flight_telemetry_project", 1, "must be a list"),
+        (["flight_telemetry_project"], "1", "must be an integer"),
+        (["flight_telemetry_project"], True, "must be an integer"),
+        (["flight_telemetry_project"], 2, "does not match"),
+    ]
+
+    for index, (raw_apps, raw_count, expected_error) in enumerate(cases):
+        result = module.ScenarioResult(
+            scenario=scenario,
+            argv=["robot"],
+            returncode=0,
+            duration_seconds=1.0,
+            summary_path=tmp_path / f"summary-{index}.json",
+            progress_path=tmp_path / f"progress-{index}.ndjson",
+            summary={
+                "success": True,
+                "app_count": raw_count,
+                "apps": raw_apps,
+                "page_count": 1,
+                "widget_count": 0,
+                "interacted_count": 0,
+                "probed_count": 0,
+                "skipped_count": 0,
+                "failed_count": 0,
+            },
+            output="",
+        )
+
+        summary = module.summarize_matrix([result])
+
+        assert summary["success"] is False
+        assert summary["failed_scenarios"] == [scenario.name]
+        assert any(expected_error in error for error in summary["inventory_errors"])
+        assert summary["scenarios"][0]["success"] is False
+        assert summary["scenarios"][0]["apps"] == raw_apps
+        assert summary["scenarios"][0]["app_count"] == raw_count
 
 
 def test_run_matrix_reuses_cached_successful_scenario(tmp_path, monkeypatch) -> None:

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -16,7 +16,7 @@ WINDOWS_CORE_TESTS_WORKFLOW_PATH = Path(".github/workflows/windows-core-tests.ym
 ROOT_TEST_SUITE_WORKFLOW_PATH = Path(".github/workflows/root-test-suite.yml")
 ROOT_CONFTEST_PATH = Path("test/conftest.py")
 WORKFLOW_PARITY_PATH = Path("tools/workflow_parity.py")
-UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/ui_robot_matrix_plan.py")
+UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/testing/ui_robot_matrix_plan.py")
 PYPROJECT_PATH = Path("pyproject.toml")
 
 VALIDATION_WORKFLOW_PATHS = (
@@ -446,7 +446,7 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert "\n  push:" not in text
     assert "ui-robot-matrix:" in text
     assert "plan_ui_robot_matrix:" in text
-    assert "tools/ui_robot_matrix_plan.py" in text
+    assert "tools/testing/ui_robot_matrix_plan.py" in text
     assert "--github-output" in text
     assert "matrix: ${{ fromJSON(needs.plan_ui_robot_matrix.outputs.matrix) }}" in text
     assert "strategy:" in text

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -16,6 +16,7 @@ WINDOWS_CORE_TESTS_WORKFLOW_PATH = Path(".github/workflows/windows-core-tests.ym
 ROOT_TEST_SUITE_WORKFLOW_PATH = Path(".github/workflows/root-test-suite.yml")
 ROOT_CONFTEST_PATH = Path("test/conftest.py")
 WORKFLOW_PARITY_PATH = Path("tools/workflow_parity.py")
+UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/ui_robot_matrix_plan.py")
 PYPROJECT_PATH = Path("pyproject.toml")
 
 VALIDATION_WORKFLOW_PATHS = (
@@ -42,27 +43,27 @@ def _load_workflow_parity_module():
     return module
 
 
+def _ui_robot_matrix_plan_rows() -> dict[str, dict[str, object]]:
+    spec = importlib.util.spec_from_file_location(
+        "ci_ui_robot_matrix_plan_test_module",
+        UI_ROBOT_MATRIX_PLAN_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    plan = module.build_plan()
+    return {
+        str(row["shard"]): dict(row)
+        for row in plan["matrix"]["include"]
+    }
+
+
 def _ui_robot_matrix_workflow_shards() -> dict[str, list[str]]:
-    shards: dict[str, list[str]] = {}
-    current_shard = ""
-    collecting = False
-    for line in UI_ROBOT_MATRIX_WORKFLOW_PATH.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if stripped.startswith("- shard:"):
-            current_shard = stripped.split(":", 1)[1].strip()
-            shards[current_shard] = []
-            collecting = False
-            continue
-        if current_shard and stripped == "scenarios: >-":
-            collecting = True
-            continue
-        if collecting:
-            if line.startswith("              ") and stripped:
-                shards[current_shard].append(stripped)
-                continue
-            collecting = False
-    assert shards
-    return shards
+    return {
+        shard: str(row["scenarios"]).split()
+        for shard, row in _ui_robot_matrix_plan_rows().items()
+    }
 
 
 def _ui_robot_matrix_parity_commands():
@@ -112,11 +113,12 @@ def _ui_robot_matrix_command_contract(argv: list[str]) -> dict[str, object]:
 
 
 def _ui_robot_matrix_workflow_contracts() -> dict[str, dict[str, object]]:
+    plan_rows = _ui_robot_matrix_plan_rows()
     return {
         shard: {
             "script": True,
             "scenarios": scenarios,
-            "apps": "all",
+            "apps": str(plan_rows[shard]["apps"]),
             "timeout": "90",
             "widget_timeout": "3",
             "json": True,
@@ -420,13 +422,16 @@ def test_release_plan_validates_managed_docs_tag_before_publish_jobs() -> None:
     )
 
 
-def test_docs_source_guard_fetches_release_tags_for_exact_proof() -> None:
-    guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
-
-    checkout_block = guard_text.split("- name: Checkout", 1)[1].split(
-        "- name: Setup Python", 1
-    )[0]
-    assert "fetch-depth: 0" in checkout_block
+def test_docs_workflows_fetch_release_tags_for_exact_proof() -> None:
+    for workflow_path in (
+        DOCS_SOURCE_GUARD_WORKFLOW_PATH,
+        DOCS_PUBLISH_WORKFLOW_PATH,
+    ):
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        checkout_block = workflow_text.split("- name: Checkout", 1)[1].split(
+            "- name: Setup Python", 1
+        )[0]
+        assert "fetch-depth: 0" in checkout_block
 
 
 def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
@@ -440,12 +445,12 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert "pull_request:" not in text
     assert "\n  push:" not in text
     assert "ui-robot-matrix:" in text
+    assert "plan_ui_robot_matrix:" in text
+    assert "tools/ui_robot_matrix_plan.py" in text
+    assert "--github-output" in text
+    assert "matrix: ${{ fromJSON(needs.plan_ui_robot_matrix.outputs.matrix) }}" in text
     assert "strategy:" in text
     assert "fail-fast: false" in text
-    assert "- shard: core" in text
-    assert "- shard: state" in text
-    assert "- shard: quality" in text
-    assert "- shard: layout" in text
     assert "tools/agilab_widget_robot_matrix.py" in text
     assert "Resolve Playwright version for browser cache key" in text
     assert "id: playwright-version" in text
@@ -464,7 +469,7 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
         "python -m playwright install --with-deps chromium"
     ) in text
     assert "Save Playwright browser cache" in text
-    assert "steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core'" in text
+    assert "steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core-01'" in text
     assert "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" in text
     assert text.index("Restore Playwright browser cache") < text.index(
         "Install Playwright browser"
@@ -473,12 +478,13 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
         "Save Playwright browser cache"
     )
     assert "uv --preview-features extra-build-dependencies run --extra ai --with playwright python tools/agilab_widget_robot_matrix.py" in text
+    planner_text = UI_ROBOT_MATRIX_PLAN_PATH.read_text(encoding="utf-8")
     for scenario in {
         scenario
         for scenarios in _ui_robot_matrix_workflow_shards().values()
         for scenario in scenarios
     }:
-        assert scenario in text
+        assert scenario in planner_text
     assert '"${scenario_args[@]}"' in text
     assert "--apps \"${robot_apps}\"" in text
     assert "--json" in text
@@ -488,6 +494,8 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert 'screenshot_dir="screenshots/ui-robot-matrix/${ROBOT_SHARD}"' in text
     assert 'failure_bundle_dir="${result_dir}/failure-bundles"' in text
     assert 'failure_artifact_dir="${result_dir}/failure-artifacts"' in text
+    assert 'robot_apps="${ROBOT_APPS}"' in text
+    assert "ROBOT_APPS: ${{ matrix.apps }}" in text
     assert '--output-dir "${result_dir}"' in text
     assert '--screenshot-dir "${screenshot_dir}"' in text
     assert '--failure-bundle-dir "${failure_bundle_dir}"' in text
@@ -516,11 +524,13 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert "test-results/ui-robot-matrix/${{ matrix.shard }}/**" in text
     assert "screenshots/ui-robot-matrix/${{ matrix.shard }}/**" in text
     assert "aggregate-ui-robot-matrix:" in text
-    assert "needs: ui-robot-matrix" in text
+    assert "- plan_ui_robot_matrix" in text
+    assert "- ui-robot-matrix" in text
     assert "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1" in text
     assert "pattern: ui-robot-matrix-*-${{ github.run_attempt }}" in text
     assert "uv --preview-features extra-build-dependencies run python tools/ui_robot_matrix_aggregate.py" in text
-    assert "--expected-shards core,state,quality,layout" in text
+    assert '--expected-shards "${EXPECTED_SHARDS}"' in text
+    assert '--expected-apps "${EXPECTED_APPS}"' in text
     assert "--output test-results/ui-robot-matrix-aggregate/aggregate.json" in text
     assert "--summary-markdown test-results/ui-robot-matrix-aggregate/summary.md" in text
     assert "ui-robot-matrix-aggregate-${{ github.run_attempt }}" in text
@@ -556,4 +566,10 @@ def test_dev_extra_installs_ruff_for_local_linting() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     dev_dependencies = pyproject["project"]["optional-dependencies"]["dev"]
 
-    assert any(dependency.startswith("ruff>=") for dependency in dev_dependencies)
+    ruff_dependencies = [
+        dependency
+        for dependency in dev_dependencies
+        if dependency.startswith("ruff>=")
+    ]
+
+    assert ruff_dependencies == ["ruff>=0.15.14,<0.16"]

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -397,6 +397,7 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
 ) -> None:
     module = _load_module()
     ui_robot_evidence = module._load_ui_robot_evidence_module()
+    apps = [f"app_{index}_project" for index in range(10)]
     run = {
         "attempt": 1,
         "conclusion": "success",
@@ -427,6 +428,7 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
         },
         scenario_summary={
             "success": True,
+            "apps": apps,
             "app_count": 10,
             "page_count": 30,
             "widget_count": 532,
@@ -467,10 +469,18 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
         return run
 
     monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+    monkeypatch.setattr(
+        module,
+        "_local_release_apps",
+        lambda _repo_root, _release_ref: apps,
+    )
 
     check = module._ui_robot_evidence_check(
         evidence_path,
-        release={"github_release_commit": "abc123"},
+        release={
+            "github_release_commit": "abc123",
+            "github_release_tag": "v2099.01.01",
+        },
         ui_robot={"mode": "release", "expected_app_count": 10},
         repo_root=Path.cwd(),
         github_repo="ThalesGroup/agilab",
@@ -480,6 +490,117 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
     assert check["status"] == "pass"
     assert check["details"]["run_id"] == "25577485125"
     assert check["details"]["failed_count"] == 0
+    assert check["details"]["local_release_apps"] == apps
+
+
+def test_release_proof_ui_robot_release_mode_requires_exact_local_tag_inventory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    evidence = json.loads(
+        Path("docs/source/data/ui_robot_evidence.json").read_text(encoding="utf-8")
+    )
+    evidence["source"]["head_sha"] = "release-commit"
+    evidence["result"]["apps"] = ["alpha_project", "beta_project"]
+    evidence["result"]["app_count"] = 2
+    evidence_path = tmp_path / "ui_robot_evidence.json"
+    evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "_local_release_apps",
+        lambda _repo_root, _release_ref: ["alpha_project", "beta_project"],
+    )
+
+    matching = module._ui_robot_evidence_check(
+        evidence_path,
+        release={
+            "github_release_commit": "release-commit",
+            "github_release_tag": "v2099.01.01",
+        },
+        ui_robot={"mode": "release", "expected_app_count": 2},
+        repo_root=tmp_path,
+        github_repo=None,
+        check_github_runs=False,
+    )
+
+    assert matching["status"] == "pass"
+    assert matching["details"]["represents_release"] is True
+    assert matching["details"]["exact_app_inventory_matches"] is True
+
+    monkeypatch.setattr(
+        module,
+        "_local_release_apps",
+        lambda _repo_root, _release_ref: ["alpha_project", "gamma_project"],
+    )
+    mismatching = module._ui_robot_evidence_check(
+        evidence_path,
+        release={
+            "github_release_commit": "release-commit",
+            "github_release_tag": "v2099.01.01",
+        },
+        ui_robot={"mode": "release", "expected_app_count": 2},
+        repo_root=tmp_path,
+        github_repo=None,
+        check_github_runs=False,
+    )
+
+    assert mismatching["status"] == "fail"
+    assert mismatching["details"]["represents_release"] is False
+    assert "release tag inventory" in " ".join(mismatching["details"]["failures"])
+
+    monkeypatch.setattr(
+        module,
+        "_local_release_apps",
+        lambda _repo_root, _release_ref: None,
+    )
+    unavailable = module._ui_robot_evidence_check(
+        evidence_path,
+        release={
+            "github_release_commit": "release-commit",
+            "github_release_tag": "v2099.01.01",
+        },
+        ui_robot={"mode": "release", "expected_app_count": 2},
+        repo_root=tmp_path,
+        github_repo=None,
+        check_github_runs=False,
+    )
+
+    assert unavailable["status"] == "fail"
+    assert unavailable["details"]["represents_release"] is False
+    assert "inventory is unavailable" in " ".join(
+        unavailable["details"]["failures"]
+    )
+
+    historical_unavailable = module._ui_robot_evidence_check(
+        evidence_path,
+        release={
+            "github_release_commit": "release-commit",
+            "github_release_tag": "v2099.01.01",
+        },
+        ui_robot={"mode": "historical", "expected_app_count": 2},
+        repo_root=tmp_path,
+        github_repo=None,
+        check_github_runs=False,
+    )
+
+    assert historical_unavailable["status"] == "pass"
+    assert historical_unavailable["details"]["represents_release"] is False
+
+
+def test_local_release_apps_filters_and_sorts_project_directories(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_run_git",
+        lambda _repo_root, _args: "zeta_project\nREADME\nalpha_project\n",
+    )
+
+    assert module._local_release_apps(Path.cwd(), "v2099.01.01") == [
+        "alpha_project",
+        "zeta_project",
+    ]
+    assert module._local_release_app_count(Path.cwd(), "v2099.01.01") == 2
 
 
 def test_release_proof_ui_robot_historical_mode_is_not_release_proof() -> None:
@@ -522,6 +643,7 @@ def test_release_proof_ui_robot_historical_mode_is_not_release_proof() -> None:
     failures = " ".join(release_check["details"]["failures"])
     assert "head SHA" in failures
     assert "app_count" in failures
+    assert "exact app inventory" in failures
 
 
 def test_release_proof_renderer_fails_unknown_template_key(tmp_path: Path) -> None:

--- a/test/test_sync_docs_source.py
+++ b/test/test_sync_docs_source.py
@@ -71,6 +71,39 @@ def _write_v2_stamp(module, source: Path, target: Path) -> Path:
     )
 
 
+def _passing_ui_robot_evidence(*, run_id: str = "123") -> dict[str, object]:
+    return {
+        "schema": "agilab.ui_robot_evidence.v1",
+        "source": {
+            "workflow": "ui-robot-matrix",
+            "run_id": run_id,
+            "run_url": f"https://example.invalid/runs/{run_id}",
+            "status": "completed",
+            "conclusion": "success",
+        },
+        "artifact": {
+            "name": "ui-robot-matrix-aggregate-1",
+            "required_files_present": True,
+            "exit_code": "0",
+            "trend_report_schema": "agilab.ui_robot_trend_report.v1",
+            "expired": False,
+        },
+        "result": {
+            "success": True,
+            "failed_count": 0,
+            "within_target": True,
+            "trend": {
+                "schema": "agilab.ui_robot_trend_report.v1",
+                "success": True,
+                "failed_page_count": 0,
+                "flaky_page_count": 0,
+                "parse_error_count": 0,
+                "budget_violation_count": 0,
+            },
+        },
+    }
+
+
 def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool) -> None:
     try:
         link.symlink_to(target, target_is_directory=target_is_directory)
@@ -1510,6 +1543,305 @@ def test_release_refresh_refuses_unrelated_ui_robot_evidence_change(
     assert stamp_path.read_bytes() == stamp_before
     ok, _message = module.verify_target_mirror_integrity(target)
     assert ok is False
+
+
+def test_ui_robot_evidence_refresh_rebaselines_only_existing_ui_evidence(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    public_contents = {
+        "data/release_proof.toml": "[release]\n",
+        "data/ui_robot_evidence.json": json.dumps(
+            _passing_ui_robot_evidence(run_id="1")
+        ),
+        "release-proof.rst": "Release proof\n",
+    }
+    for rel_path, content in public_contents.items():
+        path = target / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    payload_before = json.loads(stamp_path.read_text(encoding="utf-8"))
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence(run_id="2")),
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--refresh-ui-robot-evidence-stamp",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "UI robot evidence mirror stamp refreshed" in capsys.readouterr().out
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    assert payload["source_status"] == "verified"
+    assert payload["source_digest_sha256"] == payload_before["source_digest_sha256"]
+    before_files = payload_before["public_owned_files_sha256"]
+    after_files = payload["public_owned_files_sha256"]
+    assert (
+        after_files[module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED]
+        != before_files[module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED]
+    )
+    assert {
+        path: digest
+        for path, digest in after_files.items()
+        if path != module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    } == {
+        path: digest
+        for path, digest in before_files.items()
+        if path != module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    }
+    ok, message = module.verify_mirror_stamp(target, source)
+    assert ok is True, message
+
+
+def test_ui_robot_evidence_refresh_validates_an_idempotent_noop(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence()),
+        encoding="utf-8",
+    )
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    metadata_before = stamp_path.stat()
+
+    returned_path, written = module.refresh_ui_robot_evidence_stamp(source, target)
+
+    metadata_after = stamp_path.stat()
+    assert returned_path == stamp_path
+    assert written is False
+    assert stamp_path.read_bytes() == stamp_before
+    assert (metadata_after.st_dev, metadata_after.st_ino, metadata_after.st_mtime_ns) == (
+        metadata_before.st_dev,
+        metadata_before.st_ino,
+        metadata_before.st_mtime_ns,
+    )
+
+
+def test_ui_robot_evidence_refresh_refuses_malformed_json(tmp_path: Path) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence()),
+        encoding="utf-8",
+    )
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    evidence.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid UI robot evidence"):
+        module.refresh_ui_robot_evidence_stamp(source, target)
+
+    assert stamp_path.read_bytes() == stamp_before
+
+
+def test_ui_robot_evidence_refresh_refuses_failing_evidence_checks(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence()),
+        encoding="utf-8",
+    )
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    failing_evidence = _passing_ui_robot_evidence(run_id="456")
+    source_payload = failing_evidence["source"]
+    assert isinstance(source_payload, dict)
+    source_payload["conclusion"] = "failure"
+    evidence.write_text(json.dumps(failing_evidence), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="UI robot evidence validation failed: run_success",
+    ):
+        module.refresh_ui_robot_evidence_stamp(source, target)
+
+    assert stamp_path.read_bytes() == stamp_before
+
+
+def test_ui_robot_evidence_refresh_rolls_back_if_evidence_changes_after_validation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence(run_id="1")),
+        encoding="utf-8",
+    )
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    evidence.write_text(
+        json.dumps(_passing_ui_robot_evidence(run_id="2")),
+        encoding="utf-8",
+    )
+    original_validate = module._validate_ui_robot_evidence_at_boundary
+
+    def validate_then_replace(*args, **kwargs):
+        original_validate(*args, **kwargs)
+        evidence.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        module,
+        "_validate_ui_robot_evidence_at_boundary",
+        validate_then_replace,
+    )
+
+    with pytest.raises(ValueError, match="published mirror stamp failed verification"):
+        module.refresh_ui_robot_evidence_stamp(source, target)
+
+    assert evidence.read_text(encoding="utf-8") == "{}"
+    assert stamp_path.read_bytes() == stamp_before
+
+
+def test_ui_robot_evidence_refresh_refuses_other_public_owned_drift(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    release_proof = target / "data" / "release_proof.toml"
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text('{"run_id": 1}\n', encoding="utf-8")
+    release_proof.write_text("[release]\n", encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    evidence.write_text('{"run_id": 2}\n', encoding="utf-8")
+    release_proof.write_text("[release]\nversion = 2\n", encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--refresh-ui-robot-evidence-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "data/release_proof.toml" in capsys.readouterr().err
+    assert stamp_path.read_bytes() == stamp_before
+
+
+def test_ui_robot_evidence_refresh_refuses_canonical_source_drift(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    source_guide = source / "guide.rst"
+    source_guide.write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text('{"run_id": 1}\n', encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    evidence.write_text('{"run_id": 2}\n', encoding="utf-8")
+    source_guide.write_text("canonical drift\n", encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(source),
+            "--target",
+            str(target),
+            "--refresh-ui-robot-evidence-stamp",
+            "--quiet",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "canonical source drift" in capsys.readouterr().err
+    assert stamp_path.read_bytes() == stamp_before
+
+
+@pytest.mark.parametrize("mutation", ["create", "delete"])
+def test_ui_robot_evidence_refresh_refuses_creation_or_deletion(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    module = _load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "guide.rst").write_text("guide\n", encoding="utf-8")
+    (target / "guide.rst").write_text("guide\n", encoding="utf-8")
+    evidence = target / module.UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    if mutation == "delete":
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text('{"run_id": 1}\n', encoding="utf-8")
+    stamp_path = module.write_mirror_stamp(source, target)
+    stamp_before = stamp_path.read_bytes()
+    if mutation == "create":
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text('{"run_id": 1}\n', encoding="utf-8")
+    else:
+        evidence.unlink()
+
+    with pytest.raises(ValueError, match="creation or deletion"):
+        module.refresh_ui_robot_evidence_stamp(source, target)
+
+    assert stamp_path.read_bytes() == stamp_before
 
 
 def test_refresh_target_integrity_stamp_refuses_changed_managed_target(

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -58,7 +58,13 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
         "uav_queue_project",
         "uav_relay_queue_project",
     ]
-    assert payload["coverage"]["public_demo_contract"]["ui_apps_covered_by"] == "ui-robot-matrix --apps all"
+    assert (
+        payload["coverage"]["public_demo_contract"]["ui_apps_covered_by"]
+        == "ui-robot-matrix explicit --apps"
+    )
+    assert payload["coverage"]["ui_robot_matrix_profile_apps"] == payload["coverage"][
+        "built_in_apps"
+    ]
     assert payload["coverage"]["public_demo_contract"]["apps_pages"] == [
         "view_maps",
         "view_forecast_analysis",

--- a/test/test_ui_robot_evidence.py
+++ b/test/test_ui_robot_evidence.py
@@ -11,6 +11,18 @@ import pytest
 
 
 MODULE_PATH = Path("tools/ui_robot_evidence.py").resolve()
+AGGREGATE_APPS = [
+    "data_quality_gate_project",
+    "execution_pandas_project",
+    "execution_polars_project",
+    "flight_telemetry_project",
+    "minimal_app_project",
+    "mission_decision_project",
+    "multi_app_dag_project",
+    "pytorch_playground_project",
+    "r_runtime_bridge_project",
+    "sklearn_pipeline_project",
+]
 
 
 def _load_module():
@@ -111,6 +123,7 @@ def _aggregate_report() -> dict[str, object]:
             "missing_shard_count": 0,
             "failed_shard_count": 0,
             "scenario_count": 16,
+            "apps": AGGREGATE_APPS,
             "app_count": 10,
             "page_count": 60,
             "widget_count": 900,
@@ -479,7 +492,191 @@ def test_load_aggregate_artifact_payloads_and_build_evidence_contract(tmp_path: 
     assert artifact_checks["aggregate_report_schema"] == module.AGGREGATE_REPORT_SCHEMA
     assert artifact_checks["screenshot_count"] == 42
     assert evidence["result"]["status"] == "pass"
+    assert evidence["result"]["apps"] == AGGREGATE_APPS
+    assert evidence["result"]["app_count"] == len(AGGREGATE_APPS)
     assert evidence["result"]["page_count"] == 60
+
+
+def test_aggregate_evidence_rejects_app_count_that_differs_from_exact_inventory(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    artifact_root = _write_aggregate_artifact_payloads(tmp_path)
+    aggregate_report = _aggregate_report()
+    aggregate_report["summary"] = {
+        **aggregate_report["summary"],
+        "app_count": len(AGGREGATE_APPS) + 1,
+    }
+    (artifact_root / "aggregate.json").write_text(
+        json.dumps(aggregate_report),
+        encoding="utf-8",
+    )
+
+    matrix_summary, scenario_summary, trend_report, artifact_checks = (
+        module.load_artifact_payloads(tmp_path)
+    )
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact={**_artifact(), "name": "ui-robot-matrix-aggregate-1"},
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        trend_report=trend_report,
+        artifact_checks=artifact_checks,
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    report = module.build_report(evidence)
+
+    assert evidence["result"]["apps"] == AGGREGATE_APPS
+    assert evidence["result"]["status"] == "fail"
+    assert "app_inventory" in {
+        check["id"] for check in report["checks"] if check["status"] == "fail"
+    }
+
+
+@pytest.mark.parametrize(
+    "raw_apps",
+    [
+        ["flight_telemetry_project", "data_quality_gate_project"],
+        ["data_quality_gate_project", "data_quality_gate_project"],
+        ["data_quality_gate_project", 7],
+        [" data_quality_gate_project"],
+        "data_quality_gate_project",
+        None,
+    ],
+)
+def test_aggregate_evidence_preserves_and_rejects_malformed_raw_app_inventory(
+    tmp_path: Path,
+    raw_apps: object,
+) -> None:
+    module = _load_module()
+    artifact_root = _write_aggregate_artifact_payloads(tmp_path)
+    aggregate_report = _aggregate_report()
+    aggregate_report["summary"] = {
+        **aggregate_report["summary"],
+        "apps": raw_apps,
+        "app_count": len(raw_apps) if isinstance(raw_apps, list) else 1,
+    }
+    (artifact_root / "aggregate.json").write_text(
+        json.dumps(aggregate_report),
+        encoding="utf-8",
+    )
+
+    matrix_summary, scenario_summary, trend_report, artifact_checks = (
+        module.load_artifact_payloads(tmp_path)
+    )
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact={**_artifact(), "name": "ui-robot-matrix-aggregate-1"},
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        trend_report=trend_report,
+        artifact_checks=artifact_checks,
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    inventory_check = next(
+        check for check in module.validate_evidence(evidence)
+        if check["id"] == "app_inventory"
+    )
+
+    assert matrix_summary["apps"] == raw_apps
+    assert scenario_summary["apps"] == raw_apps
+    assert evidence["result"]["apps"] == raw_apps
+    assert evidence["result"]["status"] == "fail"
+    assert inventory_check["status"] == "fail"
+    assert inventory_check["details"]["apps"] == raw_apps
+
+
+@pytest.mark.parametrize("raw_app_count", [str(len(AGGREGATE_APPS)), True])
+def test_aggregate_evidence_preserves_and_rejects_non_integer_raw_app_count(
+    tmp_path: Path,
+    raw_app_count: object,
+) -> None:
+    module = _load_module()
+    artifact_root = _write_aggregate_artifact_payloads(tmp_path)
+    aggregate_report = _aggregate_report()
+    aggregate_report["summary"] = {
+        **aggregate_report["summary"],
+        "app_count": raw_app_count,
+    }
+    (artifact_root / "aggregate.json").write_text(
+        json.dumps(aggregate_report),
+        encoding="utf-8",
+    )
+
+    matrix_summary, scenario_summary, trend_report, artifact_checks = (
+        module.load_artifact_payloads(tmp_path)
+    )
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact={**_artifact(), "name": "ui-robot-matrix-aggregate-1"},
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        trend_report=trend_report,
+        artifact_checks=artifact_checks,
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    inventory_check = next(
+        check for check in module.validate_evidence(evidence)
+        if check["id"] == "app_inventory"
+    )
+
+    assert matrix_summary["app_count"] == raw_app_count
+    assert scenario_summary["app_count"] == raw_app_count
+    assert evidence["result"]["app_count"] == raw_app_count
+    assert evidence["result"]["status"] == "fail"
+    assert inventory_check["status"] == "fail"
+
+
+def test_aggregate_evidence_requires_the_exact_app_inventory_even_when_empty(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    artifact_root = _write_aggregate_artifact_payloads(tmp_path)
+    aggregate_report = _aggregate_report()
+    summary = dict(aggregate_report["summary"])
+    summary.pop("apps")
+    summary["app_count"] = 0
+    aggregate_report["summary"] = summary
+    (artifact_root / "aggregate.json").write_text(
+        json.dumps(aggregate_report),
+        encoding="utf-8",
+    )
+
+    matrix_summary, scenario_summary, trend_report, artifact_checks = (
+        module.load_artifact_payloads(tmp_path)
+    )
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact={**_artifact(), "name": "ui-robot-matrix-aggregate-1"},
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        trend_report=trend_report,
+        artifact_checks=artifact_checks,
+        generated_at="2026-05-08T20:30:00Z",
+    )
+
+    inventory_check = next(
+        check for check in module.validate_evidence(evidence)
+        if check["id"] == "app_inventory"
+    )
+    assert "apps" not in evidence["result"]
+    assert evidence["result"]["status"] == "fail"
+    assert inventory_check["status"] == "fail"
+    assert inventory_check["details"]["aggregate_inventory_required"] is True
+
+
+def test_checked_historical_v1_evidence_remains_explicit_count_only_baseline() -> None:
+    module = _load_module()
+    evidence = module.load_evidence(Path("docs/source/data/ui_robot_evidence.json"))
+
+    inventory_check = next(
+        check for check in module.validate_evidence(evidence)
+        if check["id"] == "app_inventory"
+    )
+
+    assert inventory_check["status"] == "pass"
+    assert inventory_check["details"]["legacy_count_only"] is True
+    assert "count-only compatibility" in inventory_check["summary"]
 
 
 def test_load_aggregate_artifact_payloads_defaults_missing_exit_code_from_success(tmp_path: Path) -> None:

--- a/test/test_ui_robot_matrix_aggregate.py
+++ b/test/test_ui_robot_matrix_aggregate.py
@@ -35,41 +35,48 @@ def _write_shard(
     failed_count: int = 0,
     exit_code: str = "0",
     retry_artifacts: bool = False,
+    apps: list[str] | None = None,
+    app_count: int | None = None,
 ) -> Path:
     shard_root = _shard_result_dir(root, shard)
     shard_root.mkdir(parents=True)
-    (shard_root / "summary.json").write_text(
-        json.dumps(
-            {
-                "schema": "agilab.widget_robot_matrix.v1",
-                "success": success,
-                "scenario_count": 2,
-                "app_count": 3,
-                "page_count": 4,
-                "widget_count": 10,
-                "interacted_count": 6,
-                "probed_count": 4,
-                "skipped_count": 0,
-                "failed_count": failed_count,
-                "cached_count": 1,
-                "failure_artifact_retry_count": 1 if retry_artifacts else 0,
-                "failure_artifact_retry_passed_count": 0,
-                "duration_seconds": 12.5,
-                "failed_scenarios": [f"{shard}-scenario"] if failed_count else [],
-                "failure_samples": [
-                    {
-                        "scenario": f"{shard}-scenario",
-                        "app": "flight_telemetry_project",
-                        "page": "ORCHESTRATE",
-                        "kind": "button",
-                        "label": "Run",
-                        "detail": "failed",
-                    }
-                ]
-                if failed_count
-                else [],
-            }
+    summary = {
+        "schema": "agilab.widget_robot_matrix.v1",
+        "success": success,
+        "scenario_count": 2,
+        "app_count": (
+            app_count
+            if app_count is not None
+            else (len(apps) if apps is not None else 3)
         ),
+        "page_count": 4,
+        "widget_count": 10,
+        "interacted_count": 6,
+        "probed_count": 4,
+        "skipped_count": 0,
+        "failed_count": failed_count,
+        "cached_count": 1,
+        "failure_artifact_retry_count": 1 if retry_artifacts else 0,
+        "failure_artifact_retry_passed_count": 0,
+        "duration_seconds": 12.5,
+        "failed_scenarios": [f"{shard}-scenario"] if failed_count else [],
+        "failure_samples": [
+            {
+                "scenario": f"{shard}-scenario",
+                "app": "flight_telemetry_project",
+                "page": "ORCHESTRATE",
+                "kind": "button",
+                "label": "Run",
+                "detail": "failed",
+            }
+        ]
+        if failed_count
+        else [],
+    }
+    if apps is not None:
+        summary["apps"] = apps
+    (shard_root / "summary.json").write_text(
+        json.dumps(summary),
         encoding="utf-8",
     )
     (shard_root / "trend-report.json").write_text(
@@ -154,6 +161,88 @@ def test_build_aggregate_summarizes_all_shards(tmp_path: Path) -> None:
     assert report["summary"]["failure_artifact_retry_count"] == 0
     assert report["summary"]["trend"]["failed_page_count"] == 0
     assert "| core | PASS |" in markdown
+
+
+def test_build_aggregate_unions_partitioned_app_inventory(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_shard(
+        tmp_path,
+        "core-01",
+        apps=["data_quality_gate_project", "execution_pandas_project"],
+    )
+    _write_shard(
+        tmp_path,
+        "core-02",
+        apps=["flight_telemetry_project"],
+    )
+
+    report = module.build_aggregate(
+        tmp_path,
+        expected_shards=("core-01", "core-02"),
+        expected_apps=(
+            "data_quality_gate_project",
+            "execution_pandas_project",
+            "flight_telemetry_project",
+        ),
+    )
+
+    assert report["success"] is True
+    assert report["expected_apps"] == [
+        "data_quality_gate_project",
+        "execution_pandas_project",
+        "flight_telemetry_project",
+    ]
+    assert report["summary"]["apps"] == report["expected_apps"]
+    assert report["summary"]["app_count"] == 3
+    assert report["missing_apps"] == []
+    assert report["unexpected_apps"] == []
+    assert report["inventory_errors"] == []
+
+
+def test_build_aggregate_fails_closed_on_malformed_shard_inventory(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_shard(
+        tmp_path,
+        "core-01",
+        apps=["flight_telemetry_project", "data_quality_gate_project"],
+        app_count=3,
+    )
+
+    report = module.build_aggregate(
+        tmp_path,
+        expected_shards=("core-01",),
+        expected_apps=("data_quality_gate_project", "flight_telemetry_project"),
+    )
+
+    assert report["success"] is False
+    assert report["failed_shards"] == ["core-01"]
+    assert report["summary"]["apps"] == [
+        "data_quality_gate_project",
+        "flight_telemetry_project",
+    ]
+    assert report["summary"]["app_count"] == 3
+    assert any("sorted, unique" in error for error in report["inventory_errors"])
+    assert any("app_count 3" in error for error in report["inventory_errors"])
+
+
+def test_build_aggregate_fails_when_expected_inventory_is_unproven(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_shard(tmp_path, "core-01", apps=["data_quality_gate_project"])
+    _write_shard(tmp_path, "state-01")
+
+    report = module.build_aggregate(
+        tmp_path,
+        expected_shards=("core-01", "state-01"),
+        expected_apps=("data_quality_gate_project", "flight_telemetry_project"),
+    )
+    markdown = module.render_markdown(report)
+
+    assert report["success"] is False
+    assert report["missing_apps"] == ["flight_telemetry_project"]
+    assert report["unexpected_apps"] == []
+    assert any("state-01: summary is missing" in error for error in report["inventory_errors"])
+    assert any("expected apps are missing" in error for error in report["inventory_errors"])
+    assert "### App Inventory Errors" in markdown
 
 
 def test_build_aggregate_includes_extra_shards_after_expected_shards(tmp_path: Path) -> None:
@@ -575,6 +664,7 @@ def test_parse_expected_shards_uses_default_for_empty_input() -> None:
     module = _load_module()
 
     assert module._parse_expected_shards(" ,, ") == module.DEFAULT_EXPECTED_SHARDS
+    assert module._parse_expected_apps(" beta,alpha,beta ") == ("alpha", "beta")
 
 
 def test_module_entrypoint_writes_compact_aggregate(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/test/test_ui_robot_matrix_plan.py
+++ b/test/test_ui_robot_matrix_plan.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLAN_MODULE_PATH = Path("tools/ui_robot_matrix_plan.py").resolve()
+MATRIX_MODULE_PATH = Path("tools/agilab_widget_robot_matrix.py").resolve()
+EXPECTED_WORKFLOW_SCENARIOS = {
+    "isolated-core-pages",
+    "isolated-entry-and-app-pages",
+    "isolated-project-page",
+    "isolated-project-editor-page",
+    "isolated-project-notebook-import",
+    "isolated-project-import-sidebar",
+    "isolated-project-rename-sidebar",
+    "isolated-settings-page",
+    "isolated-all-builtins-orchestrate-smoke",
+    "isolated-execution-pandas-orchestrate-pool-executor",
+    "isolated-all-builtins-core-render-smoke",
+    "isolated-fresh-session-core-pages",
+    "isolated-browser-history",
+    "isolated-browser-error-core-pages",
+    "isolated-pytorch-playground-analysis",
+    "isolated-release-evidence",
+    "isolated-above-fold-core-pages",
+    "isolated-keyboard-focus-core-pages",
+    "isolated-accessibility-core-pages",
+    "isolated-layout-integrity-desktop",
+    "isolated-mobile-core-pages",
+    "isolated-layout-integrity-mobile",
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _scenario_names(plan) -> list[str]:
+    return [
+        scenario
+        for shard in plan["matrix"]["include"]
+        for scenario in str(shard["scenarios"]).split()
+    ]
+
+
+def _page_count(raw_pages: str) -> int:
+    if raw_pages == "none":
+        return 0
+    return len([item for item in raw_pages.split(",") if item.strip()])
+
+
+def test_current_all_app_plan_is_complete_bounded_and_deterministic() -> None:
+    planner = _load_module("ui_robot_matrix_plan_test_module", PLAN_MODULE_PATH)
+    matrix = _load_module("ui_robot_matrix_plan_matrix_module", MATRIX_MODULE_PATH)
+
+    plan = planner.build_plan()
+    filesystem_apps = sorted(
+        path.name
+        for path in planner.DEFAULT_APPS_ROOT.glob("*_project")
+        if path.is_dir()
+    )
+    shards = plan["matrix"]["include"]
+
+    assert filesystem_apps == [
+        "data_quality_gate_project",
+        "execution_pandas_project",
+        "execution_polars_project",
+        "flight_telemetry_project",
+        "minimal_app_project",
+        "mission_decision_project",
+        "multi_app_dag_project",
+        "pytorch_playground_project",
+        "r_runtime_bridge_project",
+        "sklearn_pipeline_project",
+        "tescia_diagnostic_project",
+        "uav_queue_project",
+        "uav_relay_queue_project",
+        "weather_forecast_project",
+    ]
+    assert plan["apps"] == filesystem_apps
+    assert plan["app_count"] == 14
+    assert plan["shard_count"] == 34
+    assert plan["estimated_page_count"] == 951
+    assert plan["max_estimated_pages"] == 32
+    assert max(int(shard["estimated_pages"]) for shard in shards) <= 32
+    assert plan["expected_shards"] == [str(shard["shard"]) for shard in shards]
+
+    planned_scenarios = set(_scenario_names(plan))
+    configured_scenarios = {
+        *planner.CORE_SCENARIOS,
+        *planner.STATE_MOBILE_SCENARIOS,
+        *planner.QUALITY_SCENARIOS,
+        *planner.LAYOUT_SCENARIOS,
+        *(scenario for scenario, _app in planner.FOCUSED_SCENARIOS),
+    }
+    assert configured_scenarios == EXPECTED_WORKFLOW_SCENARIOS
+    assert planned_scenarios == EXPECTED_WORKFLOW_SCENARIOS
+    assert planned_scenarios <= set(matrix.ALL_SCENARIOS)
+    assert sum(_page_count(matrix.ALL_SCENARIOS[name].pages) for name in planner.CORE_SCENARIOS) == 12
+    assert (
+        sum(_page_count(matrix.ALL_SCENARIOS[name].pages) for name in planner.STATE_MOBILE_SCENARIOS)
+        == 9
+    )
+    assert sum(_page_count(matrix.ALL_SCENARIOS[name].pages) for name in planner.QUALITY_SCENARIOS) == 32
+    assert sum(_page_count(matrix.ALL_SCENARIOS[name].pages) for name in planner.LAYOUT_SCENARIOS) == 14
+
+    prefix_scenarios = {
+        "core": planner.CORE_SCENARIOS,
+        "state-mobile": planner.STATE_MOBILE_SCENARIOS,
+        "quality": planner.QUALITY_SCENARIOS,
+        "layout": planner.LAYOUT_SCENARIOS,
+    }
+    for prefix, scenarios in prefix_scenarios.items():
+        covered_apps = [
+            app
+            for shard in shards
+            if str(shard["shard"]).startswith(f"{prefix}-")
+            for app in str(shard["apps"]).split(",")
+        ]
+        assert sorted(covered_apps) == filesystem_apps
+        assert len(covered_apps) == len(set(covered_apps))
+        for scenario in scenarios:
+            assert _scenario_names(plan).count(scenario) == len(
+                [shard for shard in shards if str(shard["shard"]).startswith(f"{prefix}-")]
+            )
+
+    for scenario, _app in planner.FOCUSED_SCENARIOS:
+        assert _scenario_names(plan).count(scenario) == 1
+
+
+def test_subset_plan_excludes_unrequested_apps_and_focused_overrides() -> None:
+    planner = _load_module("ui_robot_matrix_plan_subset_module", PLAN_MODULE_PATH)
+
+    plan = planner.build_plan(
+        requested_apps="pytorch_playground,flight_telemetry_project"
+    )
+    selected = {"flight_telemetry_project", "pytorch_playground_project"}
+    shards = plan["matrix"]["include"]
+    focused = next(shard for shard in shards if shard["shard"] == "focused")
+
+    assert plan["apps"] == sorted(selected)
+    assert all(set(str(shard["apps"]).split(",")) <= selected for shard in shards)
+    assert focused["scenarios"] == "isolated-pytorch-playground-analysis"
+    assert "execution_pandas_project" not in focused["apps"]
+    assert _scenario_names(plan).count("isolated-pytorch-playground-analysis") == 1
+    assert "isolated-execution-pandas-orchestrate-pool-executor" not in _scenario_names(plan)
+
+
+def test_plan_rejects_unknown_empty_and_overweight_inventory(tmp_path: Path) -> None:
+    planner = _load_module("ui_robot_matrix_plan_errors_module", PLAN_MODULE_PATH)
+    apps_root = tmp_path / "builtin"
+    app_dir = apps_root / "demo_project" / "src"
+    app_dir.mkdir(parents=True)
+    (app_dir / "app_settings.toml").write_text(
+        "[pages]\nview_module = [\"view_a\", \"view_b\"]\n",
+        encoding="utf-8",
+    )
+
+    assert planner.configured_apps_page_count(app_dir.parent) == 2
+    with pytest.raises(ValueError, match="unknown built-in app"):
+        planner.build_plan(requested_apps="missing", apps_root=apps_root)
+    with pytest.raises(ValueError, match="no built-in apps"):
+        planner.build_plan(apps_root=tmp_path / "empty")
+    with pytest.raises(ValueError, match="maximum is 10 pages"):
+        planner.build_plan(apps_root=apps_root, max_estimated_pages=10)
+
+
+def test_plan_cli_writes_compact_json_and_github_outputs(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    planner = _load_module("ui_robot_matrix_plan_cli_module", PLAN_MODULE_PATH)
+    output = tmp_path / "plan.json"
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    exit_code = planner.main(
+        [
+            "--apps",
+            "flight_telemetry_project",
+            "--output",
+            str(output),
+            "--github-output",
+            "--compact",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    outputs = dict(
+        line.split("=", 1)
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+    )
+    assert exit_code == 0
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+    assert json.loads(outputs["matrix"]) == payload["matrix"]
+    assert outputs["expected_apps"] == "flight_telemetry_project"
+    assert outputs["expected_shards"] == ",".join(payload["expected_shards"])

--- a/test/test_ui_robot_matrix_plan.py
+++ b/test/test_ui_robot_matrix_plan.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-PLAN_MODULE_PATH = Path("tools/ui_robot_matrix_plan.py").resolve()
+PLAN_MODULE_PATH = Path("tools/testing/ui_robot_matrix_plan.py").resolve()
 MATRIX_MODULE_PATH = Path("tools/agilab_widget_robot_matrix.py").resolve()
 EXPECTED_WORKFLOW_SCENARIOS = {
     "isolated-core-pages",

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 MODULE_PATH = Path("tools/workflow_parity.py").resolve()
 WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 SHARD_PLAN_PATH = Path("tools/coverage_shard_plan.py").resolve()
+UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/ui_robot_matrix_plan.py").resolve()
 
 
 def _has_with_dependency(argv: list[str], dependency: str) -> bool:
@@ -70,6 +71,18 @@ def _coverage_workflow_agi_gui_targets() -> dict[str, list[str]]:
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module.static_chunk_args()
+
+
+def _ui_robot_matrix_plan() -> dict[str, object]:
+    spec = importlib.util.spec_from_file_location(
+        "workflow_parity_ui_robot_matrix_plan_test_module",
+        UI_ROBOT_MATRIX_PLAN_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.build_plan()
 
 
 def _parity_agi_gui_targets(module) -> dict[str, list[str]]:
@@ -500,40 +513,14 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "screenshots/ui-frontend-smoke" in ui_frontend_smoke.argv
     assert _has_extra(ui_frontend_smoke.argv, "ui")
     assert _has_with_dependency(ui_frontend_smoke.argv, "playwright")
-    assert set(ui_robot_matrix) == {"core", "state", "quality", "layout"}
-    expected_matrix_scenarios = {
-        "core": {
-            "isolated-core-pages",
-            "isolated-entry-and-app-pages",
-            "isolated-project-page",
-            "isolated-project-editor-page",
-            "isolated-project-notebook-import",
-            "isolated-project-import-sidebar",
-            "isolated-project-rename-sidebar",
-            "isolated-settings-page",
-            "isolated-all-builtins-orchestrate-smoke",
-            "isolated-execution-pandas-orchestrate-pool-executor",
-            "isolated-all-builtins-core-render-smoke",
-        },
-        "state": {
-            "isolated-fresh-session-core-pages",
-            "isolated-browser-history",
-        },
-        "quality": {
-            "isolated-browser-error-core-pages",
-            "isolated-pytorch-playground-analysis",
-            "isolated-release-evidence",
-            "isolated-above-fold-core-pages",
-            "isolated-keyboard-focus-core-pages",
-            "isolated-accessibility-core-pages",
-        },
-        "layout": {
-            "isolated-layout-integrity-desktop",
-            "isolated-mobile-core-pages",
-            "isolated-layout-integrity-mobile",
-        },
+    matrix_plan = _ui_robot_matrix_plan()
+    expected_matrix_rows = {
+        str(row["shard"]): row
+        for row in matrix_plan["matrix"]["include"]
     }
+    assert set(ui_robot_matrix) == set(expected_matrix_rows)
     for shard, command in ui_robot_matrix.items():
+        expected_row = expected_matrix_rows[shard]
         assert command.label == f"ui robot matrix ({shard})"
         assert command.timeout_seconds == 50 * 60
         assert command.remove_paths == [
@@ -541,9 +528,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             f"screenshots/ui-robot-matrix/{shard}",
         ]
         assert "tools/agilab_widget_robot_matrix.py" in command.argv
-        assert expected_matrix_scenarios[shard] == set(
+        assert set(str(expected_row["scenarios"]).split()) == set(
             _option_values(command.argv, "--scenario")
         )
+        assert _option_values(command.argv, "--apps") == [expected_row["apps"]]
         assert "--quiet-progress" in command.argv
         assert "--json" in command.argv
         assert "--no-result-cache" in command.argv

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 MODULE_PATH = Path("tools/workflow_parity.py").resolve()
 WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 SHARD_PLAN_PATH = Path("tools/coverage_shard_plan.py").resolve()
-UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/ui_robot_matrix_plan.py").resolve()
+UI_ROBOT_MATRIX_PLAN_PATH = Path("tools/testing/ui_robot_matrix_plan.py").resolve()
 
 
 def _has_with_dependency(argv: list[str], dependency: str) -> bool:

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -21,7 +21,7 @@ import urllib.parse
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -492,12 +492,52 @@ ACTIVE_FOCUS_STATE_JS = r"""
 LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
 () => {
   const clean = (value) => String(value || "").trim().replace(/\s+/g, " ");
-  const visible = (el) => {
-    if (el.closest("details:not([open])") && !el.closest("summary")) return false;
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+  const clips = (value) => ["auto", "clip", "hidden", "scroll"].includes(value);
+  const paintedRect = (el) => {
+    const raw = el.getBoundingClientRect();
+    if (raw.width <= 0 || raw.height <= 0) return null;
+    const rect = {left: raw.left, right: raw.right, top: raw.top, bottom: raw.bottom};
+    for (let current = el; current; current = current.parentElement) {
+      const style = window.getComputedStyle(current);
+      if (
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        style.visibility === "collapse" ||
+        style.contentVisibility === "hidden" ||
+        Number(style.opacity || "1") <= 0.01
+      ) {
+        return null;
+      }
+      if (current.tagName === "DETAILS" && !current.open) {
+        const summary = Array.from(current.children).find((child) => child.tagName === "SUMMARY");
+        if (!summary || !summary.contains(el)) return null;
+      }
+      if (current === el || current === document.body || current === document.documentElement) continue;
+      const contain = String(style.contain || "").split(/\s+/);
+      const clipX = clips(style.overflowX) || contain.some((value) => ["content", "paint", "strict"].includes(value));
+      const clipY = clips(style.overflowY) || contain.some((value) => ["content", "paint", "strict"].includes(value));
+      if (!clipX && !clipY) continue;
+      const ancestor = current.getBoundingClientRect();
+      if (clipX) {
+        rect.left = Math.max(rect.left, ancestor.left);
+        rect.right = Math.min(rect.right, ancestor.right);
+      }
+      if (clipY) {
+        rect.top = Math.max(rect.top, ancestor.top);
+        rect.bottom = Math.min(rect.bottom, ancestor.bottom);
+      }
+      if (rect.right <= rect.left || rect.bottom <= rect.top) return null;
+    }
+    return {
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      bottom: rect.bottom,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+    };
   };
+  const visible = (el) => paintedRect(el) !== null;
   const labelFor = (el) => clean(
     el.getAttribute("aria-label") ||
     el.getAttribute("title") ||
@@ -530,7 +570,8 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
   ].join(", ");
   const controls = Array.from(document.querySelectorAll(controlSelector)).filter(visible);
   for (const el of controls) {
-    const rect = el.getBoundingClientRect();
+    const rect = paintedRect(el);
+    if (!rect) continue;
     if (rect.width < 2 || rect.height < 2) {
       push("zero_size_control", el, `control rendered at ${rect.width.toFixed(1)}x${rect.height.toFixed(1)}`);
     }
@@ -558,7 +599,9 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
     const y = Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
     return x * y;
   };
-  const rects = controls.map((el) => ({el, rect: el.getBoundingClientRect(), label: labelFor(el)}));
+  const rects = controls
+    .map((el) => ({el, rect: paintedRect(el), label: labelFor(el)}))
+    .filter((item) => item.rect !== null);
   for (let i = 0; i < rects.length; i += 1) {
     for (let j = i + 1; j < rects.length; j += 1) {
       const a = rects[i];
@@ -1141,6 +1184,10 @@ class WidgetSweepSummary:
     target_seconds: float
     within_target: bool
     app_count: int
+    apps: list[str]
+    covered_apps: list[str]
+    missing_apps: list[str]
+    unexpected_apps: list[str]
     page_count: int
     widget_count: int
     interacted_count: int
@@ -1310,10 +1357,17 @@ def load_completed_page_results(progress_log: Path) -> dict[str, PageSweep]:
     return completed
 
 
-def write_summary_json(path: Path, pages: Sequence[PageSweep], *, app_count: int, target_seconds: float) -> None:
+def write_summary_json(
+    path: Path,
+    pages: Sequence[PageSweep],
+    *,
+    app_count: int,
+    target_seconds: float,
+    apps: Sequence[Path | str] | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_name(f"{path.name}.tmp")
-    summary = summarize(pages, app_count=app_count, target_seconds=target_seconds)
+    summary = summarize(pages, app_count=app_count, target_seconds=target_seconds, apps=apps)
     tmp_path.write_text(json.dumps(asdict(summary), indent=2) + "\n", encoding="utf-8")
     tmp_path.replace(path)
 
@@ -6764,17 +6818,51 @@ def sweep_remote_app(  # pragma: no cover - live browser path
     return results
 
 
-def summarize(pages: Sequence[PageSweep], *, app_count: int, target_seconds: float) -> WidgetSweepSummary:
+def summarize(
+    pages: Sequence[PageSweep],
+    *,
+    app_count: int,
+    target_seconds: float,
+    apps: Sequence[Path | str] | None = None,
+) -> WidgetSweepSummary:
     total = sum(page.duration_seconds for page in pages)
     failed_count = sum(page.failed_count for page in pages)
     skipped_count = sum(page.skipped_count for page in pages)
-    success = bool(pages) and failed_count == 0 and all(page.failed_count == 0 and page.status != "failed" for page in pages)
+    selected_apps = sorted(
+        {
+            active_app_slug(str(app))
+            for app in apps
+        }
+        if apps is not None
+        else {page.app for page in pages if page.app}
+    )
+    covered_apps = sorted(
+        {
+            page.app.strip()
+            for page in pages
+            if isinstance(page.app, str) and page.app.strip()
+        }
+    )
+    missing_apps = sorted(set(selected_apps) - set(covered_apps))
+    unexpected_apps = sorted(set(covered_apps) - set(selected_apps))
+    exact_app_coverage = apps is None or (not missing_apps and not unexpected_apps)
+    success = (
+        bool(pages)
+        and failed_count == 0
+        and all(page.failed_count == 0 and page.status != "failed" for page in pages)
+        and exact_app_coverage
+    )
+    selected_app_count = len(selected_apps) if apps is not None else app_count
     return WidgetSweepSummary(
         success=success,
         total_duration_seconds=total,
         target_seconds=target_seconds,
         within_target=success and total <= target_seconds,
-        app_count=app_count,
+        app_count=selected_app_count,
+        apps=selected_apps,
+        covered_apps=covered_apps,
+        missing_apps=missing_apps,
+        unexpected_apps=unexpected_apps,
         page_count=len(pages),
         widget_count=sum(page.widget_count for page in pages),
         main_widget_count=sum(page.main_widget_count for page in pages),
@@ -6901,6 +6989,10 @@ def render_human(summary: WidgetSweepSummary) -> str:
         f"verdict: {'PASS' if summary.success else 'FAIL'}",
         f"kpi: total={summary.total_duration_seconds:.2f}s target<={summary.target_seconds:.2f}s within_target={'yes' if summary.within_target else 'no'}",
         f"apps={summary.app_count} pages={summary.page_count} widgets={summary.widget_count} main={summary.main_widget_count} sidebar={summary.sidebar_widget_count} interacted={summary.interacted_count} probed={summary.probed_count} skipped={summary.skipped_count} failed={summary.failed_count}",
+        "coverage: "
+        f"covered={','.join(summary.covered_apps) or '-'} "
+        f"missing={','.join(summary.missing_apps) or '-'} "
+        f"unexpected={','.join(summary.unexpected_apps) or '-'}",
         f"combinations: space={summary.combination_space_count} executed={summary.combination_count} failed={summary.combination_failed_count} skipped={summary.combination_skipped_count}",
     ]
     for page in summary.pages:
@@ -6977,7 +7069,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
     def on_page_result(page: PageSweep) -> None:
         results.append(page)
         if json_output is not None:
-            write_summary_json(json_output, results, app_count=len(apps), target_seconds=args.target_seconds)
+            write_summary_json(
+                json_output,
+                results,
+                app_count=len(apps),
+                target_seconds=args.target_seconds,
+                apps=apps,
+            )
 
     progress.emit("run_start", app_count=len(apps), page_count=expected_page_count)
     for app, app_pages in app_specs:
@@ -7093,9 +7191,15 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
                 resume_page_results=resume_page_results,
                 on_page_result=on_page_result,
             )
-    summary = summarize(results, app_count=len(apps), target_seconds=args.target_seconds)
+    summary = summarize(results, app_count=len(apps), target_seconds=args.target_seconds, apps=apps)
     if json_output is not None:
-        write_summary_json(json_output, results, app_count=len(apps), target_seconds=args.target_seconds)
+        write_summary_json(
+            json_output,
+            results,
+            app_count=len(apps),
+            target_seconds=args.target_seconds,
+            apps=apps,
+        )
     progress.emit(
         "run_done",
         status="passed" if summary.success else "failed",

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -1485,16 +1485,115 @@ def run_matrix(
     return results
 
 
+def _legacy_summary_apps(summary: dict) -> list[str]:
+    pages = summary.get("pages")
+    if not isinstance(pages, list):
+        return []
+    return sorted(
+        {
+            app_name
+            for page in pages
+            if isinstance(page, dict)
+            and (app_name := str(page.get("app") or "").strip())
+        }
+    )
+
+
+def _summary_app_inventory(
+    summary: dict,
+    *,
+    scenario: str,
+) -> tuple[list[str], int, bool, list[str]]:
+    """Return a proven inventory without repairing malformed exact metadata."""
+
+    if "apps" in summary:
+        raw_apps = summary.get("apps")
+        raw_count = summary.get("app_count")
+        errors: list[str] = []
+        if not isinstance(raw_apps, list):
+            errors.append(f"{scenario}: summary apps must be a list")
+            apps: list[str] = []
+        else:
+            apps = sorted(
+                {
+                    item.strip()
+                    for item in raw_apps
+                    if isinstance(item, str) and item.strip()
+                }
+            )
+            if raw_apps != apps:
+                errors.append(
+                    f"{scenario}: summary apps must be sorted, unique, non-empty strings"
+                )
+        if type(raw_count) is not int:
+            errors.append(f"{scenario}: summary app_count must be an integer")
+            declared_count = 0
+        else:
+            declared_count = raw_count
+            if declared_count != len(apps):
+                errors.append(
+                    f"{scenario}: summary app_count {declared_count} does not match "
+                    f"the {len(apps)} listed apps"
+                )
+        return (apps if not errors else []), declared_count, True, errors
+
+    apps = _legacy_summary_apps(summary)
+    try:
+        declared_count = int(summary.get("app_count") or 0)
+    except (TypeError, ValueError):
+        declared_count = 0
+    return apps, max(0, declared_count, len(apps)), False, []
+
+
+def _matrix_app_inventory(
+    results: Sequence[ScenarioResult],
+) -> tuple[int, list[str], list[list[str]]]:
+    inventories = [
+        _summary_app_inventory(result.summary, scenario=result.scenario.name)
+        for result in results
+    ]
+    apps = sorted(
+        {
+            app_name
+            for inventory, _count, _present, errors in inventories
+            if not errors
+            for app_name in inventory
+        }
+    )
+    # A matrix frequently combines a complete ``apps=all`` sweep with focused
+    # scenario overrides. Explicit inventories are authoritative and their
+    # union counts disjoint cohorts exactly. The largest count from a legacy
+    # summary remains a conservative fallback without multiplying repeated
+    # sweeps. Invalid exact metadata contributes no unproven app names.
+    legacy_declared_count = max(
+        (count for _apps, count, present, errors in inventories if not present and not errors),
+        default=0,
+    )
+    inventory_errors = [errors for _apps, _count, _present, errors in inventories]
+    return max(legacy_declared_count, len(apps)), apps, inventory_errors
+
+
 def summarize_matrix(results: Sequence[ScenarioResult]) -> dict:
     summaries = [result.summary for result in results]
+    app_count, apps, scenario_inventory_errors = _matrix_app_inventory(results)
+    inventory_errors = [
+        error
+        for errors in scenario_inventory_errors
+        for error in errors
+    ]
     success = bool(results) and all(
-        result.returncode == 0 and result.summary.get("success") is True
-        for result in results
+        result.returncode == 0
+        and result.summary.get("success") is True
+        and not scenario_inventory_errors[index]
+        for index, result in enumerate(results)
     )
     return {
         "schema": SCHEMA,
         "success": success,
         "scenario_count": len(results),
+        "app_count": app_count,
+        "apps": apps,
+        "inventory_errors": inventory_errors,
         "page_count": sum(int(summary.get("page_count") or 0) for summary in summaries),
         "widget_count": sum(int(summary.get("widget_count") or 0) for summary in summaries),
         "interacted_count": sum(int(summary.get("interacted_count") or 0) for summary in summaries),
@@ -1513,20 +1612,43 @@ def summarize_matrix(results: Sequence[ScenarioResult]) -> dict:
         ),
         "failed_scenarios": [
             result.scenario.name
-            for result in results
-            if result.returncode != 0 or result.summary.get("success") is not True
+            for index, result in enumerate(results)
+            if (
+                result.returncode != 0
+                or result.summary.get("success") is not True
+                or scenario_inventory_errors[index]
+            )
         ],
         "failure_samples": _failure_samples(results),
         "scenarios": [
             {
                 "name": result.scenario.name,
                 "description": result.scenario.description,
-                "success": result.returncode == 0 and result.summary.get("success") is True,
+                "success": (
+                    result.returncode == 0
+                    and result.summary.get("success") is True
+                    and not scenario_inventory_errors[index]
+                ),
                 "returncode": result.returncode,
                 "duration_seconds": result.duration_seconds,
                 "cached": result.cached,
                 "summary_path": str(result.summary_path),
                 "progress_path": str(result.progress_path),
+                "app_count": result.summary.get(
+                    "app_count",
+                    _summary_app_inventory(
+                        result.summary,
+                        scenario=result.scenario.name,
+                    )[1],
+                ),
+                "apps": result.summary.get(
+                    "apps",
+                    _summary_app_inventory(
+                        result.summary,
+                        scenario=result.scenario.name,
+                    )[0],
+                ),
+                "inventory_errors": scenario_inventory_errors[index],
                 "page_count": int(result.summary.get("page_count") or 0),
                 "widget_count": int(result.summary.get("widget_count") or 0),
                 "interacted_count": int(result.summary.get("interacted_count") or 0),
@@ -1535,7 +1657,7 @@ def summarize_matrix(results: Sequence[ScenarioResult]) -> dict:
                 "failed_count": int(result.summary.get("failed_count") or 0),
                 "failure_artifact_retry": _failure_artifact_retry_summary(result.artifact_retry),
             }
-            for result in results
+            for index, result in enumerate(results)
         ],
     }
 

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -573,7 +573,7 @@ def _local_tag_commit(repo_root: Path, tag: str) -> str | None:
     return _run_git(repo_root, ["rev-list", "-n", "1", tag])
 
 
-def _local_release_app_count(repo_root: Path, release_ref: str) -> int | None:
+def _local_release_apps(repo_root: Path, release_ref: str) -> list[str] | None:
     if not release_ref:
         return None
     output = _run_git(
@@ -582,7 +582,18 @@ def _local_release_app_count(repo_root: Path, release_ref: str) -> int | None:
     )
     if output is None:
         return None
-    return len([line for line in output.splitlines() if line.strip()])
+    return sorted(
+        {
+            line.strip()
+            for line in output.splitlines()
+            if line.strip().endswith("_project")
+        }
+    )
+
+
+def _local_release_app_count(repo_root: Path, release_ref: str) -> int | None:
+    apps = _local_release_apps(repo_root, release_ref)
+    return len(apps) if apps is not None else None
 
 
 def _github_repo_base_url(repo_root: Path) -> str | None:
@@ -1061,6 +1072,24 @@ def _ui_robot_evidence_check(
     expected_app_count = ui_robot.get("expected_app_count")
     evidence_head_sha = str(source.get("head_sha", "") or "").strip()
     evidence_app_count = result.get("app_count")
+    raw_evidence_apps = result.get("apps")
+    evidence_apps = (
+        list(raw_evidence_apps)
+        if isinstance(raw_evidence_apps, list)
+        and raw_evidence_apps == sorted(
+            {
+                app.strip()
+                for app in raw_evidence_apps
+                if isinstance(app, str) and app.strip()
+            }
+        )
+        else None
+    )
+    release_ref = str(release.get("github_release_tag", "") or "").strip()
+    local_release_apps = _local_release_apps(repo_root, release_ref)
+    exact_app_inventory_matches = (
+        local_release_apps is not None and evidence_apps == local_release_apps
+    )
     if mode not in UI_ROBOT_EVIDENCE_MODES:
         failures.append(
             "manifest: ui_robot.mode must be one of "
@@ -1075,6 +1104,7 @@ def _ui_robot_evidence_check(
         and bool(expected_release_commit)
         and evidence_head_sha == expected_release_commit
         and evidence_app_count == expected_app_count
+        and exact_app_inventory_matches
     )
     if mode == "release":
         if not expected_release_commit:
@@ -1088,6 +1118,18 @@ def _ui_robot_evidence_check(
         if evidence_app_count != expected_app_count:
             failures.append(
                 "release: UI evidence app_count does not match ui_robot.expected_app_count"
+            )
+        if local_release_apps is None:
+            failures.append(
+                "release: exact app inventory is unavailable from the local release tag tree"
+            )
+        elif evidence_apps is None:
+            failures.append(
+                "release: UI evidence does not record a sorted, unique exact app inventory"
+            )
+        elif evidence_apps != local_release_apps:
+            failures.append(
+                "release: UI evidence apps do not match the release tag inventory"
             )
     github_run: dict[str, Any] | None = None
     if check_github_runs:
@@ -1145,9 +1187,12 @@ def _ui_robot_evidence_check(
             "run_url": source.get("run_url", ""),
             "head_sha": source.get("head_sha", ""),
             "app_count": result.get("app_count", 0),
+            "apps": evidence_apps,
             "mode": mode,
             "expected_release_commit": expected_release_commit,
             "expected_app_count": expected_app_count,
+            "local_release_apps": local_release_apps,
+            "exact_app_inventory_matches": exact_app_inventory_matches,
             "represents_release": represented_release,
             "page_count": result.get("page_count", 0),
             "widget_count": result.get("widget_count", 0),

--- a/tools/sync_docs_source.py
+++ b/tools/sync_docs_source.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import errno
 import hashlib
+import importlib.util
 import json
 import os
 import secrets
@@ -38,11 +39,15 @@ PUBLIC_OWNED_EXCLUSIONS = frozenset(
         "release-proof.rst",
     }
 )
+UI_ROBOT_EVIDENCE_PUBLIC_OWNED = "data/ui_robot_evidence.json"
 RELEASE_REFRESHABLE_PUBLIC_OWNED = frozenset(
     {
         "data/release_proof.toml",
         "release-proof.rst",
     }
+)
+UI_ROBOT_REFRESHABLE_PUBLIC_OWNED = frozenset(
+    {UI_ROBOT_EVIDENCE_PUBLIC_OWNED}
 )
 CANONICAL_DRIFT_NOT_CHECKED = (
     "canonical docs source unavailable; target integrity only; "
@@ -1107,7 +1112,7 @@ def _validate_public_owned_rebaseline(
     *,
     stamp_path: Path,
     allowed_changes: frozenset[str],
-) -> None:
+) -> set[str]:
     previous_files = stamp.get("public_owned_files_sha256")
     if not isinstance(previous_files, dict) or not all(
         isinstance(path, str) and isinstance(digest, str)
@@ -1127,6 +1132,56 @@ def _validate_public_owned_rebaseline(
             "refusing to re-baseline public-owned evidence not allowed by this "
             "operation: " + ", ".join(forbidden_changes)
         )
+    return changed_public_files
+
+
+def _validate_ui_robot_evidence_at_boundary(
+    boundary: PinnedMutationBoundary,
+    *,
+    expected_digest: str,
+) -> None:
+    evidence_path = boundary.target / UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+    with _pinned_destination_parent(
+        boundary,
+        evidence_path,
+        create=False,
+    ) as parent:
+        content, fingerprint = _read_regular_at(
+            parent,
+            parent.leaf_name,
+            label="UI robot evidence",
+        )
+    if fingerprint[-1] != expected_digest:
+        raise ValueError(
+            "UI robot evidence changed between target-state capture and validation"
+        )
+    validator_path = Path(__file__).with_name("ui_robot_evidence.py")
+    validator_spec = importlib.util.spec_from_file_location(
+        "agilab_ui_robot_evidence_validator",
+        validator_path,
+    )
+    if validator_spec is None or validator_spec.loader is None:
+        raise RuntimeError(
+            f"unable to load UI robot evidence validator: {validator_path}"
+        )
+    validator = importlib.util.module_from_spec(validator_spec)
+    validator_spec.loader.exec_module(validator)
+    with tempfile.TemporaryDirectory(prefix="agilab-ui-robot-validation-") as temp:
+        validation_path = Path(temp) / "ui_robot_evidence.json"
+        validation_path.write_bytes(content)
+        try:
+            evidence = validator.load_evidence(validation_path)
+        except (OSError, UnicodeError, ValueError) as exc:
+            raise ValueError(f"invalid UI robot evidence: {exc}") from exc
+    checks = validator.validate_evidence(evidence)
+    failed_checks = [
+        str(check.get("id") or "unknown")
+        for check in checks
+        if check.get("status") != "pass"
+    ]
+    if not checks or failed_checks:
+        details = ", ".join(failed_checks) if failed_checks else "no checks returned"
+        raise ValueError(f"UI robot evidence validation failed: {details}")
 
 
 def _validate_existing_public_evidence_before_full_sync(
@@ -1173,16 +1228,20 @@ def _validate_existing_public_evidence_before_full_sync(
     return public_files
 
 
-def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
-    """Refresh public integrity while preserving valid managed provenance.
-
-    Only release-proof files may change during this refresh. Other public-owned
-    evidence, including UI robot evidence, must still match its previous v3
-    per-file digest. Missing, malformed, legacy-v1, or stale managed evidence
-    fails closed and requires an explicit recovery operation.
-    """
-
+def _refresh_target_integrity_stamp(
+    target: Path,
+    *,
+    allowed_changes: frozenset[str],
+    operation_description: str,
+    source: Path | None = None,
+    required_existing_path: str | None = None,
+    require_passing_ui_robot_evidence: bool = False,
+) -> tuple[Path, bool]:
     with _pinned_mutation_boundary(target) as boundary:
+        if source is not None:
+            if not source.is_dir():
+                raise ValueError(f"canonical docs source is not a directory: {source}")
+            _ensure_disjoint_directories(source, boundary.target)
         stamp_path = stamp_path_for_target(boundary.target)
         previous = _capture_regular_stamp(stamp_path, boundary=boundary)
         stamp = _stamp_object_from_snapshot(previous, stamp_path)
@@ -1212,14 +1271,69 @@ def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
         if not managed_ok:
             raise ValueError(
                 message
-                + "; refusing to re-baseline changed managed docs during a release refresh"
+                + "; refusing to re-baseline changed managed docs during "
+                + operation_description
             )
-        _validate_public_owned_rebaseline(
+        if source is not None:
+            if stamp.get("source_status") != "verified":
+                raise ValueError(
+                    f"{operation_description} requires verified canonical-source "
+                    f"provenance in {stamp_path}"
+                )
+            source_state = _stable_manifest_state(source)
+            if (
+                source_state["digest_sha256"] != stamp.get("source_digest_sha256")
+                or source_state["file_count"] != stamp.get("file_count")
+            ):
+                raise ValueError(
+                    f"canonical source drift for {source}: stamp expected digest "
+                    f"{stamp.get('source_digest_sha256')} and file_count "
+                    f"{stamp.get('file_count')}, got {source_state['digest_sha256']} "
+                    f"and {source_state['file_count']}"
+                )
+            if source_state != target_state:
+                raise ValueError(
+                    "canonical source and managed mirror target differ; refusing "
+                    f"{operation_description}"
+                )
+        changed_public_files = _validate_public_owned_rebaseline(
             stamp,
             public_owned_files,
             stamp_path=stamp_path,
-            allowed_changes=RELEASE_REFRESHABLE_PUBLIC_OWNED,
+            allowed_changes=allowed_changes,
         )
+        if required_existing_path is not None:
+            previous_files = stamp.get("public_owned_files_sha256")
+            if (
+                not isinstance(previous_files, dict)
+                or required_existing_path not in previous_files
+                or required_existing_path not in public_owned_files
+            ):
+                raise ValueError(
+                    f"{operation_description} requires an existing stamped "
+                    f"{required_existing_path} file; creation or deletion cannot be "
+                    "re-baselined"
+                )
+            if changed_public_files not in (
+                set(),
+                {required_existing_path},
+            ):
+                raise ValueError(
+                    f"{operation_description} may refresh only "
+                    f"{required_existing_path}"
+                )
+        if require_passing_ui_robot_evidence:
+            evidence_digest = public_owned_files.get(
+                UI_ROBOT_EVIDENCE_PUBLIC_OWNED
+            )
+            if not isinstance(evidence_digest, str):
+                raise ValueError(
+                    "UI robot evidence refresh requires a captured evidence digest"
+                )
+            _validate_ui_robot_evidence_at_boundary(
+                boundary,
+                expected_digest=evidence_digest,
+            )
         source_status = str(stamp["source_status"])
         raw_source_digest = stamp.get("source_digest_sha256")
         source_digest = (
@@ -1237,7 +1351,7 @@ def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
             ok, verification_message = _verify_payload_at_boundary(
                 boundary,
                 payload,
-                source=None,
+                source=source,
             )
             if not ok:
                 raise ValueError(
@@ -1258,7 +1372,7 @@ def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
             lambda: _verify_payload_at_boundary(
                 boundary,
                 payload,
-                source=None,
+                source=source,
             ),
         )
         # Verified provenance is intentionally preserved without re-reading the
@@ -1267,6 +1381,43 @@ def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
         if final.content != _render_stamp_payload(payload):
             raise ValueError("refreshed mirror stamp changed after publication")
         return stamp_path, True
+
+
+def refresh_target_integrity_stamp(target: Path) -> tuple[Path, bool]:
+    """Refresh release-proof integrity while preserving managed provenance.
+
+    Only release-proof files may change during this refresh. Other public-owned
+    evidence, including UI robot evidence, must still match its previous v3
+    per-file digest. Missing, malformed, legacy-v1, or stale managed evidence
+    fails closed and requires an explicit recovery operation.
+    """
+
+    return _refresh_target_integrity_stamp(
+        target,
+        allowed_changes=RELEASE_REFRESHABLE_PUBLIC_OWNED,
+        operation_description="a release refresh",
+    )
+
+
+def refresh_ui_robot_evidence_stamp(
+    source: Path,
+    target: Path,
+) -> tuple[Path, bool]:
+    """Refresh only an existing UI-robot evidence digest.
+
+    This operation requires live canonical-source alignment and verified v3
+    provenance. It cannot create or delete the UI evidence file, bless managed
+    docs drift, or re-baseline any other public-owned artifact.
+    """
+
+    return _refresh_target_integrity_stamp(
+        target,
+        allowed_changes=UI_ROBOT_REFRESHABLE_PUBLIC_OWNED,
+        operation_description="a UI robot evidence refresh",
+        source=source,
+        required_existing_path=UI_ROBOT_EVIDENCE_PUBLIC_OWNED,
+        require_passing_ui_robot_evidence=True,
+    )
 
 
 def _verify_target_stamp_once(
@@ -3017,6 +3168,16 @@ def build_parser() -> argparse.ArgumentParser:
             "Other evidence changes and older stamp formats fail closed."
         ),
     )
+    mode.add_argument(
+        "--refresh-ui-robot-evidence-stamp",
+        action="store_true",
+        help=(
+            "Refresh only the digest for an existing public-owned "
+            "data/ui_robot_evidence.json in a valid v3 stamp. The canonical "
+            "source, managed target, and all other public-owned evidence must "
+            "still match their stamped state."
+        ),
+    )
     parser.add_argument(
         "--skip-missing-source",
         action="store_true",
@@ -3061,6 +3222,45 @@ def main(argv: list[str] | None = None) -> int:
                 print(
                     f"mirror stamp refreshed: {stamp_path}; source_status={source_status}"
                 )
+            else:
+                print(f"existing mirror stamp preserved: {stamp_path}")
+        return 0
+
+    if args.refresh_ui_robot_evidence_stamp:
+        if not target.exists():
+            parser.error(f"target directory not found: {target}")
+        if not target.is_dir():
+            parser.error(f"target path is not a directory: {target}")
+        if args.source is not None:
+            source_configuration = CanonicalSourceConfiguration(
+                path=_absolute_path(args.source, base=Path.cwd()),
+                origin="cli:--source",
+                required=True,
+            )
+        else:
+            try:
+                source_configuration = canonical_source_configuration()
+            except ValueError as exc:
+                parser.error(str(exc))
+        source = source_configuration.path
+        if not source.exists():
+            print(
+                "UI robot evidence mirror stamp not refreshed: canonical docs "
+                f"source not found: {source} ({source_configuration.origin})",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            stamp_path, written = refresh_ui_robot_evidence_stamp(source, target)
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(
+                f"UI robot evidence mirror stamp not refreshed: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        if not args.quiet:
+            if written:
+                print(f"UI robot evidence mirror stamp refreshed: {stamp_path}")
             else:
                 print(f"existing mirror stamp preserved: {stamp_path}")
         return 0

--- a/tools/testing/ui_robot_matrix_plan.py
+++ b/tools/testing/ui_robot_matrix_plan.py
@@ -10,7 +10,7 @@ import tomllib
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_APPS_ROOT = REPO_ROOT / "src" / "agilab" / "apps" / "builtin"
 SCHEMA = "agilab.ui_robot_matrix_plan.v1"
 MAX_ESTIMATED_PAGES_PER_SHARD = 32

--- a/tools/ui_robot_evidence.py
+++ b/tools/ui_robot_evidence.py
@@ -245,13 +245,35 @@ def _relative_to_root(path: Path | None, root: Path) -> str:
         return path.name
 
 
+def _sorted_app_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(
+        {
+            item.strip()
+            for item in value
+            if isinstance(item, str) and item.strip()
+        }
+    )
+
+
+def _exact_app_inventory_valid(raw_apps: Any, raw_app_count: Any) -> bool:
+    canonical_apps = _sorted_app_names(raw_apps)
+    return (
+        isinstance(raw_apps, list)
+        and raw_apps == canonical_apps
+        and type(raw_app_count) is int
+        and raw_app_count == len(canonical_apps)
+    )
+
+
 def _aggregate_summary_as_matrix_summary(report: Mapping[str, Any]) -> dict[str, Any]:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
-    return {
+    projection = {
         "schema": "agilab.widget_robot_matrix.aggregate_projection.v1",
         "success": bool(report.get("success")),
         "scenario_count": _int_value(summary, "scenario_count"),
-        "app_count": _int_value(summary, "app_count"),
+        "app_count": summary.get("app_count"),
         "page_count": _int_value(summary, "page_count"),
         "widget_count": _int_value(summary, "widget_count"),
         "interacted_count": _int_value(summary, "interacted_count"),
@@ -263,14 +285,17 @@ def _aggregate_summary_as_matrix_summary(report: Mapping[str, Any]) -> dict[str,
         "failed_scenarios": list(report.get("failed_scenarios") or []),
         "failure_samples": list(report.get("failure_samples") or []),
     }
+    if "apps" in summary:
+        projection["apps"] = summary.get("apps")
+    return projection
 
 
 def _aggregate_summary_as_scenario_summary(report: Mapping[str, Any]) -> dict[str, Any]:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
     trend = summary.get("trend") if isinstance(summary.get("trend"), Mapping) else {}
-    return {
+    projection = {
         "success": bool(report.get("success")),
-        "app_count": _int_value(summary, "app_count"),
+        "app_count": summary.get("app_count"),
         "page_count": _int_value(summary, "page_count"),
         "widget_count": _int_value(summary, "widget_count"),
         "interacted_count": _int_value(summary, "interacted_count"),
@@ -280,6 +305,9 @@ def _aggregate_summary_as_scenario_summary(report: Mapping[str, Any]) -> dict[st
         "total_duration_seconds": _float_value(summary, "duration_seconds"),
         "within_target": _int_value(trend, "budget_violation_count") == 0,
     }
+    if "apps" in summary:
+        projection["apps"] = summary.get("apps")
+    return projection
 
 
 def _aggregate_summary_as_trend_report(report: Mapping[str, Any]) -> dict[str, Any]:
@@ -409,6 +437,17 @@ def build_evidence(
 ) -> dict[str, Any]:
     failed_count = _int_value(scenario_summary, "failed_count")
     skipped_count = _int_value(scenario_summary, "skipped_count")
+    app_count = scenario_summary.get("app_count")
+    apps_present = "apps" in scenario_summary
+    raw_apps = scenario_summary.get("apps")
+    aggregate_inventory_required = (
+        artifact_checks.get("aggregate_report_schema") == AGGREGATE_REPORT_SCHEMA
+    )
+    app_inventory_valid = (
+        _exact_app_inventory_valid(raw_apps, app_count)
+        if apps_present
+        else not aggregate_inventory_required
+    )
     trend_summary = _trend_summary(trend_report)
     trend_valid = (
         trend_report.get("schema") == TREND_REPORT_SCHEMA
@@ -421,9 +460,39 @@ def build_evidence(
         and scenario_summary.get("success") is True
         and trend_valid
         and failed_count == 0
+        and app_inventory_valid
         and str(artifact_checks.get("exit_code", "")) == "0"
         and not bool(artifact.get("expired"))
     )
+    result = {
+        "status": "pass" if success else "fail",
+        "success": success,
+        "app_count": app_count,
+        "page_count": _int_value(scenario_summary, "page_count"),
+        "widget_count": _int_value(scenario_summary, "widget_count"),
+        "interacted_count": _int_value(scenario_summary, "interacted_count"),
+        "probed_count": _int_value(scenario_summary, "probed_count"),
+        "skipped_count": skipped_count,
+        "failed_count": failed_count,
+        "total_duration_seconds": _float_value(scenario_summary, "total_duration_seconds"),
+        "within_target": bool(scenario_summary.get("within_target")),
+        "failed_scenarios": list(matrix_summary.get("failed_scenarios") or []),
+        "failure_samples": list(matrix_summary.get("failure_samples") or []),
+        "trend": {
+            "schema": str(trend_report.get("schema", "") or ""),
+            "success": bool(trend_report.get("success")),
+            "page_count": _int_value(trend_summary, "page_count"),
+            "failed_page_count": _int_value(trend_summary, "failed_page_count"),
+            "flaky_page_count": _int_value(trend_summary, "flaky_page_count"),
+            "slow_page_count": _int_value(trend_summary, "slow_page_count"),
+            "parse_error_count": _int_value(trend_summary, "parse_error_count"),
+            "budget_violation_count": _int_value(trend_summary, "budget_violation_count"),
+            "total_duration_seconds": _float_value(trend_summary, "total_duration_seconds"),
+            "mean_page_duration_seconds": _float_value(trend_summary, "mean_page_duration_seconds"),
+        },
+    }
+    if apps_present:
+        result["apps"] = raw_apps
     return {
         "schema": SCHEMA,
         "generated_at": generated_at or utc_now_iso(),
@@ -447,33 +516,7 @@ def build_evidence(
             "archive_download_url": str(artifact.get("archive_download_url", "") or ""),
             **dict(artifact_checks),
         },
-        "result": {
-            "status": "pass" if success else "fail",
-            "success": success,
-            "app_count": _int_value(scenario_summary, "app_count"),
-            "page_count": _int_value(scenario_summary, "page_count"),
-            "widget_count": _int_value(scenario_summary, "widget_count"),
-            "interacted_count": _int_value(scenario_summary, "interacted_count"),
-            "probed_count": _int_value(scenario_summary, "probed_count"),
-            "skipped_count": skipped_count,
-            "failed_count": failed_count,
-            "total_duration_seconds": _float_value(scenario_summary, "total_duration_seconds"),
-            "within_target": bool(scenario_summary.get("within_target")),
-            "failed_scenarios": list(matrix_summary.get("failed_scenarios") or []),
-            "failure_samples": list(matrix_summary.get("failure_samples") or []),
-            "trend": {
-                "schema": str(trend_report.get("schema", "") or ""),
-                "success": bool(trend_report.get("success")),
-                "page_count": _int_value(trend_summary, "page_count"),
-                "failed_page_count": _int_value(trend_summary, "failed_page_count"),
-                "flaky_page_count": _int_value(trend_summary, "flaky_page_count"),
-                "slow_page_count": _int_value(trend_summary, "slow_page_count"),
-                "parse_error_count": _int_value(trend_summary, "parse_error_count"),
-                "budget_violation_count": _int_value(trend_summary, "budget_violation_count"),
-                "total_duration_seconds": _float_value(trend_summary, "total_duration_seconds"),
-                "mean_page_duration_seconds": _float_value(trend_summary, "mean_page_duration_seconds"),
-            },
-        },
+        "result": result,
     }
 
 
@@ -486,6 +529,19 @@ def validate_evidence(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
     artifact = evidence.get("artifact") if isinstance(evidence.get("artifact"), Mapping) else {}
     result = evidence.get("result") if isinstance(evidence.get("result"), Mapping) else {}
     trend = result.get("trend") if isinstance(result.get("trend"), Mapping) else {}
+    aggregate_inventory_required = (
+        artifact.get("aggregate_report_schema") == AGGREGATE_REPORT_SCHEMA
+    )
+    raw_apps = result.get("apps")
+    apps = _sorted_app_names(raw_apps)
+    exact_app_inventory_present = isinstance(raw_apps, list) and raw_apps == apps
+    app_count_matches = type(result.get("app_count")) is int and result.get(
+        "app_count"
+    ) == len(apps)
+    legacy_count_only = not aggregate_inventory_required and "apps" not in result
+    app_inventory_valid = legacy_count_only or (
+        exact_app_inventory_present and app_count_matches
+    )
     checks = [
         {
             "id": "schema",
@@ -539,6 +595,22 @@ def validate_evidence(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
                 else "fail"
             ),
             "summary": "UI robot trend report is present, valid, parse-error free, and within health budgets",
+        },
+        {
+            "id": "app_inventory",
+            "status": "pass" if app_inventory_valid else "fail",
+            "summary": (
+                "legacy v1 evidence predates exact app inventory; count-only compatibility applies"
+                if legacy_count_only
+                else "evidence app_count matches its sorted, unique exact app inventory"
+            ),
+            "details": {
+                "aggregate_inventory_required": aggregate_inventory_required,
+                "legacy_count_only": legacy_count_only,
+                "app_count": result.get("app_count"),
+                "apps": raw_apps,
+                "canonical_apps": apps,
+            },
         },
         {
             "id": "robot_result",

--- a/tools/ui_robot_matrix_aggregate.py
+++ b/tools/ui_robot_matrix_aggregate.py
@@ -52,6 +52,31 @@ def _mapping(value: object) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+def _summary_app_inventory(
+    summary: Mapping[str, Any],
+    *,
+    shard: str,
+) -> tuple[list[str], int, bool, list[str]]:
+    declared_count = _int_value(summary, "app_count")
+    if "apps" not in summary:
+        return [], declared_count, False, []
+
+    raw_apps = summary.get("apps")
+    if not isinstance(raw_apps, list):
+        return [], declared_count, True, [f"{shard}: summary apps must be a list"]
+    parsed_apps = [item.strip() for item in raw_apps if isinstance(item, str) and item.strip()]
+    apps = sorted(set(parsed_apps))
+    errors: list[str] = []
+    if raw_apps != apps:
+        errors.append(f"{shard}: summary apps must be sorted, unique, non-empty strings")
+    if declared_count != len(apps):
+        errors.append(
+            f"{shard}: summary app_count {declared_count} does not match "
+            f"the {len(apps)} listed apps"
+        )
+    return apps, max(declared_count, len(apps)), True, errors
+
+
 def _relative(path: Path, root: Path) -> str:
     try:
         return path.relative_to(root).as_posix()
@@ -251,6 +276,10 @@ def _load_shard_payload(
     screenshot_count: int = 0,
 ) -> dict[str, Any]:
     summary = _load_json(summary_path) if summary_path.is_file() else {}
+    apps, app_count, apps_metadata_present, inventory_errors = _summary_app_inventory(
+        summary,
+        shard=shard,
+    )
     trend_report = _load_json(trend_path) if trend_path.is_file() else {}
     trend_summary = _mapping(trend_report.get("summary"))
     exit_code = exit_code_path.read_text(encoding="utf-8").strip() if exit_code_path.is_file() else ""
@@ -288,6 +317,7 @@ def _load_shard_payload(
         and exit_code == "0"
         and _trend_ok(trend_report)
         and _int_value(summary, "failed_count") == 0
+        and not inventory_errors
     )
     return {
         "name": shard,
@@ -298,7 +328,10 @@ def _load_shard_payload(
         "trend_report_file": _relative(trend_path, root) if trend_path.is_file() else "",
         "exit_code_file": _relative(exit_code_path, root) if exit_code_path.is_file() else "",
         "scenario_count": _int_value(summary, "scenario_count"),
-        "app_count": _int_value(summary, "app_count"),
+        "apps": apps,
+        "app_count": app_count,
+        "apps_metadata_present": apps_metadata_present,
+        "inventory_errors": inventory_errors,
         "page_count": _int_value(summary, "page_count"),
         "widget_count": _int_value(summary, "widget_count"),
         "interacted_count": _int_value(summary, "interacted_count"),
@@ -381,8 +414,16 @@ def _load_shard_from_manifest(
     )
 
 
-def build_aggregate(root: Path, *, expected_shards: Sequence[str] = DEFAULT_EXPECTED_SHARDS) -> dict[str, Any]:
+def build_aggregate(
+    root: Path,
+    *,
+    expected_shards: Sequence[str] = DEFAULT_EXPECTED_SHARDS,
+    expected_apps: Sequence[str] = (),
+) -> dict[str, Any]:
     root = root.resolve(strict=False)
+    expected_app_inventory = sorted(
+        set(str(app).strip() for app in expected_apps if str(app).strip())
+    )
     manifests = discover_shard_manifests(root)
     discovery_mode = "manifest" if manifests else "summary"
     if manifests:
@@ -403,6 +444,37 @@ def build_aggregate(root: Path, *, expected_shards: Sequence[str] = DEFAULT_EXPE
     shards.extend(load_discovered_shard(shard) for shard in extra_shards)
     missing_shards = [shard for shard in expected_shards if shard not in discovered]
     failed_shards = [str(shard["name"]) for shard in shards if shard.get("success") is not True]
+    apps = sorted(
+        {
+            str(app)
+            for shard in shards
+            for app in shard.get("apps", [])
+            if isinstance(app, str) and app
+        }
+    )
+    legacy_app_count = max([_int_value(shard, "app_count") for shard in shards] or [0])
+    missing_apps = sorted(set(expected_app_inventory) - set(apps))
+    unexpected_apps = sorted(set(apps) - set(expected_app_inventory)) if expected_app_inventory else []
+    inventory_errors = [
+        str(error)
+        for shard in shards
+        for error in shard.get("inventory_errors", [])
+        if str(error)
+    ]
+    if expected_app_inventory:
+        inventory_errors.extend(
+            f"{shard['name']}: summary is missing top-level apps inventory"
+            for shard in shards
+            if shard.get("apps_metadata_present") is not True
+        )
+        if missing_apps:
+            inventory_errors.append(
+                "aggregate: expected apps are missing: " + ", ".join(missing_apps)
+            )
+        if unexpected_apps:
+            inventory_errors.append(
+                "aggregate: unexpected apps were reported: " + ", ".join(unexpected_apps)
+            )
     failure_samples = [
         sample
         for shard in shards
@@ -439,14 +511,21 @@ def build_aggregate(root: Path, *, expected_shards: Sequence[str] = DEFAULT_EXPE
     trend["mean_page_duration_seconds"] = (
         float(trend["total_duration_seconds"]) / max(1, int(trend["page_count"]))
     )
-    success = bool(shards) and not missing_shards and not failed_shards and bool(trend["success"])
+    success = (
+        bool(shards)
+        and not missing_shards
+        and not failed_shards
+        and bool(trend["success"])
+        and not inventory_errors
+    )
     summary = {
         "expected_shard_count": len(expected_shards),
         "shard_count": len(shards),
         "missing_shard_count": len(missing_shards),
         "failed_shard_count": len(failed_shards),
         "scenario_count": sum(_int_value(shard, "scenario_count") for shard in shards),
-        "app_count": max([_int_value(shard, "app_count") for shard in shards] or [0]),
+        "apps": apps,
+        "app_count": max(len(apps), legacy_app_count),
         "page_count": sum(_int_value(shard, "page_count") for shard in shards),
         "widget_count": sum(_int_value(shard, "widget_count") for shard in shards),
         "interacted_count": sum(_int_value(shard, "interacted_count") for shard in shards),
@@ -468,9 +547,13 @@ def build_aggregate(root: Path, *, expected_shards: Sequence[str] = DEFAULT_EXPE
         "success": success,
         "root": root.as_posix(),
         "expected_shards": list(expected_shards),
+        "expected_apps": expected_app_inventory,
         "missing_shards": missing_shards,
         "failed_shards": failed_shards,
         "extra_shards": extra_shards,
+        "missing_apps": missing_apps,
+        "unexpected_apps": unexpected_apps,
+        "inventory_errors": inventory_errors,
         "summary": summary,
         "discovery": {
             "mode": discovery_mode,
@@ -495,6 +578,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "",
         f"- Status: `{status}`",
         f"- Shards: `{summary.get('shard_count', 0)}/{summary.get('expected_shard_count', 0)}`",
+        f"- Apps: `{summary.get('app_count', 0)}`",
         f"- Pages: `{summary.get('page_count', 0)}`",
         f"- Widgets: `{summary.get('widget_count', 0)}`",
         f"- Failed: `{summary.get('failed_count', 0)}`",
@@ -530,6 +614,11 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     missing = report.get("missing_shards") or []
     if missing:
         lines.extend(["", "### Missing Shards", *[f"- `{shard}`" for shard in missing]])
+    inventory_errors = report.get("inventory_errors") or []
+    if inventory_errors:
+        lines.extend(
+            ["", "### App Inventory Errors", *[f"- {error}" for error in inventory_errors]]
+        )
     samples = report.get("failure_samples") or []
     lines.append("")
     lines.append("### Failure Samples")
@@ -570,6 +659,10 @@ def _parse_expected_shards(value: str) -> tuple[str, ...]:
     return shards or DEFAULT_EXPECTED_SHARDS
 
 
+def _parse_expected_apps(value: str) -> tuple[str, ...]:
+    return tuple(sorted(set(item.strip() for item in value.split(",") if item.strip())))
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -578,6 +671,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=REPO_ROOT / "test-results" / "ui-robot-matrix-artifacts",
     )
     parser.add_argument("--expected-shards", default=",".join(DEFAULT_EXPECTED_SHARDS))
+    parser.add_argument("--expected-apps", default="")
     parser.add_argument(
         "--output",
         type=Path,
@@ -610,7 +704,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps(manifest, **json_kwargs))
         return 0
 
-    report = build_aggregate(args.root, expected_shards=_parse_expected_shards(args.expected_shards))
+    report = build_aggregate(
+        args.root,
+        expected_shards=_parse_expected_shards(args.expected_shards),
+        expected_apps=_parse_expected_apps(args.expected_apps),
+    )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
         json.dumps(report, **json_kwargs) + "\n",

--- a/tools/ui_robot_matrix_plan.py
+++ b/tools/ui_robot_matrix_plan.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Build a bounded, deterministic UI robot job matrix from the built-in app inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tomllib
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_APPS_ROOT = REPO_ROOT / "src" / "agilab" / "apps" / "builtin"
+SCHEMA = "agilab.ui_robot_matrix_plan.v1"
+MAX_ESTIMATED_PAGES_PER_SHARD = 32
+
+CORE_SCENARIOS = (
+    "isolated-core-pages",
+    "isolated-entry-and-app-pages",
+    "isolated-project-page",
+    "isolated-project-editor-page",
+    "isolated-project-notebook-import",
+    "isolated-project-import-sidebar",
+    "isolated-project-rename-sidebar",
+    "isolated-settings-page",
+    "isolated-all-builtins-orchestrate-smoke",
+    "isolated-all-builtins-core-render-smoke",
+)
+STATE_MOBILE_SCENARIOS = (
+    "isolated-fresh-session-core-pages",
+    "isolated-browser-history",
+    "isolated-mobile-core-pages",
+)
+QUALITY_SCENARIOS = (
+    "isolated-browser-error-core-pages",
+    "isolated-release-evidence",
+    "isolated-above-fold-core-pages",
+    "isolated-keyboard-focus-core-pages",
+    "isolated-accessibility-core-pages",
+)
+LAYOUT_SCENARIOS = (
+    "isolated-layout-integrity-desktop",
+    "isolated-layout-integrity-mobile",
+)
+FOCUSED_SCENARIOS = (
+    (
+        "isolated-execution-pandas-orchestrate-pool-executor",
+        "execution_pandas_project",
+    ),
+    ("isolated-pytorch-playground-analysis", "pytorch_playground_project"),
+)
+
+# The broad scenario groups render this many core pages per selected app. The
+# configured apps-page count is added separately to the core estimate.
+CORE_PAGES_PER_APP = 12
+STATE_MOBILE_PAGES_PER_APP = 9
+QUALITY_PAGES_PER_APP = 32
+LAYOUT_PAGES_PER_APP = 14
+
+
+def discover_builtin_apps(apps_root: Path = DEFAULT_APPS_ROOT) -> tuple[str, ...]:
+    apps = tuple(sorted(path.name for path in apps_root.glob("*_project") if path.is_dir()))
+    if not apps:
+        raise ValueError(f"no built-in apps found under {apps_root}")
+    return apps
+
+
+def _normalized_requested_app(raw: str, available: set[str]) -> str:
+    value = raw.strip()
+    if value in available:
+        return value
+    project_name = f"{value}_project" if value and not value.endswith("_project") else value
+    if project_name in available:
+        return project_name
+    raise ValueError(f"unknown built-in app requested: {raw!r}")
+
+
+def resolve_requested_apps(
+    requested: str,
+    *,
+    available_apps: Sequence[str],
+) -> tuple[str, ...]:
+    available = tuple(dict.fromkeys(str(app).strip() for app in available_apps if str(app).strip()))
+    available_set = set(available)
+    if not available:
+        raise ValueError("available app inventory is empty")
+    if not requested.strip() or requested.strip().casefold() == "all":
+        return tuple(sorted(available))
+
+    selected = {
+        _normalized_requested_app(item, available_set)
+        for item in requested.split(",")
+        if item.strip()
+    }
+    if not selected:
+        raise ValueError("requested app selection is empty")
+    return tuple(app for app in sorted(available) if app in selected)
+
+
+def configured_apps_page_count(app_dir: Path) -> int:
+    settings_path = app_dir / "src" / "app_settings.toml"
+    try:
+        settings = tomllib.loads(settings_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
+        return 0
+    pages = settings.get("pages")
+    if not isinstance(pages, Mapping):
+        return 0
+
+    names: list[str] = []
+    default_view = pages.get("default_view")
+    if isinstance(default_view, str) and default_view.strip():
+        names.append(default_view.strip())
+    view_module = pages.get("view_module")
+    if isinstance(view_module, list):
+        names.extend(
+            item.strip()
+            for item in view_module
+            if isinstance(item, str) and item.strip()
+        )
+    return len(dict.fromkeys(names))
+
+
+def _partition_apps(
+    apps: Sequence[str],
+    *,
+    page_loads: Mapping[str, int],
+    max_pages: int,
+) -> tuple[tuple[str, ...], ...]:
+    groups: list[tuple[str, ...]] = []
+    current: list[str] = []
+    current_pages = 0
+    for app in apps:
+        app_pages = int(page_loads[app])
+        if app_pages <= 0 or app_pages > max_pages:
+            raise ValueError(
+                f"app {app!r} has invalid estimated load {app_pages}; "
+                f"maximum is {max_pages} pages"
+            )
+        if current and current_pages + app_pages > max_pages:
+            groups.append(tuple(current))
+            current = []
+            current_pages = 0
+        current.append(app)
+        current_pages += app_pages
+    if current:
+        groups.append(tuple(current))
+    return tuple(groups)
+
+
+def _broad_shards(
+    *,
+    prefix: str,
+    apps: Sequence[str],
+    scenarios: Sequence[str],
+    page_loads: Mapping[str, int],
+    max_pages: int,
+) -> list[dict[str, object]]:
+    shards: list[dict[str, object]] = []
+    for index, group in enumerate(
+        _partition_apps(apps, page_loads=page_loads, max_pages=max_pages),
+        start=1,
+    ):
+        shards.append(
+            {
+                "shard": f"{prefix}-{index:02d}",
+                "scenarios": " ".join(scenarios),
+                "apps": ",".join(group),
+                "estimated_pages": sum(int(page_loads[app]) for app in group),
+            }
+        )
+    return shards
+
+
+def build_plan(
+    *,
+    requested_apps: str = "all",
+    apps_root: Path = DEFAULT_APPS_ROOT,
+    max_estimated_pages: int = MAX_ESTIMATED_PAGES_PER_SHARD,
+) -> dict[str, Any]:
+    if max_estimated_pages <= 0:
+        raise ValueError("max_estimated_pages must be greater than zero")
+    available_apps = discover_builtin_apps(apps_root)
+    apps = resolve_requested_apps(requested_apps, available_apps=available_apps)
+
+    core_loads = {
+        app: CORE_PAGES_PER_APP + configured_apps_page_count(apps_root / app)
+        for app in apps
+    }
+    state_mobile_loads = {app: STATE_MOBILE_PAGES_PER_APP for app in apps}
+    quality_loads = {app: QUALITY_PAGES_PER_APP for app in apps}
+    layout_loads = {app: LAYOUT_PAGES_PER_APP for app in apps}
+
+    shards = [
+        *_broad_shards(
+            prefix="core",
+            apps=apps,
+            scenarios=CORE_SCENARIOS,
+            page_loads=core_loads,
+            max_pages=max_estimated_pages,
+        ),
+        *_broad_shards(
+            prefix="state-mobile",
+            apps=apps,
+            scenarios=STATE_MOBILE_SCENARIOS,
+            page_loads=state_mobile_loads,
+            max_pages=max_estimated_pages,
+        ),
+        *_broad_shards(
+            prefix="quality",
+            apps=apps,
+            scenarios=QUALITY_SCENARIOS,
+            page_loads=quality_loads,
+            max_pages=max_estimated_pages,
+        ),
+        *_broad_shards(
+            prefix="layout",
+            apps=apps,
+            scenarios=LAYOUT_SCENARIOS,
+            page_loads=layout_loads,
+            max_pages=max_estimated_pages,
+        ),
+    ]
+
+    selected = set(apps)
+    focused = [
+        (scenario, app)
+        for scenario, app in FOCUSED_SCENARIOS
+        if app in selected
+    ]
+    if focused:
+        shards.append(
+            {
+                "shard": "focused",
+                "scenarios": " ".join(scenario for scenario, _app in focused),
+                "apps": ",".join(sorted({app for _scenario, app in focused})),
+                "estimated_pages": len(focused),
+            }
+        )
+
+    shard_names = [str(shard["shard"]) for shard in shards]
+    if len(shard_names) != len(set(shard_names)):
+        raise ValueError("planned UI robot shard names must be unique")
+    max_planned_pages = max(int(shard["estimated_pages"]) for shard in shards)
+    if max_planned_pages > max_estimated_pages:
+        raise ValueError(
+            f"planned shard load {max_planned_pages} exceeds {max_estimated_pages} pages"
+        )
+
+    return {
+        "schema": SCHEMA,
+        "apps": list(apps),
+        "app_count": len(apps),
+        "shard_count": len(shards),
+        "expected_shards": shard_names,
+        "estimated_page_count": sum(int(shard["estimated_pages"]) for shard in shards),
+        "max_estimated_pages": max_planned_pages,
+        "max_estimated_pages_per_shard": max_estimated_pages,
+        "matrix": {"include": shards},
+    }
+
+
+def _write_github_outputs(plan: Mapping[str, Any], output_path: Path) -> None:
+    matrix = plan.get("matrix")
+    expected_shards = plan.get("expected_shards")
+    apps = plan.get("apps")
+    if not isinstance(matrix, Mapping) or not isinstance(expected_shards, list) or not isinstance(apps, list):
+        raise ValueError("plan is missing matrix, expected_shards, or apps output")
+    lines = (
+        f"matrix={json.dumps(matrix, sort_keys=True, separators=(',', ':'))}",
+        f"expected_shards={','.join(str(item) for item in expected_shards)}",
+        f"expected_apps={','.join(str(item) for item in apps)}",
+    )
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apps", default="all")
+    parser.add_argument("--apps-root", type=Path, default=DEFAULT_APPS_ROOT)
+    parser.add_argument(
+        "--max-estimated-pages",
+        type=int,
+        default=MAX_ESTIMATED_PAGES_PER_SHARD,
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--github-output", action="store_true")
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    plan = build_plan(
+        requested_apps=args.apps,
+        apps_root=args.apps_root,
+        max_estimated_pages=args.max_estimated_pages,
+    )
+    json_kwargs = {
+        "sort_keys": True,
+        "separators": ((",", ":") if args.compact else None),
+        "indent": (None if args.compact else 2),
+    }
+    rendered = json.dumps(plan, **json_kwargs) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    if args.github_output:
+        github_output = os.environ.get("GITHUB_OUTPUT", "").strip()
+        if not github_output:
+            raise SystemExit("--github-output requires GITHUB_OUTPUT")
+        _write_github_outputs(plan, Path(github_output))
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -68,7 +68,7 @@ def _coverage_shard_plan_module():
 
 
 def _ui_robot_matrix_plan_module():
-    module_path = REPO_ROOT / "tools" / "ui_robot_matrix_plan.py"
+    module_path = REPO_ROOT / "tools" / "testing" / "ui_robot_matrix_plan.py"
     spec = importlib.util.spec_from_file_location(
         "agilab_ui_robot_matrix_plan", module_path
     )

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -54,52 +54,6 @@ AGI_GUI_COVERAGE_CHUNKS = (
 )
 AGI_GUI_COVERAGE_MANIFEST_SCHEMA = "agilab.workflow_parity.agi_gui_coverage_chunk.v1"
 AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS = 120.0
-UI_ROBOT_MATRIX_SHARDS = (
-    (
-        "core",
-        (
-            "isolated-core-pages",
-            "isolated-entry-and-app-pages",
-            "isolated-project-page",
-            "isolated-project-editor-page",
-            "isolated-project-notebook-import",
-            "isolated-project-import-sidebar",
-            "isolated-project-rename-sidebar",
-            "isolated-settings-page",
-            "isolated-all-builtins-orchestrate-smoke",
-            "isolated-execution-pandas-orchestrate-pool-executor",
-            "isolated-all-builtins-core-render-smoke",
-        ),
-    ),
-    (
-        "state",
-        (
-            "isolated-fresh-session-core-pages",
-            "isolated-browser-history",
-        ),
-    ),
-    (
-        "quality",
-        (
-            "isolated-browser-error-core-pages",
-            "isolated-pytorch-playground-analysis",
-            "isolated-release-evidence",
-            "isolated-above-fold-core-pages",
-            "isolated-keyboard-focus-core-pages",
-            "isolated-accessibility-core-pages",
-        ),
-    ),
-    (
-        "layout",
-        (
-            "isolated-layout-integrity-desktop",
-            "isolated-mobile-core-pages",
-            "isolated-layout-integrity-mobile",
-        ),
-    ),
-)
-
-
 def _coverage_shard_plan_module():
     module_path = REPO_ROOT / "tools" / "coverage_shard_plan.py"
     spec = importlib.util.spec_from_file_location(
@@ -107,6 +61,19 @@ def _coverage_shard_plan_module():
     )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load coverage shard planner from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ui_robot_matrix_plan_module():
+    module_path = REPO_ROOT / "tools" / "ui_robot_matrix_plan.py"
+    spec = importlib.util.spec_from_file_location(
+        "agilab_ui_robot_matrix_plan", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load UI robot matrix planner from {module_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -1711,7 +1678,10 @@ def _cloud_emulators_profile() -> list[CommandSpec]:
 
 def _ui_robot_matrix_profile() -> list[CommandSpec]:
     commands: list[CommandSpec] = []
-    for shard, scenarios in UI_ROBOT_MATRIX_SHARDS:
+    plan = _ui_robot_matrix_plan_module().build_plan()
+    for row in plan["matrix"]["include"]:
+        shard = str(row["shard"])
+        scenarios = str(row["scenarios"]).split()
         result_dir = f"test-results/ui-robot-matrix/{shard}"
         screenshot_dir = f"screenshots/ui-robot-matrix/{shard}"
         argv = [
@@ -1731,7 +1701,7 @@ def _ui_robot_matrix_profile() -> list[CommandSpec]:
         argv.extend(
             [
                 "--apps",
-                "all",
+                str(row["apps"]),
                 "--timeout",
                 "90",
                 "--widget-timeout",


### PR DESCRIPTION
## Summary

- replace the four unbounded UI-robot shards with a deterministic 34-job plan covering all 14 built-in apps and all 22 scenarios, capped at 32 estimated pages per job
- carry exact selected and actually covered app inventories from child summaries through matrix aggregation, durable evidence, and release-proof validation
- fail closed on malformed, duplicated, unsorted, contradictory, missing, or tag-unverifiable app inventories
- fix layout false positives caused by controls fully clipped inside Streamlit expander wrappers and require the browser-backed regression in repo guardrails
- add a provenance-preserving, fail-closed UI evidence stamp refresh path
- bound Ruff to the 0.15 series after 0.16.1 made fresh environments fail the repository's existing lint surface
- keep the planner under `tools/testing/` so the top-level tools surface remains within its enforced 195-file budget

## Repro

The exact-tag diagnostic run [30629596712](https://github.com/ThalesGroup/agilab/actions/runs/30629596712) used the workflow stored in `v2026.07.31`. It exposed two deterministic blockers:

1. matrix summaries omitted `app_count`, so the aggregate reported `app_count=0`;
2. four shards attempted 951 page exercises and prior runs reached the 50-minute job timeout.

The partial layout artifact also reported controls as overlapping even though their ancestor expander content was fully clipped.

## Root Cause

- the workflow had a static four-shard matrix with no workload planner
- child matrix summaries did not propagate or validate exact app inventories
- evidence generation normalized contradictory inventories instead of rejecting them
- layout checks used raw DOM rectangles without ancestor clipping/paint visibility
- release-mode exact inventory checks could be bypassed when a shallow checkout lacked the tag tree
- the docs mirror had no narrow operation for re-stamping a validated public-owned UI evidence file

## Regression Test

- planner tests pin the current 14-app inventory, all 22 scenarios, 34 bounded jobs, 951 estimated pages, and 32-page maximum
- negative tests reject malformed child, aggregate, and durable evidence inventories
- coverage tests prove a selected app without a completed page makes the run fail
- release tests prove release mode fails when the tag inventory is absent or differs
- an actual Chromium test proves fully clipped expander controls are ignored while a real visible overlap remains detected
- pinned-boundary tests cover UI evidence validation, unrelated drift, replacement races, rollback, create/delete refusal, and idempotence

## Validation

- `597 passed, 2 skipped` across the integrated UI robot, planner, aggregate, evidence, release proof, docs sync, workflow contract, and pre-push suites
- strict Playwright layout regression executed and passed
- `27 passed` in the final focused workflow/planner/browser/coverage slice
- `62 passed` for the CI follow-up covering the tools-surface budget, planner, workflow contracts, and parity
- `11 passed` after canonical regeneration of `agilab-capabilities.json` for the new planner schema
- `./dev scope`, staged `./dev impact`, `./dev lint`, py_compile, Ruff F checks, new-file import checks, and `git diff --check` passed
- release proof: 12/12 checks passed
- private/public docs mirror: verified, with create/update/delete all zero
- commit provenance and pre-push hooks passed
- first PR run isolated one tools-surface budget failure; commit `b57084f` reproduces and fixes that exact contract
- second PR run validated the budget and identified the stale generated capability manifest; commit `ef8cf74` regenerates it canonically
- final PR run is green on every required check; root-test-suite completed successfully in 9m48s

## Release boundary

This PR does not rewrite or claim release-bound UI evidence for immutable tag `v2026.07.31`; that tag contains the old workflow. After merge, the corrected matrix can produce a fresh 14-app historical/post-release baseline on `main`. A later immutable release can bind evidence generated from code that already contains this workflow.

## Agent Metadata

- Tokki: `1.0.42`
- Agent/runtime: Codex; runtime version not exposed
- Model/reasoning: not exposed by the session
- `/fast`: not used

## Review Evidence

- `exact_release_app_evidence`: editing specialist; exact inventory propagation and fail-closed release-tag checks; inherited Codex model identifier not exposed
- `layout_visibility_fix`: editing specialist; painted geometry and mandatory Playwright gate; inherited Codex model identifier not exposed
- `inventory_fail_closed`: editing specialist; adversarial child/evidence inventory and real coverage hardening; inherited Codex model identifier not exposed
- `final_ui_evidence_review`: read-only adversarial review of all changed files; identified the immutable-tag boundary and two fail-open paths; inherited Codex model identifier not exposed
- primary agent: integration, dependency reproducibility fix, complete local validation, publication, and follow-through