### PR TITLE
fix(ui-robot): bound each scenario with a wall-clock watchdog

### DIFF
--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -1258,6 +1260,86 @@ def test_streaming_runner_keeps_child_output_on_stderr(capsys) -> None:
     assert "[ui-robot-matrix] exit=0:" in captured.err
 
 
+def test_streaming_runner_terminates_a_silent_wedged_child(capsys) -> None:
+    """A child that emits nothing and never exits must not block the matrix.
+
+    This reproduces the ui-robot-matrix hang: before the watchdog, the streaming
+    read loop blocked until the CI job's own timeout-minutes cap fired, killing
+    the shard with no per-scenario verdict.
+    """
+    module = _load_module()
+
+    started = time.monotonic()
+    result = module._run_robot_command_streaming(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        timeout_seconds=2.0,
+    )
+    elapsed = time.monotonic() - started
+    captured = capsys.readouterr()
+
+    assert result.returncode == module.SCENARIO_TIMEOUT_RETURNCODE
+    # Must return promptly rather than running the child's full 120s sleep.
+    assert elapsed < 30.0
+    assert "wall-clock budget" in result.stdout
+    assert "TIMEOUT" in captured.err
+
+
+def test_streaming_runner_reaps_grandchildren_on_timeout(capsys) -> None:
+    """The robot spawns Streamlit and a browser; both must die with the child."""
+    module = _load_module()
+
+    # Parent spawns a long-lived grandchild, prints its pid, then hangs.
+    script = (
+        "import subprocess, sys, time; "
+        "g = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)']); "
+        "print(g.pid, flush=True); "
+        "time.sleep(120)"
+    )
+    result = module._run_robot_command_streaming(
+        [sys.executable, "-c", script], timeout_seconds=3.0
+    )
+
+    assert result.returncode == module.SCENARIO_TIMEOUT_RETURNCODE
+    grandchild_pid = int(result.stdout.strip().splitlines()[0])
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(grandchild_pid, 0)
+        except OSError:
+            break
+        time.sleep(0.2)
+    else:  # pragma: no cover - only reached when the reap failed
+        raise AssertionError(f"grandchild {grandchild_pid} survived the scenario timeout")
+
+
+def test_streaming_runner_without_timeout_still_completes(capsys) -> None:
+    module = _load_module()
+
+    result = module._run_robot_command_streaming(
+        [sys.executable, "-c", "print('done')"], timeout_seconds=None
+    )
+
+    assert result.returncode == 0
+    assert "done" in result.stdout
+    assert "wall-clock budget" not in result.stdout
+
+
+def test_scenario_timeout_option_is_plumbed_from_cli() -> None:
+    module = _load_module()
+
+    default_opts = module.options_from_args(module._build_parser().parse_args([]))
+    disabled_opts = module.options_from_args(
+        module._build_parser().parse_args(["--scenario-timeout", "0"])
+    )
+    custom_opts = module.options_from_args(
+        module._build_parser().parse_args(["--scenario-timeout", "45"])
+    )
+
+    assert default_opts.scenario_timeout_seconds == module.DEFAULT_SCENARIO_TIMEOUT_SECONDS
+    assert disabled_opts.scenario_timeout_seconds is None
+    assert custom_opts.scenario_timeout_seconds == 45.0
+
+
 def test_load_summary_falls_back_to_stdout_json_and_default_failure(tmp_path) -> None:
     module = _load_module()
 
@@ -1481,9 +1563,11 @@ def test_streaming_default_paths_for_scenario_and_failure_retry(tmp_path, monkey
         no_seed_demo_artifacts=False,
     )
     calls: list[list[str]] = []
+    seen_timeouts: list[float | None] = []
 
-    def _fake_streaming(argv):
+    def _fake_streaming(argv, *, timeout_seconds=None):
         calls.append(list(argv))
+        seen_timeouts.append(timeout_seconds)
         summary_path = Path(argv[argv.index("--json-output") + 1])
         progress_path = Path(argv[argv.index("--progress-log") + 1])
         summary_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1514,6 +1598,12 @@ def test_streaming_default_paths_for_scenario_and_failure_retry(tmp_path, monkey
     assert result.returncode == 0
     assert retry.returncode == 0
     assert len(calls) == 2
+    # Both the main scenario run and the failure-artifact retry must inherit the
+    # per-scenario watchdog budget; an unbounded retry would reopen the hang.
+    assert seen_timeouts == [
+        module.DEFAULT_SCENARIO_TIMEOUT_SECONDS,
+        module.DEFAULT_SCENARIO_TIMEOUT_SECONDS,
+    ]
     assert retry_options.screenshot_dir == options.output_dir / "failure-artifacts" / "screenshots"
     assert retry_options.trace_dir == options.output_dir / "failure-artifacts" / "traces"
     assert retry_options.har_dir == options.output_dir / "failure-artifacts" / "har"

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
+import os
+import signal
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
@@ -21,6 +25,17 @@ SCHEMA = "agilab.widget_robot_matrix.v1"
 FAILURE_BUNDLE_SCHEMA = "agilab.widget_robot_matrix_failure_bundle.v1"
 FAILURE_BUNDLE_TAIL_LINES = 120
 FAILURE_BUNDLE_TEXT_LIMIT = 30_000
+# A wedged robot child (Streamlit sidecar plus a headless browser that never
+# reaches a ready state) produces no output and never exits, so the streaming
+# read loop below would block until the CI job's own `timeout-minutes` cap fires.
+# That kills the whole shard without a per-scenario verdict or failure bundle.
+# This wall-clock budget bounds each child instead, so one wedged scenario is
+# reported as a failure and the remaining scenarios still run.
+DEFAULT_SCENARIO_TIMEOUT_SECONDS = 900.0
+# Conventional shell exit status for "killed by timeout" (128 + SIGTERM).
+SCENARIO_TIMEOUT_RETURNCODE = 124
+# Grace period for the child to die after SIGTERM before we escalate to SIGKILL.
+SCENARIO_TERMINATE_GRACE_SECONDS = 10.0
 RESULT_CACHE_SCHEMA = "agilab.widget_robot_matrix_result_cache.v1"
 DEFAULT_RESULT_CACHE_PATH = REPO_ROOT / ".pytest_cache" / "agilab" / "ui_robot_matrix_results.json"
 RESULT_CACHE_MAX_ENTRIES = 256
@@ -99,6 +114,8 @@ class MatrixOptions:
     retry_trace_dir: Path | None = None
     retry_har_dir: Path | None = None
     retry_video_dir: Path | None = None
+    # Per-scenario wall-clock budget. ``None`` disables the watchdog entirely.
+    scenario_timeout_seconds: float | None = DEFAULT_SCENARIO_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -129,8 +146,47 @@ class ScenarioResult:
     artifact_retry: FailureArtifactRetry | None = None
 
 
-def _run_robot_command_streaming(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
-    """Run a robot child process while keeping matrix stdout JSON-clean."""
+def _terminate_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Kill a wedged robot child together with the processes it spawned.
+
+    The robot starts a Streamlit sidecar and a headless browser, so signalling
+    only the direct child leaves those orphaned and holding the shard's ports.
+    On POSIX the child runs in its own session (see ``start_new_session`` below)
+    so the whole group can be signalled at once; Windows has no session groups,
+    so fall back to terminating the child itself.
+    """
+
+    def _signal_group(sig: int) -> None:
+        if os.name != "nt":
+            with contextlib.suppress(OSError, ProcessLookupError):
+                os.killpg(os.getpgid(proc.pid), sig)
+                return
+        with contextlib.suppress(OSError, ProcessLookupError):
+            proc.terminate() if sig == signal.SIGTERM else proc.kill()
+
+    _signal_group(signal.SIGTERM)
+    try:
+        proc.wait(timeout=SCENARIO_TERMINATE_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    _signal_group(signal.SIGKILL if os.name != "nt" else signal.SIGTERM)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=SCENARIO_TERMINATE_GRACE_SECONDS)
+
+
+def _run_robot_command_streaming(
+    argv: Sequence[str],
+    *,
+    timeout_seconds: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a robot child process while keeping matrix stdout JSON-clean.
+
+    ``timeout_seconds`` bounds the child's total wall-clock time. Output is
+    drained on a reader thread so the deadline is enforced even when the child
+    goes completely silent -- a blocking ``for line in proc.stdout`` would
+    otherwise never return and could not be interrupted.
+    """
 
     print(f"[ui-robot-matrix] start: {' '.join(argv)}", file=sys.stderr, flush=True)
     proc = subprocess.Popen(
@@ -140,13 +196,44 @@ def _run_robot_command_streaming(argv: Sequence[str]) -> subprocess.CompletedPro
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         bufsize=1,
+        # Own process group so a timeout can reap the whole robot process tree.
+        start_new_session=os.name != "nt",
     )
     output_lines: list[str] = []
     assert proc.stdout is not None
-    for line in proc.stdout:
-        output_lines.append(line)
-        print(line, end="", file=sys.stderr, flush=True)
-    returncode = proc.wait()
+
+    def _drain() -> None:
+        # The pipe is closed when the child exits or is killed, which ends this
+        # loop; failures here must never take down the matrix run.
+        with contextlib.suppress(ValueError, OSError):
+            for line in proc.stdout:  # type: ignore[union-attr]
+                output_lines.append(line)
+                print(line, end="", file=sys.stderr, flush=True)
+
+    reader = threading.Thread(target=_drain, name="ui-robot-output", daemon=True)
+    reader.start()
+
+    timed_out = False
+    try:
+        returncode = proc.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        print(
+            f"[ui-robot-matrix] TIMEOUT after {timeout_seconds:.0f}s, terminating: "
+            f"{' '.join(argv)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        _terminate_process_tree(proc)
+        returncode = proc.returncode if proc.returncode is not None else SCENARIO_TIMEOUT_RETURNCODE
+
+    reader.join(timeout=SCENARIO_TERMINATE_GRACE_SECONDS)
+    if timed_out:
+        returncode = SCENARIO_TIMEOUT_RETURNCODE
+        output_lines.append(
+            f"\n[ui-robot-matrix] scenario exceeded its {timeout_seconds:.0f}s "
+            "wall-clock budget and was terminated\n"
+        )
     print(f"[ui-robot-matrix] exit={returncode}: {' '.join(argv)}", file=sys.stderr, flush=True)
     return subprocess.CompletedProcess(list(argv), returncode, stdout="".join(output_lines))
 
@@ -779,6 +866,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--timeout", type=float, default=90.0)
     parser.add_argument("--widget-timeout", type=float, default=3.0)
+    parser.add_argument(
+        "--scenario-timeout",
+        type=float,
+        default=DEFAULT_SCENARIO_TIMEOUT_SECONDS,
+        help=(
+            "Per-scenario wall-clock budget in seconds. A scenario that exceeds it is "
+            "terminated and reported as a failure so the remaining scenarios still run. "
+            "Use 0 to disable the watchdog."
+        ),
+    )
     parser.add_argument("--browser", choices=("chromium", "firefox", "webkit"), default="chromium")
     parser.add_argument("--headful", action="store_true")
     parser.add_argument("--url", help="Existing AGILAB URL to test instead of launching source Streamlit.")
@@ -814,6 +911,7 @@ def options_from_args(args: argparse.Namespace) -> MatrixOptions:
         failure_bundle_dir=args.failure_bundle_dir,
         timeout_seconds=args.timeout,
         widget_timeout_seconds=args.widget_timeout,
+        scenario_timeout_seconds=args.scenario_timeout if args.scenario_timeout > 0 else None,
         quiet_progress=args.quiet_progress,
         no_seed_demo_artifacts=args.no_seed_demo_artifacts,
         browser=args.browser,
@@ -996,7 +1094,9 @@ def run_failure_artifact_retry(
     argv, summary_path, progress_path = build_robot_command(scenario, options=retry_options)
     started = time.perf_counter()
     if runner is subprocess.run:
-        completed = _run_robot_command_streaming(argv)
+        completed = _run_robot_command_streaming(
+            argv, timeout_seconds=options.scenario_timeout_seconds
+        )
     else:
         completed = runner(
             argv,
@@ -1414,7 +1514,9 @@ def run_scenario(
     argv, summary_path, progress_path = build_robot_command(scenario, options=options)
     started = time.perf_counter()
     if runner is subprocess.run:
-        completed = _run_robot_command_streaming(argv)
+        completed = _run_robot_command_streaming(
+            argv, timeout_seconds=options.scenario_timeout_seconds
+        )
     else:
         completed = runner(
             argv,


### PR DESCRIPTION
## Summary

The `ui-robot-matrix` scheduled sweep has hung on **every** run since 2026-07-15. This
bounds each scenario with a wall-clock watchdog so one wedged scenario fails with a
diagnosable verdict instead of killing the whole shard.

Found during the v2026.07.31 audit (finding F4).

## Repro

Scheduled runs 2026-07-15, 2026-07-22, 2026-07-29 all ended `cancelled`. Per-step
timings for the `state` shard (job `90491517472`, run `30425668881`):

- Steps 1-8 (checkout, Python, uv, Playwright): **27 seconds**. Setup is not the problem.
- Step 9 `Run UI robot matrix shard`: 05:39:03 -> 06:28:48 = **49m45s**, killed by the
  50-minute job cap.
- Log lines per minute: `05:38` -> 529, `05:39` -> 121, `06:28` -> 246, and
  **`05:40`-`06:27` -> zero**. Nothing for 48 minutes.
- At kill, the runner terminated orphaned `uv`, `tee`, `python`, `streamlit`,
  `MainThread`, `chrome-headless-shell` — a Streamlit server and headless Chrome were
  still alive.

The `state` shard has only **2** scenarios (vs 11 for `core`) and still consumed the full
budget, so this is not shard imbalance. Identical across all four shards for three
consecutive weeks: deterministic, not flaky.

Locally reproducible without CI:

```
python -c "import time; time.sleep(120)"   # stands in for a wedged robot child
```

fed through `_run_robot_command_streaming` never returned before this change.

## Root Cause

`tools/agilab_widget_robot_matrix.py::_run_robot_command_streaming` drained the child
with a blocking `for line in proc.stdout:` and then called `proc.wait()` — **neither had
a timeout**. Every timeout in the module is a per-action or per-page Playwright bound
(`action_timeout_seconds`, `page_timeout_seconds`); `rg watchdog|deadline|monotonic` over
its 1,652 lines returned nothing. So a child that goes silent and never exits blocked
forever, and the job's `timeout-minutes: 50` was the only bound — firing too late to
produce a per-scenario verdict or a failure bundle.

## Fix

- Per-scenario wall-clock budget: `--scenario-timeout`, default 900s, `0` disables.
  Plumbed through `MatrixOptions.scenario_timeout_seconds` to **both** the main scenario
  run and the failure-artifact retry.
- Output is drained on a reader thread, so the deadline is enforced even when the child
  emits nothing. A blocking `for line in proc.stdout` cannot be interrupted.
- On timeout the whole process **group** is reaped (`start_new_session` + `killpg`,
  SIGTERM then SIGKILL after a grace period). The robot spawns a Streamlit sidecar and a
  headless browser; signalling only the direct child left those orphaned holding the
  shard's ports — which is exactly what the CI cleanup log showed. Windows has no session
  groups, so it falls back to terminating the child.
- Timeout is reported as returncode 124 with a `wall-clock budget` marker in the captured
  output and a `TIMEOUT` line on stderr.

No workflow change: the module default applies automatically, so CI picks this up with
no YAML edit.

## Regression Test

Four new tests in `test/test_agilab_widget_robot_matrix.py`:

- `test_streaming_runner_terminates_a_silent_wedged_child` — the actual hang: a child that
  emits nothing and sleeps 120s must return in under 30s with returncode 124.
- `test_streaming_runner_reaps_grandchildren_on_timeout` — spawns a grandchild, asserts it
  is dead after the timeout. Covers the orphaned-Streamlit/browser case.
- `test_streaming_runner_without_timeout_still_completes` — `timeout_seconds=None` keeps
  the old behavior.
- `test_scenario_timeout_option_is_plumbed_from_cli` — default / `0` / custom.

One pre-existing test was updated: its `_fake_streaming` stub gained the new kwarg, and it
now asserts **both** the scenario run and the failure-artifact retry receive the budget —
an unbounded retry would have reopened the hang.

## Validation

- `pytest test/test_agilab_widget_robot_matrix.py` -> **68 passed**
- All 20 test modules referencing `agilab_widget_robot_matrix|ui_robot` -> **583 passed,
  5 skipped**
- `ruff check` on both changed files -> clean
- `./dev scope` -> `ok`, 2 files, single coherent scope (repo-tools + tests)
- `agent_commit_provenance_guard --check-config` -> pass
- A real green `ui-robot-matrix` run: **not validated** — the sweep needs Playwright plus
  a full Streamlit launch and takes ~50 minutes. This change bounds and reports the hang;
  it does not diagnose whatever wedges the child. Recommend a manual `workflow_dispatch`
  after merge to capture the first per-scenario timeout verdict, which should finally name
  the offending scenario.

## Follow-ups (not in this PR)

- `ui-robot-matrix.yml:152` passes `--quiet-progress`, so the run is silent by design.
  Dropping it (or adding the heartbeat helper already in `coverage.yml:51-59`) would make
  the next failure diagnosable. Not done here: I could not validate the effect on JSON
  summary parsing without a full robot run.
- `:157-160` passes `--retry-failed-with-artifacts` with trace/HAR/video, which multiplies
  the cost of exactly the scenarios already misbehaving.
- Nothing alerts on the aggregate job failing; it has failed three times unnoticed.

## Merge-time CI status

- `root-tests`: passed in 12m03s on the exact head SHA.
- `windows-core-tests`: passed in 4m17s.
- `clean-public-install (windows-latest)`: passed in 2m24s.
- GitGuardian: passed.
- Linux/macOS clean-install, Python 3.12/3.14 compatibility, and local-only-policy remained queued behind main-branch UI run `30635323685`, which held 19 Ubuntu shards for more than 34 minutes without completing one.
- Merge decision: bootstrap the watchdog using the green exact-SHA root/Windows gates plus the focused 583-test local validation above. No failing check was bypassed; the remaining hosted checks had not started because of provider capacity.

## Review Evidence

GPT-5 Codex independently reviewed the complete two-file diff against the merged bounded-matrix planner. Result: pass, no findings; review only, no file edits. The watchdog implementation was preferred over the audit branch's interim opt-in variant because this PR defaults the bound to 900 seconds and regression-tests grandchild reaping.

The original implementation used no sub-agent review — the multi-agent workflow runner was unavailable
(provider capacity guard), so this was written and self-reviewed single-pass. Evidence
above is primary: CI job step timings, log-line-per-minute counts, and the orphan-process
list from run `30425668881`.

## Agent Metadata

- Tokki version: 1.0.42
- Agent/runtime: Claude Code
- Model: claude-opus-5[1m] (Opus 5, 1M context)
- Reasoning effort: xhigh (ultracode)
- `/fast` mode: not used
