### PR TITLE
fix(ui-robot): bound matrix semantics and diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,8 @@ jobs:
             --extra ui \
             --with "playwright==${{ steps.playwright-version.outputs.version }}" \
             python -m pytest -q -o addopts='' \
-            test/test_agilab_widget_robot.py::test_layout_integrity_collector_uses_painted_geometry_for_expander_content
+            test/test_agilab_widget_robot.py::test_layout_integrity_collector_uses_painted_geometry_for_expander_content \
+            test/test_agilab_widget_robot.py::test_visible_combobox_semantics_collector_filters_hidden_controls
 
       - name: Save Playwright browser cache
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -128,9 +128,7 @@ jobs:
           mkdir -p \
             "${failure_bundle_dir}" \
             "${screenshot_dir}" \
-            "${failure_artifact_dir}/traces" \
-            "${failure_artifact_dir}/har" \
-            "${failure_artifact_dir}/video"
+            "${failure_artifact_dir}/traces"
           robot_apps="${ROBOT_APPS}"
           robot_timeout="${INPUT_TIMEOUT:-90}"
           robot_widget_timeout="${INPUT_WIDGET_TIMEOUT:-3}"
@@ -156,8 +154,7 @@ jobs:
             --failure-bundle-dir "${failure_bundle_dir}" \
             --retry-failed-with-artifacts \
             --retry-trace-dir "${failure_artifact_dir}/traces" \
-            --retry-har-dir "${failure_artifact_dir}/har" \
-            --retry-video-dir "${failure_artifact_dir}/video" \
+            --failure-retry-timeout 300 \
             | tee "${result_dir}/summary.json"
           status="${PIPESTATUS[0]}"
           set -e
@@ -299,7 +296,7 @@ jobs:
             test-results/ui-robot-matrix/${{ matrix.shard }}/**
             screenshots/ui-robot-matrix/${{ matrix.shard }}/**
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 3
 
   aggregate-ui-robot-matrix:
     name: ui-robot-matrix aggregate

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -1131,6 +1131,498 @@ def test_required_text_probe_reads_child_frames() -> None:
     assert probe.kind == "required_text"
 
 
+def test_required_text_probe_reads_visible_combobox_semantics() -> None:
+    module = _load_module()
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            return "ORCHESTRATE"
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        @staticmethod
+        def evaluate(script: str) -> list[str]:
+            assert script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS
+            return ["Pool executor", "Auto (ORCHESTRATE setting)"]
+
+    probe = module._required_text_probe(
+        _Page(),
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor", "Auto (ORCHESTRATE setting)"),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "interacted"
+    assert probe.kind == "required_text"
+
+
+def test_required_text_probe_reads_combobox_semantics_when_body_text_fails() -> None:
+    module = _load_module()
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            raise RuntimeError("body text unavailable")
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        @staticmethod
+        def evaluate(script: str) -> list[str]:
+            assert script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS
+            return ["Pool executor", "Auto (ORCHESTRATE setting)"]
+
+    probe = module._required_text_probe(
+        _Page(),
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor", "Auto (ORCHESTRATE setting)"),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "interacted"
+
+
+def test_required_text_probe_scrolls_to_materialize_combobox_semantics() -> None:
+    module = _load_module()
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            return "ORCHESTRATE"
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        def __init__(self) -> None:
+            self.scroll_y = 125
+            self.scrolls: list[int] = []
+            self.restore_roots: list[str] = []
+            self.semantic_collections = 0
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        def evaluate(self, script: str, *args: int) -> object:
+            if script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS:
+                self.semantic_collections += 1
+                if self.scroll_y >= 800:
+                    return ["Pool executor", "Auto (ORCHESTRATE setting)"]
+                return []
+            if script == module.SCROLL_METRICS_JS:
+                return {"root": "stMain", "y": self.scroll_y, "height": 1000, "scrollHeight": 1800}
+            if script == module.SCROLL_TO_JS:
+                target = args[0]
+                if isinstance(target, dict):
+                    self.restore_roots.append(str(target["root"]))
+                    target = target["y"]
+                self.scroll_y = int(target)
+                self.scrolls.append(self.scroll_y)
+                return None
+            raise AssertionError(f"unexpected script: {script}")
+
+        @staticmethod
+        def wait_for_timeout(_timeout_ms: float) -> None:
+            return None
+
+    page = _Page()
+    probe = module._required_text_probe(
+        page,
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor", "Auto (ORCHESTRATE setting)"),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "interacted"
+    assert page.semantic_collections >= 2
+    assert page.scrolls == [0, 800, 125]
+    assert page.scroll_y == 125
+    assert page.restore_roots == ["stMain"]
+
+
+def test_required_text_probe_retries_scroll_metrics_until_dom_materializes() -> None:
+    module = _load_module()
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            return "ORCHESTRATE"
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        def __init__(self) -> None:
+            self.scroll_y = 125
+            self.scrolls: list[int] = []
+            self.restore_targets: list[dict[str, object]] = []
+            self.metrics_collections = 0
+            self.semantic_collections = 0
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        def evaluate(self, script: str, *args: object) -> object:
+            if script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS:
+                self.semantic_collections += 1
+                if self.metrics_collections >= 4 and self.scroll_y >= 800:
+                    return ["Pool executor", "Auto (ORCHESTRATE setting)"]
+                return []
+            if script == module.SCROLL_METRICS_JS:
+                self.metrics_collections += 1
+                return {
+                    "root": "stMain",
+                    "y": self.scroll_y,
+                    "height": 1000,
+                    "scrollHeight": 1800 if self.metrics_collections >= 4 else 1000,
+                }
+            if script == module.SCROLL_TO_JS:
+                target = args[0]
+                if isinstance(target, dict):
+                    self.restore_targets.append(target)
+                    target = target["y"]
+                self.scroll_y = int(target)
+                self.scrolls.append(self.scroll_y)
+                return None
+            raise AssertionError(f"unexpected script: {script}")
+
+        @staticmethod
+        def wait_for_timeout(_timeout_ms: float) -> None:
+            return None
+
+    page = _Page()
+    probe = module._required_text_probe(
+        page,
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor", "Auto (ORCHESTRATE setting)"),
+        timeout_ms=1000,
+    )
+
+    assert probe.status == "interacted"
+    assert page.metrics_collections == 4
+    assert page.semantic_collections == 5
+    assert page.scrolls == [0, 0, 0, 800, 125]
+    assert page.restore_targets == [{"root": "stMain", "y": 125}]
+
+
+def test_required_text_probe_bounds_scroll_positions_and_deadline(monkeypatch) -> None:
+    module = _load_module()
+
+    class _Clock:
+        now = 0.0
+
+    clock = _Clock()
+    monkeypatch.setattr(module.time, "perf_counter", lambda: clock.now)
+    monkeypatch.setattr(module, "_page_scroll_positions", lambda _page: list(range(100)))
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            return "ORCHESTRATE"
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        def __init__(self) -> None:
+            self.scrolls: list[int] = []
+            self.restore_roots: list[str] = []
+            self.semantic_collections = 0
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        def evaluate(self, script: str, *args: int) -> object:
+            if script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS:
+                self.semantic_collections += 1
+                return []
+            if script == module.SCROLL_METRICS_JS:
+                return {"root": "stMain", "y": 17, "height": 1000, "scrollHeight": 100_000}
+            if script == module.SCROLL_TO_JS:
+                target = args[0]
+                if isinstance(target, dict):
+                    self.restore_roots.append(str(target["root"]))
+                    target = target["y"]
+                self.scrolls.append(int(target))
+                return None
+            raise AssertionError(f"unexpected script: {script}")
+
+        @staticmethod
+        def wait_for_timeout(timeout_ms: float) -> None:
+            clock.now += timeout_ms / 1000.0
+
+    page = _Page()
+    probe = module._required_text_probe(
+        page,
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor",),
+        timeout_ms=250,
+    )
+
+    assert probe.status == "failed"
+    assert clock.now == pytest.approx(0.25)
+    assert page.scrolls[-1] == 17
+    assert len(page.scrolls) - 1 < module.REQUIRED_TEXT_MAX_SCROLL_POSITIONS
+    assert page.semantic_collections == 3
+    assert page.restore_roots == ["stMain"]
+
+
+def test_required_text_probe_caps_repeated_scroll_attempts(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_page_scroll_positions", lambda _page: [0])
+
+    class _Locator:
+        @staticmethod
+        def inner_text(**_kwargs) -> str:
+            return "ORCHESTRATE"
+
+    class _Page:
+        url = "http://demo/ORCHESTRATE"
+        frames: list[object] = []
+        main_frame = None
+
+        def __init__(self) -> None:
+            self.scrolls: list[int] = []
+            self.restore_targets: list[dict[str, object]] = []
+            self.semantic_collections = 0
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+        def evaluate(self, script: str, *args: object) -> object:
+            if script == module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS:
+                self.semantic_collections += 1
+                return []
+            if script == module.SCROLL_METRICS_JS:
+                return {"root": "window", "y": 9, "height": 1000, "scrollHeight": 1000}
+            if script == module.SCROLL_TO_JS:
+                target = args[0]
+                if isinstance(target, dict):
+                    self.restore_targets.append(target)
+                    return None
+                self.scrolls.append(int(target))
+                return None
+            raise AssertionError(f"unexpected script: {script}")
+
+        @staticmethod
+        def wait_for_timeout(_timeout_ms: float) -> None:
+            return None
+
+    page = _Page()
+    probe = module._required_text_probe(
+        page,
+        app_name="execution_pandas_project",
+        display="ORCHESTRATE",
+        required_text=("Pool executor",),
+        timeout_ms=1000,
+    )
+
+    assert probe.status == "failed"
+    assert page.scrolls == [0] * module.REQUIRED_TEXT_MAX_SCROLL_POSITIONS
+    assert page.semantic_collections == module.REQUIRED_TEXT_MAX_SCROLL_POSITIONS + 1
+    assert page.restore_targets == [{"root": "window", "y": 9}]
+
+
+def test_required_text_scroll_positions_are_evenly_bounded() -> None:
+    module = _load_module()
+
+    positions = module._bounded_required_text_scroll_positions(range(100))
+
+    assert len(positions) == module.REQUIRED_TEXT_MAX_SCROLL_POSITIONS
+    assert positions == sorted(set(positions))
+    assert positions[0] == 0
+    assert positions[-1] == 99
+
+
+def test_visible_combobox_semantics_collector_filters_hidden_controls(monkeypatch) -> None:
+    require_browser = os.environ.get(REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION_ENV) == "1"
+    try:
+        from playwright import sync_api
+    except ModuleNotFoundError:
+        if require_browser:
+            pytest.fail("Playwright is required by the layout-regression gate", pytrace=False)
+        pytest.skip("Playwright is not installed")
+    module = _load_module()
+
+    cache_candidates = [
+        Path(REAL_PLAYWRIGHT_BROWSERS_PATH) if REAL_PLAYWRIGHT_BROWSERS_PATH else None,
+        REAL_HOME / "Library" / "Caches" / "ms-playwright",
+        REAL_HOME / ".cache" / "ms-playwright",
+        REAL_HOME / "AppData" / "Local" / "ms-playwright",
+    ]
+    cache_root = next(
+        (path for path in cache_candidates if path is not None and path.is_dir()), None
+    )
+    if cache_root is not None:
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(cache_root))
+
+    try:
+        with sync_api.sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            try:
+                page = browser.new_page(viewport={"width": 800, "height": 600})
+                page.set_content(
+                    """
+                    <style>
+                      html, body {
+                        height: 100%;
+                        margin: 0;
+                        overflow: hidden;
+                      }
+                      .offscreen {
+                        position: absolute;
+                        top: 2400px;
+                        left: 20px;
+                        width: 220px;
+                        height: 40px;
+                      }
+                      .offscreen input { width: 200px; height: 28px; }
+                      .opacity-zero { opacity: 0; }
+                      .visibility-hidden { visibility: hidden; }
+                      .visibility-collapse { visibility: collapse; }
+                      .content-hidden { content-visibility: hidden; }
+                      .clipped-ancestor {
+                        height: 0;
+                        overflow: hidden;
+                      }
+                      .outer-viewport {
+                        position: fixed;
+                        top: 20px;
+                        left: 280px;
+                        width: 300px;
+                        height: 340px;
+                        overflow: hidden;
+                      }
+                      section[data-testid="stMain"] {
+                        width: 280px;
+                        height: 300px;
+                        overflow: auto;
+                      }
+                      .scrollable-content {
+                        position: relative;
+                        height: 2800px;
+                      }
+                      .scrollable-choice {
+                        position: absolute;
+                        top: 2400px;
+                        left: 20px;
+                        width: 200px;
+                        height: 28px;
+                      }
+                      .zero-size {
+                        width: 0;
+                        height: 0;
+                        padding: 0;
+                        border: 0;
+                      }
+                      .sr-only {
+                        position: absolute;
+                        width: 1px;
+                        height: 1px;
+                        padding: 0;
+                        margin: -1px;
+                        overflow: hidden;
+                        clip: rect(0, 0, 0, 0);
+                        clip-path: inset(50%);
+                        white-space: nowrap;
+                        border: 0;
+                      }
+                    </style>
+                    <div class="offscreen">
+                      <input role="combobox" aria-label="Offscreen choice" value="Available">
+                    </div>
+                    <div hidden>
+                      <input role="combobox" aria-label="Hidden attribute" value="Hidden">
+                    </div>
+                    <div style="display: none">
+                      <input role="combobox" aria-label="Display none" value="Hidden">
+                    </div>
+                    <div class="opacity-zero">
+                      <input role="combobox" aria-label="Opacity zero" value="Hidden">
+                    </div>
+                    <div class="visibility-hidden">
+                      <input role="combobox" aria-label="Visibility hidden" value="Hidden">
+                    </div>
+                    <div class="visibility-collapse">
+                      <input role="combobox" aria-label="Visibility collapse" value="Hidden">
+                    </div>
+                    <div class="content-hidden">
+                      <input role="combobox" aria-label="Content hidden" value="Hidden">
+                    </div>
+                    <div class="clipped-ancestor">
+                      <input role="combobox" aria-label="Ancestor clipped" value="Hidden">
+                    </div>
+                    <div class="outer-viewport">
+                      <section data-testid="stMain">
+                        <div class="scrollable-content">
+                          <input class="scrollable-choice" role="combobox" aria-label="Scrollable choice" value="Reachable">
+                        </div>
+                      </section>
+                    </div>
+                    <input class="zero-size" role="combobox" aria-label="Zero size" value="Hidden">
+                    <input class="sr-only" role="combobox" aria-label="Screen reader only" value="Hidden">
+                    """
+                )
+
+                page.evaluate(module.SCROLL_TO_JS, 125)
+                offscreen_box = page.locator("[aria-label='Offscreen choice']").bounding_box()
+                sr_only_box = page.locator("[aria-label='Screen reader only']").bounding_box()
+                initial_metrics = page.evaluate(module.SCROLL_METRICS_JS)
+                initial_semantics = page.evaluate(module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS)
+                probe = module._required_text_probe(
+                    page,
+                    app_name="execution_pandas_project",
+                    display="ORCHESTRATE",
+                    required_text=("Scrollable choice", "Reachable"),
+                    timeout_ms=3000,
+                )
+                final_metrics = page.evaluate(module.SCROLL_METRICS_JS)
+                restored_semantics = page.evaluate(module.VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS)
+            finally:
+                browser.close()
+    except sync_api.Error as exc:
+        if require_browser:
+            pytest.fail(f"Chromium is required by the layout-regression gate: {exc}", pytrace=False)
+        pytest.skip(f"Chromium is unavailable for combobox collector regression: {exc}")
+
+    assert offscreen_box is not None
+    assert offscreen_box["y"] > 600
+    assert sr_only_box is not None
+    assert sr_only_box["width"] == 1
+    assert sr_only_box["height"] == 1
+    assert initial_metrics == {"root": "stMain", "y": 125, "height": 300, "scrollHeight": 2800}
+    assert initial_semantics == ["Offscreen choice", "Available"]
+    assert probe.status == "interacted"
+    assert final_metrics == initial_metrics
+    assert restored_semantics == initial_semantics
+
+
 def test_required_text_probe_reports_missing_text() -> None:
     module = _load_module()
 

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -74,28 +74,28 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert project_editor.pages == "PROJECT_EDITOR"
     assert project_editor.apps_pages == "none"
     assert project_editor.runtime_isolation == "isolated"
-    assert project_editor.action_button_policy == "safe-click"
+    assert project_editor.action_button_policy == "trial"
     assert project_editor.required_text == "Edit project files"
     assert project_editor.forbidden_text == "Worker class,Source LOC,Environment Health"
     assert project_notebook.pages == "PROJECT"
     assert project_notebook.route_query == "start=notebook-import"
     assert project_notebook.apps_pages == "none"
     assert project_notebook.runtime_isolation == "isolated"
-    assert project_notebook.action_button_policy == "safe-click"
+    assert project_notebook.action_button_policy == "trial"
     assert project_import.pages == "PROJECT"
     assert project_import.preselect_labels == "Import"
     assert project_import.apps_pages == "none"
     assert project_import.runtime_isolation == "isolated"
-    assert project_import.action_button_policy == "safe-click"
+    assert project_import.action_button_policy == "trial"
     assert project_rename.pages == "PROJECT"
     assert project_rename.preselect_labels == "Rename"
     assert project_rename.apps_pages == "none"
     assert project_rename.runtime_isolation == "isolated"
-    assert project_rename.action_button_policy == "safe-click"
+    assert project_rename.action_button_policy == "trial"
     assert settings.pages == "SETTINGS"
     assert settings.apps_pages == "none"
     assert settings.runtime_isolation == "isolated"
-    assert settings.action_button_policy == "safe-click"
+    assert settings.action_button_policy == "trial"
     assert settings.action_timeout_seconds == 30.0
     assert current_home.pages == "ORCHESTRATE"
     assert current_home.runtime_isolation == "current-home"
@@ -124,6 +124,8 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert pool_parameters.apps == "flight_telemetry_project"
     assert pool_parameters.runtime_isolation == "isolated"
     assert pool_parameters.action_button_policy == "trial"
+    assert pool_parameters.interaction_mode == "actionability"
+    assert pool_parameters.combination_mode == "off"
     assert pool_parameters.max_action_clicks_per_page == 0
     assert pool_parameters.required_text == "Pool parameters,Max workers,Item timeout seconds,Pool executor"
     assert pool_parameters.browser_error_check is True
@@ -131,6 +133,8 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert execution_pandas_pool.apps == "execution_pandas_project"
     assert execution_pandas_pool.runtime_isolation == "isolated"
     assert execution_pandas_pool.action_button_policy == "trial"
+    assert execution_pandas_pool.interaction_mode == "actionability"
+    assert execution_pandas_pool.combination_mode == "off"
     assert execution_pandas_pool.max_action_clicks_per_page == 0
     assert execution_pandas_pool.required_text == "Pool executor,Auto (ORCHESTRATE setting)"
     assert execution_pandas_pool.browser_error_check is True
@@ -167,7 +171,7 @@ def test_opt_in_browser_history_scenario_is_not_part_of_default_all() -> None:
     assert history.pages == "PROJECT"
     assert history.apps_pages == "none"
     assert history.runtime_isolation == "isolated"
-    assert history.action_button_policy == "safe-click"
+    assert history.action_button_policy == "trial"
     assert history.browser_history_check is True
 
 
@@ -230,6 +234,8 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert hf_apps_pages_smoke.name not in default_names
     assert hf_view_maps_smoke.name not in default_names
     assert cross_browser.name not in default_names
+    assert pytorch_analysis.interaction_mode == "actionability"
+    assert pytorch_analysis.combination_mode == "off"
     assert mobile.viewport_width == 390
     assert mobile.viewport_height == 844
     assert evidence.success_screenshot is True
@@ -319,6 +325,8 @@ def test_build_robot_command_contains_scenario_controls(tmp_path) -> None:
     assert argv[argv.index("--pages") + 1] == "ORCHESTRATE"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "current-home"
+    assert argv[argv.index("--interaction-mode") + 1] == "full"
+    assert argv[argv.index("--combination-mode") + 1] == "exhaustive"
     assert argv[argv.index("--action-button-policy") + 1] == "click-selected"
     assert argv[argv.index("--click-action-labels") + 1] == "CHECK distribute,Run -> Load -> Export"
     assert argv[argv.index("--preselect-labels") + 1] == "Run now"
@@ -443,7 +451,7 @@ def test_build_robot_command_enables_browser_history_check(tmp_path) -> None:
     argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
 
     assert argv[argv.index("--pages") + 1] == "PROJECT"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert "--browser-history-check" in argv
     assert argv[argv.index("--screenshot-dir") + 1] == str(tmp_path / "screenshots" / "isolated-browser-history")
     assert summary_path == tmp_path / "isolated-browser-history.json"
@@ -608,6 +616,8 @@ def test_build_robot_command_covers_pytorch_playground_analysis_text(tmp_path) -
     assert argv[argv.index("--apps") + 1] == "pytorch_playground_project"
     assert argv[argv.index("--pages") + 1] == "ANALYSIS"
     assert argv[argv.index("--apps-pages") + 1] == "none"
+    assert argv[argv.index("--interaction-mode") + 1] == "actionability"
+    assert argv[argv.index("--combination-mode") + 1] == "off"
     assert argv[argv.index("--route-query") + 1] == "current_page=app_ui"
     assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
     assert argv[argv.index("--forbidden-sidebar-text") + 1] == "Project:"
@@ -616,6 +626,39 @@ def test_build_robot_command_covers_pytorch_playground_analysis_text(tmp_path) -
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "isolated-pytorch-playground-analysis.json"
     assert progress_path == tmp_path / "isolated-pytorch-playground-analysis.ndjson"
+
+
+def test_build_robot_command_covers_execution_pandas_pool_executor_text(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.ALL_SCENARIOS["isolated-execution-pandas-orchestrate-pool-executor"]
+    options = module.MatrixOptions(
+        apps="all",
+        output_dir=tmp_path,
+        screenshot_dir=tmp_path / "screenshots",
+        timeout_seconds=12.0,
+        widget_timeout_seconds=2.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+    )
+
+    argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
+
+    assert argv[argv.index("--apps") + 1] == "execution_pandas_project"
+    assert argv[argv.index("--pages") + 1] == "ORCHESTRATE"
+    assert argv[argv.index("--apps-pages") + 1] == "none"
+    assert argv[argv.index("--interaction-mode") + 1] == "actionability"
+    assert argv[argv.index("--combination-mode") + 1] == "off"
+    assert argv[argv.index("--required-text") + 1] == "Pool executor,Auto (ORCHESTRATE setting)"
+    assert "--browser-error-check" in argv
+    assert summary_path == tmp_path / "isolated-execution-pandas-orchestrate-pool-executor.json"
+    assert progress_path == tmp_path / "isolated-execution-pandas-orchestrate-pool-executor.ndjson"
+
+    pool_argv, _, _ = module.build_robot_command(
+        module.ALL_SCENARIOS["isolated-orchestrate-pool-parameters"],
+        options=options,
+    )
+    assert pool_argv[pool_argv.index("--interaction-mode") + 1] == "actionability"
+    assert pool_argv[pool_argv.index("--combination-mode") + 1] == "off"
 
 
 def test_build_robot_command_covers_network_sim_analysis_no_app_ui_link(tmp_path) -> None:
@@ -1125,7 +1168,7 @@ def test_build_robot_command_covers_project_editor_page(tmp_path) -> None:
     assert argv[argv.index("--pages") + 1] == "PROJECT_EDITOR"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--required-text") + 1] == "Edit project files"
     assert argv[argv.index("--forbidden-text") + 1] == "Worker class,Source LOC,Environment Health"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
@@ -1153,7 +1196,7 @@ def test_build_robot_command_covers_project_notebook_import_deep_link(tmp_path) 
     assert argv[argv.index("--pages") + 1] == "PROJECT"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--route-query") + 1] == "start=notebook-import"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
         tmp_path / "screenshots" / "isolated-project-notebook-import"
@@ -1180,7 +1223,7 @@ def test_build_robot_command_covers_project_import_sidebar(tmp_path) -> None:
     assert argv[argv.index("--pages") + 1] == "PROJECT"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--preselect-labels") + 1] == "Import"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
         tmp_path / "screenshots" / "isolated-project-import-sidebar"
@@ -1207,7 +1250,7 @@ def test_build_robot_command_covers_project_rename_sidebar(tmp_path) -> None:
     assert argv[argv.index("--pages") + 1] == "PROJECT"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--preselect-labels") + 1] == "Rename"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
         tmp_path / "screenshots" / "isolated-project-rename-sidebar"
@@ -1234,7 +1277,7 @@ def test_build_robot_command_covers_settings_page(tmp_path) -> None:
     assert argv[argv.index("--pages") + 1] == "SETTINGS"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--action-timeout") + 1] == "30.0"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
         tmp_path / "screenshots" / "isolated-settings-page"
@@ -1338,6 +1381,19 @@ def test_scenario_timeout_option_is_plumbed_from_cli() -> None:
     assert default_opts.scenario_timeout_seconds == module.DEFAULT_SCENARIO_TIMEOUT_SECONDS
     assert disabled_opts.scenario_timeout_seconds is None
     assert custom_opts.scenario_timeout_seconds == 45.0
+
+    assert (
+        default_opts.failure_retry_timeout_seconds
+        == module.DEFAULT_FAILURE_RETRY_TIMEOUT_SECONDS
+    )
+    disabled_retry = module.options_from_args(
+        module._build_parser().parse_args(["--failure-retry-timeout", "0"])
+    )
+    custom_retry = module.options_from_args(
+        module._build_parser().parse_args(["--failure-retry-timeout", "75"])
+    )
+    assert disabled_retry.failure_retry_timeout_seconds is None
+    assert custom_retry.failure_retry_timeout_seconds == 75.0
 
 
 def test_load_summary_falls_back_to_stdout_json_and_default_failure(tmp_path) -> None:
@@ -1598,16 +1654,16 @@ def test_streaming_default_paths_for_scenario_and_failure_retry(tmp_path, monkey
     assert result.returncode == 0
     assert retry.returncode == 0
     assert len(calls) == 2
-    # Both the main scenario run and the failure-artifact retry must inherit the
-    # per-scenario watchdog budget; an unbounded retry would reopen the hang.
+    # The main scenario retains its watchdog while the diagnostic retry is
+    # deliberately shorter so evidence collection cannot reopen the hang.
     assert seen_timeouts == [
         module.DEFAULT_SCENARIO_TIMEOUT_SECONDS,
-        module.DEFAULT_SCENARIO_TIMEOUT_SECONDS,
+        module.DEFAULT_FAILURE_RETRY_TIMEOUT_SECONDS,
     ]
     assert retry_options.screenshot_dir == options.output_dir / "failure-artifacts" / "screenshots"
     assert retry_options.trace_dir == options.output_dir / "failure-artifacts" / "traces"
-    assert retry_options.har_dir == options.output_dir / "failure-artifacts" / "har"
-    assert retry_options.video_dir == options.output_dir / "failure-artifacts" / "video"
+    assert retry_options.har_dir is None
+    assert retry_options.video_dir is None
 
 
 def test_run_matrix_ignores_malformed_cache_entries_and_failure_sample_limits(tmp_path, monkeypatch) -> None:
@@ -2030,8 +2086,7 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
         no_seed_demo_artifacts=False,
         retry_failed_with_artifacts=True,
         retry_trace_dir=tmp_path / "retry" / "traces",
-        retry_har_dir=tmp_path / "retry" / "har",
-        retry_video_dir=tmp_path / "retry" / "video",
+        failure_retry_timeout_seconds=30.0,
     )
     calls: list[list[str]] = []
 
@@ -2040,6 +2095,14 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
         summary_path = Path(argv[argv.index("--json-output") + 1])
         progress_path = Path(argv[argv.index("--progress-log") + 1])
         is_retry = "failure-retry" in summary_path.parts
+        page_result = {
+            "app": "flight_telemetry_project",
+            "page": "PROJECT",
+            "success": True,
+            "status": "passed",
+            "failed_count": 0,
+            "failures": [],
+        }
         summary_path.parent.mkdir(parents=True, exist_ok=True)
         progress_path.parent.mkdir(parents=True, exist_ok=True)
         summary_path.write_text(
@@ -2051,7 +2114,8 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
                     "interacted_count": 0,
                     "probed_count": 1,
                     "skipped_count": 0,
-                    "failed_count": 0 if is_retry else 1,
+                    "failed_count": 0,
+                    "pages": [page_result],
                 }
             ),
             encoding="utf-8",
@@ -2062,12 +2126,17 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
                     "event": "page_done",
                     "scenario": scenario.name,
                     "success": is_retry,
+                    "result": page_result,
                 }
             )
             + "\n",
             encoding="utf-8",
         )
-        return subprocess.CompletedProcess(argv, 0 if is_retry else 1, stdout="")
+        return subprocess.CompletedProcess(
+            argv,
+            0 if is_retry else module.SCENARIO_TIMEOUT_RETURNCODE,
+            stdout="",
+        )
 
     result = module.run_scenario(scenario, options=options, runner=_runner)
     summary = module.summarize_matrix([result])
@@ -2080,13 +2149,12 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
     assert retry_argv[retry_argv.index("--trace-dir") + 1] == str(
         tmp_path / "retry" / "traces" / "isolated-project-page"
     )
-    assert retry_argv[retry_argv.index("--har-dir") + 1] == str(
-        tmp_path / "retry" / "har" / "isolated-project-page"
+    assert "--har-dir" not in retry_argv
+    assert "--video-dir" not in retry_argv
+    assert retry_argv[retry_argv.index("--resume-from-progress") + 1] == str(
+        tmp_path / "results" / "isolated-project-page.ndjson"
     )
-    assert retry_argv[retry_argv.index("--video-dir") + 1] == str(
-        tmp_path / "retry" / "video" / "isolated-project-page"
-    )
-    assert result.returncode == 1
+    assert result.returncode == module.SCENARIO_TIMEOUT_RETURNCODE
     assert result.artifact_retry is not None
     assert result.artifact_retry.returncode == 0
     assert summary["success"] is False
@@ -2104,6 +2172,248 @@ def test_run_scenario_retries_failed_scenario_with_artifacts(tmp_path) -> None:
         ).read_text(encoding="utf-8")
     )
     assert manifest["failure_artifact_retry"]["success"] is True
+
+
+def test_failure_artifact_retry_rejects_semantic_and_page_watchdog_failures(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-project-page"]
+
+    cases = [
+        (
+            1,
+            {"success": False, "failed_count": 1, "pages": []},
+            "not an infrastructure watchdog",
+        ),
+        (
+            module.SCENARIO_TIMEOUT_RETURNCODE,
+            {
+                "success": False,
+                "failed_count": 1,
+                "pages": [
+                    {
+                        "app": "flight_telemetry_project",
+                        "page": "ORCHESTRATE",
+                        "success": False,
+                        "status": "timed_out",
+                        "failed_count": 1,
+                        "failures": [
+                            {
+                                "kind": "page_watchdog",
+                                "detail": "page watchdog expired after 420 seconds",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "already contains failure evidence",
+        ),
+        (
+            module.SCENARIO_TIMEOUT_RETURNCODE,
+            {
+                "success": False,
+                "failed_count": 1,
+                "pages": [
+                    {
+                        "app": "flight_telemetry_project",
+                        "page": "PROJECT",
+                        "success": False,
+                        "status": "failed",
+                        "failed_count": 1,
+                        "failures": [
+                            {
+                                "kind": "combination_space",
+                                "detail": "combination space was capped",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "already contains failure evidence",
+        ),
+    ]
+
+    for index, (returncode, summary, expected_reason) in enumerate(cases):
+        result = module.ScenarioResult(
+            scenario=scenario,
+            argv=["robot"],
+            returncode=returncode,
+            duration_seconds=1.0,
+            summary_path=tmp_path / f"summary-{index}.json",
+            progress_path=tmp_path / f"progress-{index}.ndjson",
+            summary=summary,
+            output="",
+        )
+        eligible, reason = module._failure_artifact_retry_decision(result)
+        assert eligible is False
+        assert expected_reason in reason
+
+
+def test_run_scenario_does_not_retry_a_page_watchdog(tmp_path, capsys) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-core-pages"]
+    options = module.MatrixOptions(
+        apps="flight_telemetry_project",
+        output_dir=tmp_path / "results",
+        screenshot_dir=None,
+        timeout_seconds=10.0,
+        widget_timeout_seconds=1.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+        retry_failed_with_artifacts=True,
+    )
+    calls = 0
+
+    def _runner(argv, **_kwargs):
+        nonlocal calls
+        calls += 1
+        summary_path = Path(argv[argv.index("--json-output") + 1])
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(
+            json.dumps(
+                {
+                    "success": False,
+                    "failed_count": 1,
+                    "pages": [
+                        {
+                            "app": "flight_telemetry_project",
+                            "page": "ORCHESTRATE",
+                            "success": False,
+                            "status": "timed_out",
+                            "failed_count": 1,
+                            "failures": [
+                                {"kind": "page_watchdog", "detail": "page watchdog expired"}
+                            ],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(
+            argv, module.SCENARIO_TIMEOUT_RETURNCODE, stdout=""
+        )
+
+    result = module.run_scenario(scenario, options=options, runner=_runner)
+
+    assert calls == 1
+    assert result.artifact_retry is None
+    assert "compact retry skipped" in capsys.readouterr().err
+
+
+def test_run_scenario_uses_progress_log_to_reject_retry_when_summary_is_missing(
+    tmp_path, capsys
+) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-core-pages"]
+    options = module.MatrixOptions(
+        apps="flight_telemetry_project",
+        output_dir=tmp_path / "results",
+        screenshot_dir=None,
+        timeout_seconds=10.0,
+        widget_timeout_seconds=1.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+        retry_failed_with_artifacts=True,
+    )
+    calls = 0
+
+    def _runner(argv, **_kwargs):
+        nonlocal calls
+        calls += 1
+        progress_path = Path(argv[argv.index("--progress-log") + 1])
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        progress_path.write_text(
+            json.dumps(
+                {
+                    "event": "page_done",
+                    "result": {
+                        "app": "flight_telemetry_project",
+                        "page": "ORCHESTRATE",
+                        "success": False,
+                        "status": "timed_out",
+                        "failed_count": 1,
+                        "failures": [
+                            {
+                                "kind": "combination",
+                                "detail": "page watchdog expired after 420 seconds",
+                            }
+                        ],
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(
+            argv, module.SCENARIO_TIMEOUT_RETURNCODE, stdout="not-json"
+        )
+
+    result = module.run_scenario(scenario, options=options, runner=_runner)
+
+    assert calls == 1
+    assert result.summary["error"] == "robot did not emit a JSON summary"
+    assert result.artifact_retry is None
+    assert "already contains failure evidence" in capsys.readouterr().err
+
+
+def test_failure_artifact_retry_rejects_a_truncated_progress_log(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-core-pages"]
+    progress_path = tmp_path / "progress.ndjson"
+    progress_path.write_text(
+        '{"event":"page_start","app":"flight_telemetry_project"}\n{"event":"page_done"',
+        encoding="utf-8",
+    )
+    result = module.ScenarioResult(
+        scenario=scenario,
+        argv=["robot"],
+        returncode=module.SCENARIO_TIMEOUT_RETURNCODE,
+        duration_seconds=1.0,
+        summary_path=tmp_path / "missing.json",
+        progress_path=progress_path,
+        summary={"success": False, "error": "robot did not emit a JSON summary"},
+        output="",
+    )
+
+    eligible, reason = module._failure_artifact_retry_decision(result)
+
+    assert eligible is False
+    assert "progress evidence is malformed" in reason
+
+
+def test_failure_artifact_retry_rejects_incomplete_page_done_evidence(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-core-pages"]
+    progress_path = tmp_path / "progress.ndjson"
+    progress_path.write_text(
+        json.dumps(
+            {
+                "event": "page_done",
+                "result": {
+                    "app": "flight_telemetry_project",
+                    "page": "ORCHESTRATE",
+                    "failed_count": 0,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = module.ScenarioResult(
+        scenario=scenario,
+        argv=["robot"],
+        returncode=module.SCENARIO_TIMEOUT_RETURNCODE,
+        duration_seconds=1.0,
+        summary_path=tmp_path / "missing.json",
+        progress_path=progress_path,
+        summary={"success": False, "error": "robot did not emit a JSON summary"},
+        output="",
+    )
+
+    eligible, reason = module._failure_artifact_retry_decision(result)
+
+    assert eligible is False
+    assert "already contains failure evidence" in reason
 
 
 def test_run_matrix_fail_fast_stops_on_first_failed_scenario(tmp_path) -> None:

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -107,8 +107,7 @@ def _ui_robot_matrix_command_contract(argv: list[str]) -> dict[str, object]:
         "failure_bundle_dir": _single_option(argv, "--failure-bundle-dir"),
         "retry_failed_with_artifacts": "--retry-failed-with-artifacts" in argv,
         "retry_trace_dir": _single_option(argv, "--retry-trace-dir"),
-        "retry_har_dir": _single_option(argv, "--retry-har-dir"),
-        "retry_video_dir": _single_option(argv, "--retry-video-dir"),
+        "failure_retry_timeout": _single_option(argv, "--failure-retry-timeout"),
     }
 
 
@@ -129,8 +128,7 @@ def _ui_robot_matrix_workflow_contracts() -> dict[str, dict[str, object]]:
             "failure_bundle_dir": f"test-results/ui-robot-matrix/{shard}/failure-bundles",
             "retry_failed_with_artifacts": True,
             "retry_trace_dir": f"test-results/ui-robot-matrix/{shard}/failure-artifacts/traces",
-            "retry_har_dir": f"test-results/ui-robot-matrix/{shard}/failure-artifacts/har",
-            "retry_video_dir": f"test-results/ui-robot-matrix/{shard}/failure-artifacts/video",
+            "failure_retry_timeout": "300",
         }
         for shard, scenarios in _ui_robot_matrix_workflow_shards().items()
     }
@@ -171,6 +169,16 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
         "Install Playwright browser for frontend smoke", 1
     )[0]
     assert "Install Playwright browser for frontend smoke" in text
+    assert "Validate widget layout visibility collector" in text
+    assert 'AGILAB_REQUIRE_PLAYWRIGHT_LAYOUT_REGRESSION: "1"' in text
+    assert (
+        "test/test_agilab_widget_robot.py::"
+        "test_layout_integrity_collector_uses_painted_geometry_for_expander_content"
+    ) in text
+    assert (
+        "test/test_agilab_widget_robot.py::"
+        "test_visible_combobox_semantics_collector_filters_hidden_controls"
+    ) in text
     assert "Validate Streamlit frontend smoke" in text
     assert (
         'uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" '
@@ -501,8 +509,10 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert '--failure-bundle-dir "${failure_bundle_dir}"' in text
     assert "--retry-failed-with-artifacts" in text
     assert '--retry-trace-dir "${failure_artifact_dir}/traces"' in text
-    assert '--retry-har-dir "${failure_artifact_dir}/har"' in text
-    assert '--retry-video-dir "${failure_artifact_dir}/video"' in text
+    assert "--retry-har-dir" not in text
+    assert "--retry-video-dir" not in text
+    assert "--failure-retry-timeout 300" in text
+    assert "retention-days: 3" in text
     assert "tools/ui_robot_trend_report.py" in text
     assert '--glob "${result_dir}/*.ndjson"' in text
     assert "--max-total-seconds 2700" in text

--- a/test/test_ui_robot_matrix_plan.py
+++ b/test/test_ui_robot_matrix_plan.py
@@ -88,7 +88,7 @@ def test_current_all_app_plan_is_complete_bounded_and_deterministic() -> None:
     ]
     assert plan["apps"] == filesystem_apps
     assert plan["app_count"] == 14
-    assert plan["shard_count"] == 34
+    assert plan["shard_count"] == 35
     assert plan["estimated_page_count"] == 951
     assert plan["max_estimated_pages"] == 32
     assert max(int(shard["estimated_pages"]) for shard in shards) <= 32
@@ -97,6 +97,7 @@ def test_current_all_app_plan_is_complete_bounded_and_deterministic() -> None:
     planned_scenarios = set(_scenario_names(plan))
     configured_scenarios = {
         *planner.CORE_SCENARIOS,
+        *planner.APP_PAGE_SCENARIOS,
         *planner.STATE_MOBILE_SCENARIOS,
         *planner.QUALITY_SCENARIOS,
         *planner.LAYOUT_SCENARIOS,
@@ -133,6 +134,44 @@ def test_current_all_app_plan_is_complete_bounded_and_deterministic() -> None:
                 [shard for shard in shards if str(shard["shard"]).startswith(f"{prefix}-")]
             )
 
+    configured_page_apps = sorted(
+        app
+        for app in filesystem_apps
+        if planner.configured_apps_page_count(planner.DEFAULT_APPS_ROOT / app) > 0
+    )
+    app_page_shards = [
+        shard
+        for shard in shards
+        if str(shard["shard"]).startswith("app-pages-")
+    ]
+    app_page_apps = [
+        app
+        for shard in app_page_shards
+        for app in str(shard["apps"]).split(",")
+    ]
+    assert configured_page_apps == [
+        "flight_telemetry_project",
+        "mission_decision_project",
+        "uav_queue_project",
+        "uav_relay_queue_project",
+        "weather_forecast_project",
+    ]
+    assert sorted(app_page_apps) == configured_page_apps
+    assert len(app_page_apps) == len(set(app_page_apps))
+    assert all(
+        str(shard["scenarios"]) == "isolated-entry-and-app-pages"
+        for shard in app_page_shards
+    )
+    for scenario in planner.APP_PAGE_SCENARIOS:
+        assert _scenario_names(plan).count(scenario) == len(app_page_shards)
+
+    covered_by_any_shard = {
+        app
+        for shard in shards
+        for app in str(shard["apps"]).split(",")
+    }
+    assert sorted(covered_by_any_shard) == filesystem_apps
+
     for scenario, _app in planner.FOCUSED_SCENARIOS:
         assert _scenario_names(plan).count(scenario) == 1
 
@@ -146,13 +185,96 @@ def test_subset_plan_excludes_unrequested_apps_and_focused_overrides() -> None:
     selected = {"flight_telemetry_project", "pytorch_playground_project"}
     shards = plan["matrix"]["include"]
     focused = next(shard for shard in shards if shard["shard"] == "focused")
+    app_pages = next(shard for shard in shards if shard["shard"] == "app-pages-01")
 
     assert plan["apps"] == sorted(selected)
     assert all(set(str(shard["apps"]).split(",")) <= selected for shard in shards)
     assert focused["scenarios"] == "isolated-pytorch-playground-analysis"
+    assert app_pages["scenarios"] == "isolated-entry-and-app-pages"
+    assert app_pages["apps"] == "flight_telemetry_project"
     assert "execution_pandas_project" not in focused["apps"]
     assert _scenario_names(plan).count("isolated-pytorch-playground-analysis") == 1
     assert "isolated-execution-pandas-orchestrate-pool-executor" not in _scenario_names(plan)
+
+
+def test_scheduled_scenarios_have_one_bounded_exhaustive_lane() -> None:
+    planner = _load_module("ui_robot_matrix_plan_modes_module", PLAN_MODULE_PATH)
+    matrix = _load_module("ui_robot_matrix_modes_module", MATRIX_MODULE_PATH)
+
+    scheduled = {
+        *planner.CORE_SCENARIOS,
+        *planner.APP_PAGE_SCENARIOS,
+        *planner.STATE_MOBILE_SCENARIOS,
+        *planner.QUALITY_SCENARIOS,
+        *planner.LAYOUT_SCENARIOS,
+        *(scenario for scenario, _app in planner.FOCUSED_SCENARIOS),
+    }
+    expected = {
+        name: ("actionability", "off", "trial", 0)
+        for name in scheduled
+    }
+    expected["isolated-project-page"] = (
+        "full",
+        "exhaustive",
+        "safe-click",
+        25,
+    )
+    for name in (
+        "isolated-project-notebook-import",
+        "isolated-project-import-sidebar",
+        "isolated-project-rename-sidebar",
+    ):
+        expected[name] = ("full", "off", "trial", 0)
+
+    actual = {
+        name: (
+            matrix.ALL_SCENARIOS[name].interaction_mode,
+            matrix.ALL_SCENARIOS[name].combination_mode,
+            matrix.ALL_SCENARIOS[name].action_button_policy,
+            matrix.ALL_SCENARIOS[name].max_action_clicks_per_page,
+        )
+        for name in scheduled
+    }
+
+    assert scheduled == EXPECTED_WORKFLOW_SCENARIOS
+    assert len(scheduled) == 22
+    assert actual == expected
+    assert sum(mode[0] == "full" for mode in actual.values()) == 4
+    assert sum(mode[1] == "exhaustive" for mode in actual.values()) == 1
+
+
+def test_app_page_shards_exclude_zero_page_apps_without_losing_exact_inventory(
+    tmp_path: Path,
+) -> None:
+    planner = _load_module("ui_robot_matrix_plan_app_pages_module", PLAN_MODULE_PATH)
+    apps_root = tmp_path / "builtin"
+    configured_src = apps_root / "configured_project" / "src"
+    configured_src.mkdir(parents=True)
+    (configured_src / "app_settings.toml").write_text(
+        "[pages]\nview_module = [\"view_a\", \"view_b\"]\n",
+        encoding="utf-8",
+    )
+    (apps_root / "plain_project" / "src").mkdir(parents=True)
+
+    plan = planner.build_plan(apps_root=apps_root)
+    shards = plan["matrix"]["include"]
+    app_page_shards = [
+        shard
+        for shard in shards
+        if str(shard["shard"]).startswith("app-pages-")
+    ]
+
+    assert plan["apps"] == ["configured_project", "plain_project"]
+    assert plan["app_count"] == 2
+    assert len(app_page_shards) == 1
+    assert app_page_shards[0]["apps"] == "configured_project"
+    assert app_page_shards[0]["estimated_pages"] == 2
+    assert app_page_shards[0]["scenarios"] == "isolated-entry-and-app-pages"
+    assert {
+        app
+        for shard in shards
+        for app in str(shard["apps"]).split(",")
+    } == {"configured_project", "plain_project"}
 
 
 def test_plan_rejects_unknown_empty_and_overweight_inventory(tmp_path: Path) -> None:

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -543,14 +543,9 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             f"test-results/ui-robot-matrix/{shard}/failure-artifacts/traces"
             in command.argv
         )
-        assert (
-            f"test-results/ui-robot-matrix/{shard}/failure-artifacts/har"
-            in command.argv
-        )
-        assert (
-            f"test-results/ui-robot-matrix/{shard}/failure-artifacts/video"
-            in command.argv
-        )
+        assert "--retry-har-dir" not in command.argv
+        assert "--retry-video-dir" not in command.argv
+        assert command.argv[command.argv.index("--failure-retry-timeout") + 1] == "300"
         assert _has_with_dependency(command.argv, "playwright")
         assert _has_extra(command.argv, "ai")
     assert ui_artifact_capture_robot.label == "ui artifact capture robot"

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -65,6 +65,8 @@ ACTION_OUTCOME_POLL_MS = 100
 # loops. They must stay small so a missing element does not stall the loop for seconds.
 LOCATOR_VISIBILITY_TIMEOUT_MS = 500
 BODY_TEXT_PROBE_TIMEOUT_MS = 1000
+REQUIRED_TEXT_MAX_SCROLL_POSITIONS = 24
+REQUIRED_TEXT_SCROLL_SETTLE_MS = 100.0
 # Substring (lower-cased) of the AGILAB boot spinner copy rendered by
 # ``st.spinner("Initializing environment...")`` in src/agilab/main_page.py. Readiness detection
 # keys off this text, so keep it in sync if that copy changes.
@@ -341,6 +343,76 @@ WIDGET_COLLECTOR_JS = r"""
 }
 """
 
+VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS = r"""
+() => {
+  const semantics = [];
+  const seen = new Set();
+  const clips = (value) => ["auto", "clip", "hidden", "scroll"].includes(value);
+  const paintedRect = (el) => {
+    const raw = el.getBoundingClientRect();
+    if (raw.width <= 0 || raw.height <= 0) return null;
+    const rect = {left: raw.left, right: raw.right, top: raw.top, bottom: raw.bottom};
+    for (let current = el; current; current = current.parentElement) {
+      const style = window.getComputedStyle(current);
+      if (
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        style.visibility === "collapse" ||
+        style.contentVisibility === "hidden" ||
+        Number(style.opacity || "1") <= 0.01
+      ) {
+        return null;
+      }
+      if (current.tagName === "DETAILS" && !current.open) {
+        const summary = Array.from(current.children).find((child) => child.tagName === "SUMMARY");
+        if (!summary || !summary.contains(el)) return null;
+      }
+      if (current === el || current === document.body || current === document.documentElement) continue;
+      const contain = String(style.contain || "").split(/\s+/);
+      const clipX = clips(style.overflowX) || contain.some((value) => ["content", "paint", "strict"].includes(value));
+      const clipY = clips(style.overflowY) || contain.some((value) => ["content", "paint", "strict"].includes(value));
+      if (!clipX && !clipY) continue;
+      const ancestor = current.getBoundingClientRect();
+      if (clipX) {
+        rect.left = Math.max(rect.left, ancestor.left);
+        rect.right = Math.min(rect.right, ancestor.right);
+      }
+      if (clipY) {
+        rect.top = Math.max(rect.top, ancestor.top);
+        rect.bottom = Math.min(rect.bottom, ancestor.bottom);
+      }
+      if (rect.right <= rect.left || rect.bottom <= rect.top) return null;
+    }
+    return {
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      bottom: rect.bottom,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+    };
+  };
+  const isHidden = (element) => {
+    if (element.closest("[aria-hidden='true']")) return true;
+    const rect = paintedRect(element);
+    return rect === null || rect.width < 2 || rect.height < 2;
+  };
+  const append = (value) => {
+    const normalized = String(value || "").trim().replace(/\s+/g, " ");
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      semantics.push(normalized);
+    }
+  };
+  for (const element of document.querySelectorAll("[role='combobox']")) {
+    if (isHidden(element)) continue;
+    append(element.getAttribute("aria-label"));
+    append(element.value);
+  }
+  return semantics;
+}
+"""
+
 OPEN_EXPANDERS_JS = r"""
 () => {
   let changed = 0;
@@ -411,13 +483,41 @@ CLOSE_EXPANDERS_EXCEPT_WIDGET_JS = r"""
 
 SCROLL_METRICS_JS = r"""
 () => {
+  const main = document.querySelector("section[data-testid='stMain']");
+  if (main && main.scrollHeight > main.clientHeight) {
+    return {
+      root: "stMain",
+      y: main.scrollTop || 0,
+      height: main.clientHeight || 1,
+      scrollHeight: main.scrollHeight || 0,
+    };
+  }
   const doc = document.documentElement;
   const body = document.body || doc;
   return {
+    root: "window",
     y: window.scrollY || doc.scrollTop || body.scrollTop || 0,
     height: window.innerHeight || doc.clientHeight || 1000,
     scrollHeight: Math.max(body.scrollHeight || 0, doc.scrollHeight || 0),
   };
+}
+"""
+
+SCROLL_TO_JS = r"""
+(target) => {
+  const request = target && typeof target === "object" ? target : {root: "auto", y: target};
+  const requestedRoot = String(request.root || "auto");
+  const targetY = Math.max(Number(request.y) || 0, 0);
+  const main = document.querySelector("section[data-testid='stMain']");
+  if (requestedRoot === "stMain" || (requestedRoot === "auto" && main && main.scrollHeight > main.clientHeight)) {
+    if (!main) return {root: "stMain", y: 0, found: false};
+    main.scrollTop = targetY;
+    return {root: "stMain", y: main.scrollTop || 0};
+  }
+  window.scrollTo(0, targetY);
+  const doc = document.documentElement;
+  const body = document.body || doc;
+  return {root: "window", y: window.scrollY || doc.scrollTop || body.scrollTop || 0};
 }
 """
 
@@ -3502,11 +3602,26 @@ def _page_scroll_positions(page: Any) -> list[int]:  # pragma: no cover - live b
     return sorted(set(positions))
 
 
-def _scroll_to(page: Any, y: int) -> None:  # pragma: no cover - live browser path
+def _bounded_required_text_scroll_positions(positions: Sequence[int]) -> list[int]:
+    normalized = sorted({max(int(position), 0) for position in positions})
+    if len(normalized) <= REQUIRED_TEXT_MAX_SCROLL_POSITIONS:
+        return normalized
+    last_index = len(normalized) - 1
+    sampled_indexes = {
+        round(index * last_index / (REQUIRED_TEXT_MAX_SCROLL_POSITIONS - 1))
+        for index in range(REQUIRED_TEXT_MAX_SCROLL_POSITIONS)
+    }
+    return [normalized[index] for index in sorted(sampled_indexes)]
+
+
+def _scroll_to(page: Any, y: int, *, root: str | None = None) -> None:  # pragma: no cover - live browser path
+    target: int | dict[str, object] = int(y)
+    if root is not None:
+        target = {"root": str(root), "y": int(y)}
     try:
-        page.evaluate("targetY => window.scrollTo(0, targetY)", y)
+        page.evaluate(SCROLL_TO_JS, target)
     except TypeError:
-        page.evaluate(f"() => window.scrollTo(0, {int(y)})")
+        page.evaluate(f"() => ({SCROLL_TO_JS})({json.dumps(target)})")
     except Exception:
         logger.debug("Unable to scroll page to %s", y, exc_info=True)
         return
@@ -5722,16 +5837,33 @@ def _above_fold_probe(page: Any, *, app_name: str, display: str) -> WidgetProbe:
     )
 
 
+def _remaining_timeout_ms(deadline: float) -> float:
+    return max((deadline - time.perf_counter()) * 1000.0, 0.0)
+
+
 def _page_and_frame_text(page: Any, *, timeout_ms: float = 1000.0) -> str:  # pragma: no cover - live browser path
     texts: list[str] = []
+    deadline = time.perf_counter() + max(timeout_ms, 0.0) / 1000.0
 
     def append_locator_text(owner: Any) -> None:
-        try:
-            text = owner.locator("body").inner_text(timeout=timeout_ms)
-        except Exception:
+        remaining_ms = _remaining_timeout_ms(deadline)
+        if remaining_ms <= 0:
             return
+        try:
+            text = owner.locator("body").inner_text(timeout=remaining_ms)
+        except Exception:
+            text = ""
         if text:
             texts.append(str(text))
+
+        if _remaining_timeout_ms(deadline) <= 0:
+            return
+        try:
+            combobox_semantics = owner.evaluate(VISIBLE_COMBOBOX_SEMANTICS_COLLECTOR_JS)
+        except Exception:
+            combobox_semantics = []
+        if isinstance(combobox_semantics, list):
+            texts.extend(str(value) for value in combobox_semantics if str(value).strip())
 
     append_locator_text(page)
     try:
@@ -5775,9 +5907,54 @@ def _required_text_probe(  # pragma: no cover - live browser path
     timeout_ms: float,
 ) -> WidgetProbe:
     expected = tuple(str(label).strip() for label in required_text if str(label).strip())
-    text = _page_and_frame_text(page, timeout_ms=timeout_ms)
+    deadline = time.perf_counter() + max(timeout_ms, 0.0) / 1000.0
+    text = _page_and_frame_text(page, timeout_ms=_remaining_timeout_ms(deadline))
     normalized_text = text.lower()
     missing = [label for label in expected if label.lower() not in normalized_text]
+    if missing and _remaining_timeout_ms(deadline) > 0:
+        try:
+            metrics = page.evaluate(SCROLL_METRICS_JS)
+        except Exception:
+            metrics = {}
+        try:
+            original_scroll_y = int(float((metrics or {}).get("y") or 0))
+        except (AttributeError, TypeError, ValueError):
+            original_scroll_y = 0
+        try:
+            original_scroll_root = str((metrics or {}).get("root") or "window")
+        except AttributeError:
+            original_scroll_root = "window"
+        collected_texts = [text] if text else []
+        scroll_attempts = 0
+        try:
+            while (
+                missing
+                and scroll_attempts < REQUIRED_TEXT_MAX_SCROLL_POSITIONS
+                and _remaining_timeout_ms(deadline) > 0
+            ):
+                positions = _bounded_required_text_scroll_positions(_page_scroll_positions(page)) or [0]
+                for scroll_y in positions:
+                    if scroll_attempts >= REQUIRED_TEXT_MAX_SCROLL_POSITIONS:
+                        break
+                    remaining_ms = _remaining_timeout_ms(deadline)
+                    if remaining_ms <= 0:
+                        break
+                    scroll_attempts += 1
+                    _scroll_to(page, scroll_y)
+                    _wait_for_timeout(page, min(remaining_ms, REQUIRED_TEXT_SCROLL_SETTLE_MS))
+                    remaining_ms = _remaining_timeout_ms(deadline)
+                    if remaining_ms <= 0:
+                        break
+                    scrolled_text = _page_and_frame_text(page, timeout_ms=remaining_ms)
+                    if scrolled_text:
+                        collected_texts.append(scrolled_text)
+                    text = "\n".join(collected_texts)
+                    normalized_text = text.lower()
+                    missing = [label for label in expected if label.lower() not in normalized_text]
+                    if not missing:
+                        break
+        finally:
+            _scroll_to(page, original_scroll_y, root=original_scroll_root)
     if missing:
         detail = f"required text missing: {missing}; page/frame text sample={text[:500]!r}"
         return WidgetProbe(

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -32,6 +32,10 @@ FAILURE_BUNDLE_TEXT_LIMIT = 30_000
 # This wall-clock budget bounds each child instead, so one wedged scenario is
 # reported as a failure and the remaining scenarios still run.
 DEFAULT_SCENARIO_TIMEOUT_SECONDS = 900.0
+# Infrastructure-only diagnostic retries must remain shorter than the original
+# scenario budget. They resume passed pages and collect a trace, not a second
+# full matrix worth of HAR/video evidence.
+DEFAULT_FAILURE_RETRY_TIMEOUT_SECONDS = 300.0
 # Conventional shell exit status for "killed by timeout" (128 + SIGTERM).
 SCENARIO_TIMEOUT_RETURNCODE = 124
 # Grace period for the child to die after SIGTERM before we escalate to SIGKILL.
@@ -58,6 +62,8 @@ class RobotScenario:
     apps_pages: str
     runtime_isolation: str
     action_button_policy: str
+    interaction_mode: str = "full"
+    combination_mode: str = "exhaustive"
     apps: str = ""
     click_action_labels: str = ""
     preselect_labels: str = ""
@@ -116,6 +122,8 @@ class MatrixOptions:
     retry_video_dir: Path | None = None
     # Per-scenario wall-clock budget. ``None`` disables the watchdog entirely.
     scenario_timeout_seconds: float | None = DEFAULT_SCENARIO_TIMEOUT_SECONDS
+    # Wall-clock budget for the single infrastructure-only diagnostic retry.
+    failure_retry_timeout_seconds: float | None = DEFAULT_FAILURE_RETRY_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -249,6 +257,9 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
+        max_action_clicks_per_page=0,
         assert_workflow_artifacts=True,
     ),
     "isolated-entry-and-app-pages": RobotScenario(
@@ -261,6 +272,8 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="configured",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
         max_action_clicks_per_page=0,
@@ -275,6 +288,8 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="safe-click",
+        interaction_mode="full",
+        combination_mode="exhaustive",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
     ),
@@ -287,11 +302,14 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         pages="PROJECT_EDITOR",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         required_text="Edit project files",
         forbidden_text="Worker class,Source LOC,Environment Health",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "isolated-project-notebook-import": RobotScenario(
         name="isolated-project-notebook-import",
@@ -303,10 +321,13 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         pages="PROJECT",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="full",
+        combination_mode="off",
         route_query="start=notebook-import",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "isolated-project-import-sidebar": RobotScenario(
         name="isolated-project-import-sidebar",
@@ -318,10 +339,13 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         pages="PROJECT",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="full",
+        combination_mode="off",
         preselect_labels="Import",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "isolated-project-rename-sidebar": RobotScenario(
         name="isolated-project-rename-sidebar",
@@ -333,10 +357,13 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         pages="PROJECT",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="full",
+        combination_mode="off",
         preselect_labels="Rename",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "isolated-settings-page": RobotScenario(
         name="isolated-settings-page",
@@ -347,9 +374,12 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         pages="SETTINGS",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "current-home-actions": RobotScenario(
         name="current-home-actions",
@@ -420,6 +450,8 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         max_action_clicks_per_page=0,
         required_text="Pool parameters,Max workers,Item timeout seconds,Pool executor",
         browser_error_check=True,
@@ -435,6 +467,8 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         max_action_clicks_per_page=0,
         required_text="Pool executor,Auto (ORCHESTRATE setting)",
         browser_error_check=True,
@@ -454,6 +488,8 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=15.0,
         page_timeout_seconds=120.0,
         target_seconds=900.0,
@@ -473,6 +509,8 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=15.0,
         page_timeout_seconds=120.0,
         target_seconds=900.0,
@@ -488,10 +526,13 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         pages="PROJECT",
         apps_pages="none",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=360.0,
         target_seconds=900.0,
+        max_action_clicks_per_page=0,
         browser_history_check=True,
     ),
     "isolated-mobile-core-pages": RobotScenario(
@@ -504,9 +545,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         viewport_width=390,
         viewport_height=844,
     ),
@@ -520,9 +564,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         success_screenshot=True,
         max_first_render_seconds=90.0,
         max_widgets_ready_seconds=30.0,
@@ -538,9 +585,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         fresh_browser_context_per_page=True,
     ),
     "isolated-keyboard-focus-core-pages": RobotScenario(
@@ -553,9 +603,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         keyboard_focus_check=True,
     ),
     "isolated-layout-integrity-desktop": RobotScenario(
@@ -568,9 +621,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         layout_integrity_check=True,
     ),
     "isolated-layout-integrity-mobile": RobotScenario(
@@ -583,9 +639,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         layout_integrity_check=True,
         viewport_width=390,
         viewport_height=844,
@@ -600,9 +659,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         accessibility_check=True,
     ),
     "isolated-browser-error-core-pages": RobotScenario(
@@ -615,9 +677,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         browser_error_check=True,
     ),
     "isolated-cross-browser-core-pages": RobotScenario(
@@ -646,6 +711,9 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
+        max_action_clicks_per_page=0,
         apps="pytorch_playground_project",
         route_query="current_page=app_ui",
         required_text="PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings",
@@ -687,9 +755,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps_pages="none",
         runtime_isolation="isolated",
         action_button_policy="trial",
+        interaction_mode="actionability",
+        combination_mode="off",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
         target_seconds=1200.0,
+        max_action_clicks_per_page=0,
         above_fold_check=True,
     ),
     "isolated-visual-baseline-core-pages": RobotScenario(
@@ -834,8 +905,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--retry-failed-with-artifacts",
         action="store_true",
         help=(
-            "When a scenario fails, rerun only that scenario once with trace, "
-            "HAR, and video artifact directories enabled."
+            "When a scenario hits the infrastructure watchdog without a completed "
+            "semantic failure, resume passed pages once and collect compact diagnostics."
         ),
     )
     parser.add_argument(
@@ -876,6 +947,15 @@ def _build_parser() -> argparse.ArgumentParser:
             "Use 0 to disable the watchdog."
         ),
     )
+    parser.add_argument(
+        "--failure-retry-timeout",
+        type=float,
+        default=DEFAULT_FAILURE_RETRY_TIMEOUT_SECONDS,
+        help=(
+            "Wall-clock budget in seconds for the single infrastructure-only failure "
+            "retry. The retry resumes passed pages. Use 0 to disable its watchdog."
+        ),
+    )
     parser.add_argument("--browser", choices=("chromium", "firefox", "webkit"), default="chromium")
     parser.add_argument("--headful", action="store_true")
     parser.add_argument("--url", help="Existing AGILAB URL to test instead of launching source Streamlit.")
@@ -912,6 +992,9 @@ def options_from_args(args: argparse.Namespace) -> MatrixOptions:
         timeout_seconds=args.timeout,
         widget_timeout_seconds=args.widget_timeout,
         scenario_timeout_seconds=args.scenario_timeout if args.scenario_timeout > 0 else None,
+        failure_retry_timeout_seconds=(
+            args.failure_retry_timeout if args.failure_retry_timeout > 0 else None
+        ),
         quiet_progress=args.quiet_progress,
         no_seed_demo_artifacts=args.no_seed_demo_artifacts,
         browser=args.browser,
@@ -968,7 +1051,9 @@ def build_robot_command(
         "--target-seconds",
         str(scenario.target_seconds),
         "--interaction-mode",
-        "full",
+        scenario.interaction_mode,
+        "--combination-mode",
+        scenario.combination_mode,
         "--action-button-policy",
         scenario.action_button_policy,
         "--missing-selected-action-policy",
@@ -1059,6 +1144,77 @@ def _scenario_failed(result: ScenarioResult) -> bool:
     return result.returncode != 0 or result.summary.get("success") is not True
 
 
+def _completed_page_failure_reason(page: object) -> str:
+    if not isinstance(page, dict):
+        return "completed page evidence is malformed"
+    status = str(page.get("status") or "").strip().casefold()
+    failures = page.get("failures")
+    try:
+        failed_count = int(page.get("failed_count") or 0)
+    except (TypeError, ValueError):
+        return "completed page failed_count is malformed"
+    if page.get("success") is not True or status != "passed" or failed_count != 0:
+        app = str(page.get("app") or "?")
+        page_name = str(page.get("page") or "?")
+        return f"completed page {app}/{page_name} already contains failure evidence"
+    if not isinstance(failures, list):
+        return "completed page failures evidence is malformed"
+    if failures:
+        app = str(page.get("app") or "?")
+        page_name = str(page.get("page") or "?")
+        return f"completed page {app}/{page_name} already contains failure evidence"
+    return ""
+
+
+def _progress_failure_reason(path: Path) -> str:
+    if not path.exists():
+        return ""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return f"progress evidence is unreadable: {exc.__class__.__name__}"
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            return f"progress evidence is malformed at line {line_number}"
+        if not isinstance(record, dict):
+            return f"progress evidence is malformed at line {line_number}"
+        if record.get("event") != "page_done":
+            continue
+        if "result" not in record:
+            return f"page_done evidence is incomplete at line {line_number}"
+        reason = _completed_page_failure_reason(record.get("result"))
+        if reason:
+            return reason
+    return ""
+
+
+def _failure_artifact_retry_decision(result: ScenarioResult) -> tuple[bool, str]:
+    """Retry only an infrastructure watchdog with no completed semantic failure."""
+
+    if result.returncode != SCENARIO_TIMEOUT_RETURNCODE:
+        return False, f"return code {result.returncode} is not an infrastructure watchdog"
+
+    pages = result.summary.get("pages")
+    if "pages" in result.summary and not isinstance(pages, list):
+        return False, "summary page evidence is malformed"
+    if not isinstance(pages, list):
+        pages = []
+    for page in pages:
+        reason = _completed_page_failure_reason(page)
+        if reason:
+            return False, reason
+
+    progress_reason = _progress_failure_reason(result.progress_path)
+    if progress_reason:
+        return False, progress_reason
+
+    return True, "scenario watchdog fired without completed semantic failure evidence"
+
+
 def _failure_artifact_retry_options(options: MatrixOptions) -> MatrixOptions:
     retry_output_dir = options.output_dir / "failure-retry"
     retry_artifact_root = options.output_dir / "failure-artifacts"
@@ -1073,8 +1229,8 @@ def _failure_artifact_retry_options(options: MatrixOptions) -> MatrixOptions:
         screenshot_dir=retry_screenshot_dir,
         failure_bundle_dir=None,
         trace_dir=options.retry_trace_dir or retry_artifact_root / "traces",
-        har_dir=options.retry_har_dir or retry_artifact_root / "har",
-        video_dir=options.retry_video_dir or retry_artifact_root / "video",
+        har_dir=options.retry_har_dir,
+        video_dir=options.retry_video_dir,
         result_cache_path=None,
         retry_failed_with_artifacts=False,
         retry_trace_dir=None,
@@ -1087,15 +1243,27 @@ def run_failure_artifact_retry(
     scenario: RobotScenario,
     *,
     options: MatrixOptions,
+    resume_from_progress: Path | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> FailureArtifactRetry:
     retry_options = _failure_artifact_retry_options(options)
     retry_options.output_dir.mkdir(parents=True, exist_ok=True)
     argv, summary_path, progress_path = build_robot_command(scenario, options=retry_options)
+    if resume_from_progress is not None:
+        argv.extend(["--resume-from-progress", str(resume_from_progress)])
+        print(
+            f"[ui-robot-matrix] infrastructure retry resumes passed pages from "
+            f"{resume_from_progress}",
+            file=sys.stderr,
+            flush=True,
+        )
     started = time.perf_counter()
     if runner is subprocess.run:
+        retry_timeout = options.failure_retry_timeout_seconds
+        if retry_timeout is not None and options.scenario_timeout_seconds is not None:
+            retry_timeout = min(retry_timeout, options.scenario_timeout_seconds)
         completed = _run_robot_command_streaming(
-            argv, timeout_seconds=options.scenario_timeout_seconds
+            argv, timeout_seconds=retry_timeout
         )
     else:
         completed = runner(
@@ -1538,10 +1706,23 @@ def run_scenario(
         output=output,
     )
     if options.retry_failed_with_artifacts and _scenario_failed(result):
-        result = replace(
-            result,
-            artifact_retry=run_failure_artifact_retry(scenario, options=options, runner=runner),
-        )
+        retry_eligible, retry_reason = _failure_artifact_retry_decision(result)
+        if retry_eligible:
+            result = replace(
+                result,
+                artifact_retry=run_failure_artifact_retry(
+                    scenario,
+                    options=options,
+                    resume_from_progress=progress_path,
+                    runner=runner,
+                ),
+            )
+        else:
+            print(
+                f"[ui-robot-matrix] compact retry skipped for {scenario.name}: {retry_reason}",
+                file=sys.stderr,
+                flush=True,
+            )
     _write_matrix_failure_bundle(result, options=options)
     return result
 

--- a/tools/testing/ui_robot_matrix_plan.py
+++ b/tools/testing/ui_robot_matrix_plan.py
@@ -17,7 +17,6 @@ MAX_ESTIMATED_PAGES_PER_SHARD = 32
 
 CORE_SCENARIOS = (
     "isolated-core-pages",
-    "isolated-entry-and-app-pages",
     "isolated-project-page",
     "isolated-project-editor-page",
     "isolated-project-notebook-import",
@@ -27,6 +26,7 @@ CORE_SCENARIOS = (
     "isolated-all-builtins-orchestrate-smoke",
     "isolated-all-builtins-core-render-smoke",
 )
+APP_PAGE_SCENARIOS = ("isolated-entry-and-app-pages",)
 STATE_MOBILE_SCENARIOS = (
     "isolated-fresh-session-core-pages",
     "isolated-browser-history",
@@ -51,8 +51,9 @@ FOCUSED_SCENARIOS = (
     ("isolated-pytorch-playground-analysis", "pytorch_playground_project"),
 )
 
-# The broad scenario groups render this many core pages per selected app. The
-# configured apps-page count is added separately to the core estimate.
+# The broad scenario groups render this many pages per selected app. Configured
+# apps-pages use a dedicated shard so apps without such pages are never selected
+# for a zero-page scenario that cannot satisfy exact coverage.
 CORE_PAGES_PER_APP = 12
 STATE_MOBILE_PAGES_PER_APP = 9
 QUALITY_PAGES_PER_APP = 32
@@ -184,10 +185,14 @@ def build_plan(
     available_apps = discover_builtin_apps(apps_root)
     apps = resolve_requested_apps(requested_apps, available_apps=available_apps)
 
-    core_loads = {
-        app: CORE_PAGES_PER_APP + configured_apps_page_count(apps_root / app)
+    configured_page_loads = {
+        app: configured_apps_page_count(apps_root / app)
         for app in apps
     }
+    apps_with_configured_pages = tuple(
+        app for app in apps if configured_page_loads[app] > 0
+    )
+    core_loads = {app: CORE_PAGES_PER_APP for app in apps}
     state_mobile_loads = {app: STATE_MOBILE_PAGES_PER_APP for app in apps}
     quality_loads = {app: QUALITY_PAGES_PER_APP for app in apps}
     layout_loads = {app: LAYOUT_PAGES_PER_APP for app in apps}
@@ -198,6 +203,13 @@ def build_plan(
             apps=apps,
             scenarios=CORE_SCENARIOS,
             page_loads=core_loads,
+            max_pages=max_estimated_pages,
+        ),
+        *_broad_shards(
+            prefix="app-pages",
+            apps=apps_with_configured_pages,
+            scenarios=APP_PAGE_SCENARIOS,
+            page_loads=configured_page_loads,
             max_pages=max_estimated_pages,
         ),
         *_broad_shards(

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -1718,10 +1718,8 @@ def _ui_robot_matrix_profile() -> list[CommandSpec]:
                 "--retry-failed-with-artifacts",
                 "--retry-trace-dir",
                 f"{result_dir}/failure-artifacts/traces",
-                "--retry-har-dir",
-                f"{result_dir}/failure-artifacts/har",
-                "--retry-video-dir",
-                f"{result_dir}/failure-artifacts/video",
+                "--failure-retry-timeout",
+                "300",
             ]
         )
         commands.append(


### PR DESCRIPTION
## Summary

- make required-text checks read visible combobox semantics across the real Streamlit scroll root, including delayed cold renders
- recalibrate the exact 14-app matrix to 22 intent-specific scenarios, with one bounded exhaustive lane and no combinatorial work in render/quality lanes
- isolate configured app-page coverage so apps without pages cannot produce false inventory failures
- retry only infrastructure watchdogs, resume already-passed pages, cap retries at 300 seconds, and remove automatic HAR/video capture
- add mandatory Chromium regressions plus planner/workflow parity contracts

## Why

Run 30635323685 exposed deterministic 420-second ORCHESTRATE page watchdogs caused by full/exhaustive state combinations. The old failure retry replayed whole scenarios with trace, HAR, and video, producing 13.73 GiB across 23 artifacts. This change fixes the root cause and keeps diagnostics bounded.

## Local validation

- required impact slice: 332 passed, 3 skipped
- UI evidence/release/docs slice: 272 passed, 2 skipped
- mandatory Chromium widget regressions: included and passing
- Ruff, py_compile, diff check, worktree scope, and staged impact: passing
- cold focused Pandas probe: 5/5 independent runs, 48 widgets, 0 failures, 0 combinations