### PR TITLE
Fix UI robot framework geometry detection

### DIFF
--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -710,6 +710,82 @@ def test_layout_integrity_collector_uses_painted_geometry_for_expander_content(
                         width: 200px;
                         height: 40px;
                       }
+                      .scroll-edge {
+                        position: fixed;
+                        inset: 180px auto auto 400px;
+                        width: 220px;
+                        height: 40px;
+                        overflow: auto;
+                      }
+                      .scroll-edge button {
+                        position: absolute;
+                        inset: 39px auto auto 0;
+                        width: 200px;
+                        height: 40px;
+                      }
+                      .hard-clip {
+                        position: fixed;
+                        inset: 240px auto auto 700px;
+                        width: 220px;
+                        height: 1px;
+                        overflow: hidden;
+                      }
+                      .hard-clip button {
+                        position: absolute;
+                        inset: 0 auto auto 0;
+                        width: 200px;
+                        height: 40px;
+                      }
+                      .actual-tiny {
+                        position: fixed;
+                        inset: 260px auto auto 400px;
+                        width: 1px;
+                        height: 1px;
+                        min-width: 0;
+                        min-height: 0;
+                        padding: 0;
+                        border: 0;
+                      }
+                      .custom-tiny-input {
+                        inset: 300px auto auto 400px;
+                      }
+                      .framework-tiny-input {
+                        inset: 320px auto auto 400px;
+                      }
+                      .off-left {
+                        position: fixed;
+                        inset: 360px auto auto -10px;
+                        width: 40px;
+                        height: 30px;
+                      }
+                      .grid-canvas {
+                        position: fixed;
+                        width: 120px;
+                        height: 60px;
+                      }
+                      .framework-grid-canvas {
+                        inset: 420px auto auto 400px;
+                      }
+                      .custom-grid-canvas {
+                        inset: 500px auto auto 400px;
+                      }
+                      .animated-expander {
+                        position: fixed;
+                        inset: 420px auto auto 20px;
+                        width: 340px;
+                        height: 55px;
+                        overflow: hidden;
+                        transition: height 500ms cubic-bezier(0.2, 0, 0, 1);
+                      }
+                      .animated-expander[open] {
+                        height: 140px;
+                      }
+                      .animated-expander button {
+                        position: absolute;
+                        inset: 95px auto auto 10px;
+                        width: 300px;
+                        height: 40px;
+                      }
                     </style>
                     <details open>
                       <summary>Preview distribution workplan</summary>
@@ -727,10 +803,47 @@ def test_layout_integrity_collector_uses_painted_geometry_for_expander_content(
                       <button>Visible primary</button>
                       <button>Visible secondary</button>
                     </div>
+                    <div class="scroll-edge">
+                      <button>Normal control at scroll edge</button>
+                    </div>
+                    <div class="hard-clip">
+                      <button>Hard-clipped custom</button>
+                    </div>
+                    <button class="actual-tiny">Tiny control</button>
+                    <input class="actual-tiny custom-tiny-input">
+                    <div data-testid="stSelectbox">
+                      <input class="actual-tiny framework-tiny-input">
+                    </div>
+                    <button class="off-left">Off left</button>
+                    <div data-testid="stDataFrame">
+                      <canvas
+                        class="grid-canvas framework-grid-canvas"
+                        data-testid="data-grid-canvas"
+                        tabindex="0"
+                      ></canvas>
+                    </div>
+                    <canvas
+                      class="grid-canvas custom-grid-canvas"
+                      data-testid="data-grid-canvas"
+                      tabindex="0"
+                    ></canvas>
+                    <details class="animated-expander">
+                      <summary>Animated Streamlit expander</summary>
+                      <button>Transient expander control</button>
+                    </details>
                     """
                 )
 
+                page.evaluate(module.OPEN_EXPANDERS_JS)
+                page.wait_for_timeout(250)
+                opening_issues = page.evaluate(module.LAYOUT_INTEGRITY_COLLECTOR_JS)
+                settled_probe = module._layout_integrity_probe(
+                    page,
+                    app_name="test_app",
+                    display="PROJECT",
+                )
                 issues = page.evaluate(module.LAYOUT_INTEGRITY_COLLECTOR_JS)
+                accessibility_issues = page.evaluate(module.ACCESSIBILITY_COLLECTOR_JS)
             finally:
                 browser.close()
     except sync_api.Error as exc:
@@ -749,6 +862,110 @@ def test_layout_integrity_collector_uses_painted_geometry_for_expander_content(
     )
     assert all("CHECK distribute" not in detail for detail in overlap_details)
     assert all("Benchmark modes" not in detail for detail in overlap_details)
+    zero_size_issues = [
+        issue
+        for issue in issues
+        if issue.get("kind") == "zero_size_control"
+    ]
+    zero_size_labels = {issue.get("label", "") for issue in zero_size_issues}
+    assert "Normal control at scroll edge" not in zero_size_labels
+    assert "Tiny control" in zero_size_labels
+    assert any(
+        issue.get("label") == "INPUT" and issue.get("framework_owned") is False
+        for issue in zero_size_issues
+    )
+    assert any(
+        issue.get("label") == "INPUT"
+        and issue.get("framework_owned") is True
+        and issue.get("framework_owner") == "stSelectbox"
+        for issue in zero_size_issues
+    )
+
+    clipped_labels = {
+        issue.get("label", "")
+        for issue in issues
+        if issue.get("kind") == "clipped_control"
+    }
+    assert "Hard-clipped custom" in clipped_labels
+    assert settled_probe.status == "failed"
+    assert "Hard-clipped custom" in settled_probe.detail
+    assert any(
+        issue.get("kind") == "clipped_control"
+        and issue.get("label") == "Transient expander control"
+        for issue in opening_issues
+    )
+    assert "Transient expander control" not in clipped_labels
+    assert "Normal control at scroll edge" not in clipped_labels
+    assert "CHECK distribute" not in clipped_labels
+    assert "Benchmark modes" not in clipped_labels
+
+    horizontal_overflow_labels = {
+        issue.get("label", "")
+        for issue in issues
+        if issue.get("kind") == "horizontal_overflow"
+    }
+    assert "Off left" in horizontal_overflow_labels
+
+    custom_tiny_issue = next(
+        issue
+        for issue in zero_size_issues
+        if issue.get("label") == "INPUT" and issue.get("framework_owned") is False
+    )
+    framework_tiny_issue = next(
+        issue
+        for issue in zero_size_issues
+        if issue.get("label") == "INPUT" and issue.get("framework_owned") is True
+    )
+    assert (
+        module._layout_integrity_result_probe(
+            app_name="test_app",
+            display="PROJECT",
+            url=page.url,
+            issues=[custom_tiny_issue],
+        ).status
+        == "failed"
+    )
+    assert (
+        module._layout_integrity_result_probe(
+            app_name="test_app",
+            display="PROJECT",
+            url=page.url,
+            issues=[framework_tiny_issue],
+        ).status
+        == "interacted"
+    )
+
+    data_grid_issues = [
+        issue
+        for issue in accessibility_issues
+        if issue.get("kind") == "missing_accessible_name"
+        and issue.get("label") == "data-grid-canvas"
+    ]
+    assert {issue.get("framework_owned") for issue in data_grid_issues} == {False, True}
+    framework_grid_issue = next(
+        issue for issue in data_grid_issues if issue.get("framework_owned") is True
+    )
+    custom_grid_issue = next(
+        issue for issue in data_grid_issues if issue.get("framework_owned") is False
+    )
+    assert (
+        module._accessibility_result_probe(
+            app_name="test_app",
+            display="PROJECT",
+            url=page.url,
+            issues=[framework_grid_issue],
+        ).status
+        == "interacted"
+    )
+    assert (
+        module._accessibility_result_probe(
+            app_name="test_app",
+            display="PROJECT",
+            url=page.url,
+            issues=[custom_grid_issue],
+        ).status
+        == "failed"
+    )
 
 
 def test_layout_integrity_result_probe_ignores_framework_artifacts() -> None:
@@ -759,7 +976,12 @@ def test_layout_integrity_result_probe_ignores_framework_artifacts() -> None:
         display="PROJECT",
         url="http://demo/PROJECT",
         issues=[
-            {"kind": "zero_size_control", "label": "INPUT", "detail": "control rendered at 1.0x1.0"},
+            {
+                "kind": "zero_size_control",
+                "label": "INPUT",
+                "detail": "control rendered at 1.0x1.0",
+                "framework_owned": True,
+            },
             {"kind": "text_overflow", "label": "Install agi-app", "detail": "text width 95px exceeds container 79px"},
             {
                 "kind": "control_overlap",
@@ -841,7 +1063,12 @@ def test_layout_integrity_result_probe_keeps_actionable_issue_after_filtering() 
         display="PROJECT",
         url="http://demo/PROJECT",
         issues=[
-            {"kind": "zero_size_control", "label": "INPUT", "detail": "control rendered at 1.0x1.0"},
+            {
+                "kind": "zero_size_control",
+                "label": "INPUT",
+                "detail": "control rendered at 1.0x1.0",
+                "framework_owned": True,
+            },
             {"kind": "horizontal_overflow", "label": "RUN", "detail": "control spans outside viewport"},
         ],
     )
@@ -899,6 +1126,12 @@ def test_accessibility_result_probe_ignores_framework_noise() -> None:
                 "detail": "visible interactive control has no accessible name",
             },
             {
+                "kind": "missing_accessible_name",
+                "label": "data-grid-canvas",
+                "detail": "visible interactive control has no accessible name",
+                "framework_owned": True,
+            },
+            {
                 "kind": "heading_level_jump",
                 "label": "Runtime diagnostics",
                 "detail": "heading jumps from h2 to h4",
@@ -907,7 +1140,28 @@ def test_accessibility_result_probe_ignores_framework_noise() -> None:
     )
 
     assert probe.status == "interacted"
-    assert "ignored 3" in probe.detail
+    assert "ignored 4" in probe.detail
+
+
+def test_accessibility_result_probe_keeps_custom_canvas_name_issue_actionable() -> None:
+    module = _load_module()
+
+    probe = module._accessibility_result_probe(
+        app_name="flight_telemetry_project",
+        display="PROJECT",
+        url="http://demo/PROJECT",
+        issues=[
+            {
+                "kind": "missing_accessible_name",
+                "label": "data-grid-canvas",
+                "detail": "visible interactive control has no accessible name",
+                "framework_owned": False,
+            },
+        ],
+    )
+
+    assert probe.status == "failed"
+    assert "data-grid-canvas" in probe.detail
 
 
 def test_accessibility_result_probe_keeps_actionable_issues_after_filtering() -> None:

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -59,6 +59,7 @@ DEFAULT_PAGE_TIMEOUT_SECONDS = 300.0
 DEFAULT_ACTION_TIMEOUT_SECONDS = 30.0
 PAGE_READY_POLL_MS = 150
 PAGE_READY_STABILIZE_MS = 100
+LAYOUT_INTEGRITY_EXPANDER_SETTLE_MS = 600
 WIDGET_READY_POLL_MS = 150
 ACTION_OUTCOME_POLL_MS = 100
 # Short Playwright timeouts for "is it on screen right now?" probes that run inside polling
@@ -593,10 +594,14 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
 () => {
   const clean = (value) => String(value || "").trim().replace(/\s+/g, " ");
   const clips = (value) => ["auto", "clip", "hidden", "scroll"].includes(value);
+  const hardClips = (value) => ["clip", "hidden"].includes(value);
   const paintedRect = (el) => {
     const raw = el.getBoundingClientRect();
     if (raw.width <= 0 || raw.height <= 0) return null;
     const rect = {left: raw.left, right: raw.right, top: raw.top, bottom: raw.bottom};
+    let hardClippedX = false;
+    let hardClippedY = false;
+    let hardClipOwner = "";
     for (let current = el; current; current = current.parentElement) {
       const style = window.getComputedStyle(current);
       if (
@@ -614,17 +619,32 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
       }
       if (current === el || current === document.body || current === document.documentElement) continue;
       const contain = String(style.contain || "").split(/\s+/);
-      const clipX = clips(style.overflowX) || contain.some((value) => ["content", "paint", "strict"].includes(value));
-      const clipY = clips(style.overflowY) || contain.some((value) => ["content", "paint", "strict"].includes(value));
+      const containedPaint = contain.some((value) => ["content", "paint", "strict"].includes(value));
+      const clipX = clips(style.overflowX) || containedPaint;
+      const clipY = clips(style.overflowY) || containedPaint;
+      const hardClipX = hardClips(style.overflowX) || containedPaint;
+      const hardClipY = hardClips(style.overflowY) || containedPaint;
       if (!clipX && !clipY) continue;
       const ancestor = current.getBoundingClientRect();
       if (clipX) {
-        rect.left = Math.max(rect.left, ancestor.left);
-        rect.right = Math.min(rect.right, ancestor.right);
+        const nextLeft = Math.max(rect.left, ancestor.left);
+        const nextRight = Math.min(rect.right, ancestor.right);
+        if (hardClipX && (nextLeft > rect.left + 2 || nextRight < rect.right - 2)) {
+          hardClippedX = true;
+          hardClipOwner ||= clean(current.getAttribute("data-testid") || current.tagName);
+        }
+        rect.left = nextLeft;
+        rect.right = nextRight;
       }
       if (clipY) {
-        rect.top = Math.max(rect.top, ancestor.top);
-        rect.bottom = Math.min(rect.bottom, ancestor.bottom);
+        const nextTop = Math.max(rect.top, ancestor.top);
+        const nextBottom = Math.min(rect.bottom, ancestor.bottom);
+        if (hardClipY && (nextTop > rect.top + 2 || nextBottom < rect.bottom - 2)) {
+          hardClippedY = true;
+          hardClipOwner ||= clean(current.getAttribute("data-testid") || current.tagName);
+        }
+        rect.top = nextTop;
+        rect.bottom = nextBottom;
       }
       if (rect.right <= rect.left || rect.bottom <= rect.top) return null;
     }
@@ -635,6 +655,9 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
       bottom: rect.bottom,
       width: rect.right - rect.left,
       height: rect.bottom - rect.top,
+      hardClippedX,
+      hardClippedY,
+      hardClipOwner,
     };
   };
   const visible = (el) => paintedRect(el) !== null;
@@ -649,11 +672,24 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
     ""
   ).slice(0, 120);
   const issues = [];
+  const frameworkInputOwner = (el) => {
+    if (el.tagName !== "INPUT") return "";
+    const owner = el.closest([
+      "[data-testid='stFileUploader']",
+      "[data-testid='stFileUploaderDropzoneInput']",
+      "[data-testid='stMultiSelect']",
+      "[data-testid='stSelectbox']",
+    ].join(", "));
+    return clean(owner?.getAttribute("data-testid"));
+  };
   const push = (kind, el, detail) => {
+    const frameworkOwner = frameworkInputOwner(el);
     issues.push({
       kind,
       label: labelFor(el),
       detail: clean(detail).slice(0, 260),
+      framework_owned: Boolean(frameworkOwner),
+      framework_owner: frameworkOwner,
     });
   };
   const controlSelector = [
@@ -670,13 +706,22 @@ LAYOUT_INTEGRITY_COLLECTOR_JS = r"""
   ].join(", ");
   const controls = Array.from(document.querySelectorAll(controlSelector)).filter(visible);
   for (const el of controls) {
-    const rect = paintedRect(el);
-    if (!rect) continue;
-    if (rect.width < 2 || rect.height < 2) {
-      push("zero_size_control", el, `control rendered at ${rect.width.toFixed(1)}x${rect.height.toFixed(1)}`);
+    const painted = paintedRect(el);
+    if (!painted) continue;
+    const rendered = el.getBoundingClientRect();
+    if (rendered.width < 2 || rendered.height < 2) {
+      push("zero_size_control", el, `control rendered at ${rendered.width.toFixed(1)}x${rendered.height.toFixed(1)}`);
     }
-    if (rect.left < -4 || rect.right > window.innerWidth + 4) {
-      push("horizontal_overflow", el, `control spans x=${rect.left.toFixed(1)}..${rect.right.toFixed(1)} viewport=${window.innerWidth}`);
+    if (painted.hardClippedX || painted.hardClippedY) {
+      const axes = [painted.hardClippedX ? "horizontal" : "", painted.hardClippedY ? "vertical" : ""].filter(Boolean).join("+");
+      push(
+        "clipped_control",
+        el,
+        `control clipped from ${rendered.width.toFixed(1)}x${rendered.height.toFixed(1)} to ${painted.width.toFixed(1)}x${painted.height.toFixed(1)} by ${painted.hardClipOwner || "non-scrollable ancestor"} (${axes})`,
+      );
+    }
+    if (painted.left < -4 || painted.right > window.innerWidth + 4) {
+      push("horizontal_overflow", el, `control spans x=${painted.left.toFixed(1)}..${painted.right.toFixed(1)} viewport=${window.innerWidth}`);
     }
   }
   const textSelector = [
@@ -748,11 +793,16 @@ ACCESSIBILITY_COLLECTOR_JS = r"""
     return clean(textFor(container || el)).slice(0, 160);
   };
   const issues = [];
+  const frameworkDataGridCanvas = (el) => (
+    el.getAttribute("data-testid") === "data-grid-canvas" &&
+    Boolean(el.closest("[data-testid='stDataFrame'], [data-testid='stDataEditor']"))
+  );
   const push = (kind, el, detail) => {
     issues.push({
       kind,
       label: clean(labelFor(el) || el.getAttribute("data-testid") || el.tagName).slice(0, 120),
       detail: clean(detail).slice(0, 260),
+      framework_owned: frameworkDataGridCanvas(el),
     });
   };
   const interactiveSelector = [
@@ -5585,7 +5635,12 @@ def _ignored_layout_issue_reason(issue: Mapping[str, Any], *, display: str) -> s
     kind = str(issue.get("kind") or "")
     label = str(issue.get("label") or "")
     detail = str(issue.get("detail") or "")
-    if kind == "zero_size_control" and label == "INPUT" and "1.0x1.0" in detail:
+    if (
+        kind == "zero_size_control"
+        and label == "INPUT"
+        and "1.0x1.0" in detail
+        and issue.get("framework_owned") is True
+    ):
         return "Streamlit hidden input"
     if kind == "text_overflow" and label == "Install agi-app":
         return "intentional Streamlit sidebar action label measurement"
@@ -5627,6 +5682,11 @@ def _layout_span_is_fully_offscreen_left(detail: str) -> bool:
 
 def _layout_integrity_probe(page: Any, *, app_name: str, display: str) -> WidgetProbe:  # pragma: no cover - live browser path
     try:
+        # OPEN_EXPANDERS_JS is also called during readiness, but Streamlit animates
+        # the height of newly opened details for 500 ms.  Keep this longer settle
+        # local to geometry checks so other expander callers stay fast.
+        page.evaluate(OPEN_EXPANDERS_JS)
+        _wait_for_timeout(page, LAYOUT_INTEGRITY_EXPANDER_SETTLE_MS)
         issues = page.evaluate(LAYOUT_INTEGRITY_COLLECTOR_JS)
     except Exception as exc:
         issues = [{"kind": "collector_error", "label": "", "detail": str(exc)}]
@@ -5684,6 +5744,12 @@ def _ignored_accessibility_issue_reason(issue: Mapping[str, Any]) -> str | None:
     label = str(issue.get("label") or "")
     if kind == "contrast_risk":
         return "contrast heuristic is conservative with Streamlit computed backgrounds"
+    if (
+        kind == "missing_accessible_name"
+        and label == "data-grid-canvas"
+        and issue.get("framework_owned") is True
+    ):
+        return "Streamlit dataframe canvas is backed by framework-owned grid semantics"
     if kind == "missing_accessible_name" and label in {
         "stFileUploaderDropzoneInput",
         "stNumberInputStepDown",


### PR DESCRIPTION
## Summary

- distinguish framework-owned Streamlit dataframe canvases from custom unnamed canvases
- ignore hidden 1x1 inputs only when their Streamlit control provenance is explicit
- detect intrinsic zero-size controls and hard clipping while keeping scroll-edge geometry valid
- wait 600 ms locally before layout collection so Streamlit's 500 ms expander animation settles

## Evidence

The exact 14-app matrix at https://github.com/ThalesGroup/agilab/actions/runs/30642228064 exposed six dataframe-canvas accessibility false positives and two near-zero painted-height layout false positives.

Local validation after the fix:

- mandatory Chromium test slice: 270 passed, 3 skipped
- six originally failing accessibility apps: 42/42 pages passed
- exact TEScia desktop layout: 7/7 pages passed in three consecutive runs
- resumed all-app desktop layout sweep: 98/98 pages passed, 0 failures
- Ruff, py_compile, diff-check, impact analysis, and scope guard passed

The regression remains fail-closed for custom unnamed canvases, custom 1x1 inputs, and genuine overflow:hidden clipping.