### PR TITLE
fix(dispatcher): gate chunk partitioning on work size, not nchunk2

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
@@ -370,12 +370,17 @@ class WorkDispatcher:
         chunks and chunks_sizes must be left to None
 
         Args:
-          nchunk2: list of number of chunks level 2
-          weights: the list of weight level2
+          nchunk2: number of level-2 works, kept for reporting and backwards
+            compatibility. It does NOT select the partitioning algorithm: the
+            exponential/heuristic gate is derived from ``len(weights)``, which is
+            what actually drives the search cost. Callers that understate this
+            value can no longer force a large work list down the exponential path.
+          weights: the list of level-2 weights as ``(label, size)`` tuples
           capacities: the list of workers capacity (Default value = None)
           verbose: whether to display run detail or not (Default value = 0)
-          threshold: the number of nchunk2 max to run the optimal algo otherwise downgrade to suboptimal one (Default value = 12)
-          weights: list:
+          threshold: maximum number of works for which the optimal (exponential)
+            algorithm is used; at or above it the suboptimal LPT heuristic runs
+            instead (Default value = 12)
 
 
         Returns:
@@ -389,11 +394,25 @@ class WorkDispatcher:
         capacities = WorkDispatcher._normalize_worker_capacities(capacities, workers)  # ty: ignore[invalid-assignment]
 
         if len(weights) > 1:
-            if nchunk2 < threshold:
-                logging.info(f"optimal - workers capacities {capacities} - {nchunk2} works to be done")
+            # Gate on the actual work size, not on the caller-supplied ``nchunk2``.
+            # ``_make_chunks_optimal`` is an exponential branch-and-bound whose cost is
+            # driven by ``len(weights)``; keying the threshold off a separate argument
+            # let a caller that understated it send an arbitrarily large work list down
+            # the exponential path and hang plan construction with no diagnostic
+            # (measured: 16 works ~0.2s, 20 works >20s).
+            nwork = len(weights)
+            if nwork != nchunk2:
+                logging.warning(
+                    "make_chunks called with nchunk2=%s but %s weighted works; "
+                    "using the work count to pick the partitioning algorithm",
+                    nchunk2,
+                    nwork,
+                )
+            if nwork < threshold:
+                logging.info(f"optimal - workers capacities {capacities} - {nwork} works to be done")
                 chunks = WorkDispatcher._make_chunks_optimal(weights, capacities)  # ty: ignore[invalid-argument-type]
             else:
-                logging.info(f"fastest - workers capacities {capacities} - {nchunk2} works to be done")
+                logging.info(f"fastest - workers capacities {capacities} - {nwork} works to be done")
                 chunks = WorkDispatcher._make_chunks_fastest(weights, capacities)  # ty: ignore[invalid-argument-type]
 
             return chunks

--- a/src/agilab/core/test/test_work_dispatcher.py
+++ b/src/agilab/core/test/test_work_dispatcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import datetime
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -825,9 +826,45 @@ def test_make_chunks_selects_optimal_or_fastest(monkeypatch):
     monkeypatch.setattr(WorkDispatcher, "_make_chunks_optimal", lambda *_args, **_kwargs: [["optimal"]])
     monkeypatch.setattr(WorkDispatcher, "_make_chunks_fastest", lambda *_args, **_kwargs: [["fastest"]])
 
-    weights = [("a", 3), ("b", 1)]
-    assert WorkDispatcher.make_chunks(2, weights, workers={"127.0.0.1": 1}, threshold=3) == [["optimal"]]
-    assert WorkDispatcher.make_chunks(5, weights, workers={"127.0.0.1": 1}, threshold=3) == [["fastest"]]
+    small = [("a", 3), ("b", 1)]
+    large = [("a", 3), ("b", 1), ("c", 2), ("d", 4)]
+
+    # The gate follows the number of weighted works, not ``nchunk2``.
+    assert WorkDispatcher.make_chunks(
+        len(small), small, workers={"127.0.0.1": 1}, threshold=3
+    ) == [["optimal"]]
+    assert WorkDispatcher.make_chunks(
+        len(large), large, workers={"127.0.0.1": 1}, threshold=3
+    ) == [["fastest"]]
+
+    # Regression: an understated ``nchunk2`` must not force a large work list down
+    # the exponential path. This previously selected ``_make_chunks_optimal``.
+    assert WorkDispatcher.make_chunks(
+        1, large, workers={"127.0.0.1": 1}, threshold=3
+    ) == [["fastest"]]
+
+
+def test_make_chunks_understated_nchunk2_cannot_trigger_exponential_hang():
+    """Run the real partitioner: an understated ``nchunk2`` must stay bounded.
+
+    Before the gate was derived from ``len(weights)``, ``make_chunks(1, weights, ...)``
+    routed any work list into the exponential branch-and-bound. Measured on this
+    surface: 16 works completed in ~0.2s while 20 works exceeded 20s, so plan
+    construction hung with no diagnostic. Nothing is monkeypatched here — the point
+    is that the real code path terminates.
+    """
+    weights = [(f"job-{index}", float((index % 7) + 1)) for index in range(24)]
+
+    started = time.perf_counter()
+    chunks = WorkDispatcher.make_chunks(
+        1, weights, workers={"127.0.0.1": 4}, threshold=12
+    )
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 5.0, f"partitioning 24 works took {elapsed:.1f}s; exponential path reachable"
+    # Every work must be placed exactly once, whichever algorithm ran.
+    placed = [item for chunk in chunks for item in chunk]
+    assert sorted(placed) == sorted(weights)
 
 
 def test_make_chunks_uses_default_workers_and_builds_default_capacities(monkeypatch):


### PR DESCRIPTION
## Summary

`make_chunks` picked its partitioning algorithm from the wrong value. Found during the
v2026.07.31 execution-engine audit (finding F8).

## Repro

```python
from agi_node.agi_dispatcher import WorkDispatcher
weights = [(f"job-{i}", float((i % 7) + 1)) for i in range(20)]
WorkDispatcher.make_chunks(1, weights, workers={"127.0.0.1": 4}, threshold=12)
```

Measured on this surface, understating `nchunk2` so the gate always picks the exponential
path:

| works | wall clock |
|---|---|
| 8 | 0.000 s |
| 12 | 0.006 s |
| 16 | 0.169 s |
| 20 | **>20 s (aborted)** |

No progress output, no timeout, no diagnostic — plan construction simply stops responding.

## Root Cause

`agi_dispatcher.py` chose between `_make_chunks_optimal` (exponential branch-and-bound) and
`_make_chunks_fastest` (LPT heuristic) with:

```python
if len(weights) > 1:
    if nchunk2 < threshold:
        chunks = WorkDispatcher._make_chunks_optimal(weights, capacities)
```

The gate reads `nchunk2`, a caller-supplied `int`, but the search cost is driven by
`len(weights)` (recursion depth in `_search`) and the worker count. Nothing enforced that
the two agreed, and the docstring described `nchunk2` as a "list of number of chunks level
2" although it is an `int`.

## Scope

**Shipped code was not affected.** All eight built-in apps pass `len(weights)`
(`mission_decision`, `flight_telemetry`, `execution_pandas`, `execution_polars`,
`uav_queue`, `uav_relay_queue`, `weather_forecast`, `tescia_diagnostic`). The defect is
reachable through app authoring, which is AGILAB's primary extension surface, where the
parameter was redundant, undocumented and unvalidated.

This is a hang during plan construction, before any worker runs — no partial or wrong
output was ever produced.

## Fix

- Derive the gate from `len(weights)`.
- Log a warning when `nchunk2` disagrees, so an existing miscall is visible rather than
  silently reinterpreted.
- Keep `nchunk2` in the signature for backwards compatibility and reporting; correct its
  docstring.

## Regression Test

The previous `test_make_chunks_selects_optimal_or_fastest` asserted the old behaviour: it
varied `nchunk2` (2 vs 5) over a fixed two-element weights list while monkeypatching **both**
implementations, so the exponential path never actually ran and the divergence was treated
as correct. Updated to:

- vary the **work list** rather than `nchunk2`;
- assert that an understated `nchunk2` on a larger list still selects the heuristic;
- plus a new `test_make_chunks_understated_nchunk2_cannot_trigger_exponential_hang` that
  monkeypatches nothing, partitions 24 works with `nchunk2=1`, asserts it completes within
  a time budget, and asserts every work is placed exactly once.

## Validation

- `pytest src/agilab/core/test/test_work_dispatcher.py` -> **50 passed**
- `pytest src/agilab/core/test` -> **1518 passed, 5 skipped**
- `ruff check` on both changed files -> clean
- `./dev scope` -> `ok`, 2 files (`core:agi-node`, `core:test`)
- `agent_commit_provenance_guard --check-config` -> pass

Note: run the suite with the repo's default pytest config. Passing `-o addopts=''` breaks
collection in `src/agilab/core/test` with `ModuleNotFoundError: No module named
'agilab.core'` for unrelated files too — that is pre-existing and not introduced here.

## Also verified sound while in this code (no change needed)

- **Work conservation** — partitioning at n = 8/12/16 places every item exactly once.
- **Determinism** — stable `sort(reverse=True, key=...)`, `range(nchk)` iteration, and
  `np.argmin` first-occurrence, so identical inputs partition identically. That matters
  directly for the reproducibility claim.
- **The branch-and-bound cut is correct** — the prune fires only when a chunk can absorb all
  remaining work and stay under the current maximum, so optimality is preserved; the
  `(size, capacity)` symmetry break is safe because the objective depends only on max load.

## Review Evidence

No sub-agent or model review — the multi-agent workflow runner was unavailable (provider
capacity guard), so this was written and self-reviewed single-pass. The core claim is
backed by measurement rather than reading.

## Agent Metadata

- Tokki version: 1.0.42
- Agent/runtime: Claude Code
- Model: claude-opus-5[1m] (Opus 5, 1M context)
- Reasoning effort: xhigh (ultracode)
- `/fast` mode: not used
