### PR TITLE
Refresh exact main-branch UI robot evidence

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,7 +2,7 @@
   "file_count": 273,
   "format_version": 3,
   "managed_target": "docs/source",
-  "public_owned_digest_sha256": "56f01c16f5b3906e8ee75908b0feec6e17db5070f794ed7a9f1d1247dbf1fc18",
+  "public_owned_digest_sha256": "ee5d0016996cded96b51e7e83ce869a75ce8eac723d6817d8b0eeb5839b6d6d8",
   "public_owned_exclusions": [
     "data/release_proof.toml",
     "data/ui_robot_evidence.json",
@@ -11,8 +11,8 @@
   "public_owned_file_count": 3,
   "public_owned_files_sha256": {
     "data/release_proof.toml": "b5c5f018521602637029f5f13c6ea564a5c1adf2a8e5d2fa5c5a7b708294b0bd",
-    "data/ui_robot_evidence.json": "62cc908a94f4e7d656872a48341bb1f561ae4c0928a4ab33e4cd8a2ee75c5ae5",
-    "release-proof.rst": "c7424dc552751d3dc032ad3d15397339a51cff1e77c3d3cf10298798593b763a"
+    "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
+    "release-proof.rst": "44237e6e21591932e0518ccf8696ebfaffeea8ffd101c2bd4012e492ce585065"
   },
   "source_digest_sha256": "241cfcf5e643bf98d18ed27800bef5b0a351eac26626ef49a070783d571d92a1",
   "source_hint": "../thales_agilab/docs/source",

--- a/docs/source/data/ui_robot_evidence.json
+++ b/docs/source/data/ui_robot_evidence.json
@@ -2,7 +2,7 @@
   "artifact": {
     "aggregate_report_file": "aggregate.json",
     "aggregate_report_schema": "agilab.ui_robot_matrix_aggregate.v1",
-    "archive_download_url": "https://api.github.com/repos/ThalesGroup/agilab/actions/artifacts/8799482872/zip",
+    "archive_download_url": "https://api.github.com/repos/ThalesGroup/agilab/actions/artifacts/8800220834/zip",
     "exit_code": "0",
     "exit_code_file": "exit-code.txt",
     "expired": false,
@@ -14,11 +14,11 @@
     "scenario_summary_file": "aggregate.json",
     "screenshot_count": 56,
     "shard_count": 35,
-    "size_bytes": 9556,
+    "size_bytes": 9587,
     "trend_report_file": "aggregate.json",
     "trend_report_schema": "agilab.ui_robot_trend_report.v1"
   },
-  "generated_at": "2026-07-31T16:13:18Z",
+  "generated_at": "2026-07-31T17:20:14Z",
   "result": {
     "app_count": 14,
     "apps": [
@@ -40,40 +40,40 @@
     "failed_count": 0,
     "failed_scenarios": [],
     "failure_samples": [],
-    "interacted_count": 1553,
+    "interacted_count": 1561,
     "page_count": 951,
-    "probed_count": 33808,
-    "skipped_count": 53,
+    "probed_count": 33697,
+    "skipped_count": 32,
     "status": "pass",
     "success": true,
-    "total_duration_seconds": 9761.135791534,
+    "total_duration_seconds": 9888.920752407,
     "trend": {
       "budget_violation_count": 0,
       "failed_page_count": 0,
       "flaky_page_count": 0,
-      "mean_page_duration_seconds": 25.0630647934212,
+      "mean_page_duration_seconds": 25.42363079754155,
       "page_count": 349,
       "parse_error_count": 0,
       "schema": "agilab.ui_robot_trend_report.v1",
       "slow_page_count": 0,
       "success": true,
-      "total_duration_seconds": 8747.009612904
+      "total_duration_seconds": 8872.847148342
     },
-    "widget_count": 35414,
+    "widget_count": 35290,
     "within_target": true
   },
   "schema": "agilab.ui_robot_evidence.v1",
   "source": {
     "conclusion": "success",
-    "created_at": "2026-07-31T15:57:07Z",
+    "created_at": "2026-07-31T16:24:02Z",
     "event": "workflow_dispatch",
-    "head_branch": "agent/audit-remediation-2026-07-31",
-    "head_sha": "d315d747bad9502b92ce0a0b9f01c3f75e5d49f6",
+    "head_branch": "main",
+    "head_sha": "adf8c597b5e4b852bc301e1adb9cf7bbb8fb3a7c",
     "run_attempt": "1",
-    "run_id": "30645071346",
-    "run_url": "https://github.com/ThalesGroup/agilab/actions/runs/30645071346",
+    "run_id": "30646957592",
+    "run_url": "https://github.com/ThalesGroup/agilab/actions/runs/30646957592",
     "status": "completed",
-    "updated_at": "2026-07-31T16:12:40Z",
+    "updated_at": "2026-07-31T16:39:59Z",
     "workflow": "ui-robot-matrix"
   }
 }

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -59,8 +59,8 @@ What was proved
   exact app inventory matches the 14-app release inventory. Use
   ``tools/ui_robot_coverage_contract.py --json`` and the local
   ``ui-robot-matrix`` profile to verify the current checkout. Historical UI
-  robot baseline: run ``30645071346``, commit ``d315d747bad9``, generated
-  ``2026-07-31T16:13:18Z``. It records ``14`` apps while this release expects
+  robot baseline: run ``30646957592``, commit ``adf8c597b5e4``, generated
+  ``2026-07-31T17:20:14Z``. It records ``14`` apps while this release expects
   ``14``; it is not UI proof for this release.
 - The public demo scope includes the lightweight ``flight_telemetry_project``
   and ``weather_forecast_project`` routes documented in :doc:`agilab-demo` and


### PR DESCRIPTION
## Summary

- replace the branch-derived historical UI baseline with successful exact 14-app run 30646957592 from `main`
- preserve the reviewed release/attestation policy merged in #932 unchanged
- regenerate only the public-owned UI evidence, release-proof rendering, and mirror integrity stamp

The new evidence head `adf8c597...` is an ancestor of current `main`. The previous evidence head `d315d747...` came from `agent/audit-remediation-2026-07-31` and is not an ancestor after squash merge. The evidence remains explicitly historical and non-release-bound because neither head is the release tag commit `3e88def...`.

## Evidence

Run: https://github.com/ThalesGroup/agilab/actions/runs/30646957592

- 37/37 jobs succeeded
- 14 apps, 35/35 shards, 951 pages, 165 scenarios
- 35,290 widgets; 1,561 interacted; 33,697 probed
- zero failed pages/shards, flaky pages, slow pages, budget violations, parse errors, missing apps, or unexpected apps

## Local validation

- evidence validation: 7/7 passed
- release proof with live GitHub checks: 13/13 passed
- focused evidence/release/capability tests: 69 passed
- docs workflow parity and Sphinx build: passed
- public/private docs mirror stamp, scope guard, and diff check: passed

Final diff versus `main`: exactly three generated/public-owned artifacts.