### PR TITLE
docs(kpi): refresh public strategic score

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Current public evaluation summary, refreshed from the public KPI bundle:
 
 - `4.0 / 5` for ease of adoption, research experimentation, and engineering prototyping.
 - `3.2 / 5` for production readiness.
-- `4.2 / 5` for strategic potential.
+- `4.3 / 5` for strategic potential.
 - Overall public evaluation, rounded category average: `3.8 / 5`.
 <!-- AGILAB_PUBLIC_KPI_SUMMARY_END -->
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -480,12 +480,14 @@ compatibility status, and roadmap scope live in:
 
 ## Evaluation Snapshot
 
+<!-- AGILAB_PUBLIC_KPI_SUMMARY_START -->
 Current public evaluation summary, refreshed from the public KPI bundle:
 
 - `4.0 / 5` for ease of adoption, research experimentation, and engineering prototyping.
 - `3.2 / 5` for production readiness.
-- `4.2 / 5` for strategic potential.
+- `4.3 / 5` for strategic potential.
 - Overall public evaluation, rounded category average: `3.8 / 5`.
+<!-- AGILAB_PUBLIC_KPI_SUMMARY_END -->
 
 These are public experimentation-workbench scores, not production MLOps claims.
 They cover project setup, environment management, execution, and result analysis.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
     "release-proof.rst": "44237e6e21591932e0518ccf8696ebfaffeea8ffd101c2bd4012e492ce585065"
   },
-  "source_digest_sha256": "241cfcf5e643bf98d18ed27800bef5b0a351eac26626ef49a070783d571d92a1",
+  "source_digest_sha256": "fe28cdebc46e90b4ffb6063cfac8607a92ab3f5e625959df2c7fbd128c6fd5f2",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "241cfcf5e643bf98d18ed27800bef5b0a351eac26626ef49a070783d571d92a1"
+  "target_digest_sha256": "fe28cdebc46e90b4ffb6063cfac8607a92ab3f5e625959df2c7fbd128c6fd5f2"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -351,11 +351,13 @@ between research experiments and engineering validation:
 - a roadmap ordered around run evidence, promotion decisions, compatibility
   automation, and cross-app orchestration
 
-That supports a ``Strategic potential`` score of ``4.2 / 5``. It is not scored
-higher yet because future app/template reducer adoption discipline and broader
-fresh-install validation are still roadmap work. The public scorecard in
-:doc:`strategic-potential` defines the evidence required before maintainers
-should move that score to ``4.3 / 5`` or higher.
+That supports a ``Strategic potential`` score of ``4.3 / 5``. The current
+release gate, packaged-example maturity contract, release proof, and live
+Hugging Face smoke align the public GitHub, PyPI, docs, and demo state required
+for that threshold. It is not scored at ``4.5 / 5`` because that level still
+requires two attached external fresh-machine proofs, live multi-app operator UI
+evidence, and credentialed operator-gated connector validation. The public
+scorecard in :doc:`strategic-potential` keeps those boundaries explicit.
 
 Together, the current public category scores round to an overall public
 evaluation of ``3.8 / 5``. This is a compact experimentation-workbench snapshot,

--- a/docs/source/strategic-potential.rst
+++ b/docs/source/strategic-potential.rst
@@ -26,11 +26,18 @@ monitor, or standalone certification layer.
 Current score
 -------------
 
-AGILAB currently supports a ``Strategic potential`` score of ``4.2 / 5``.
+AGILAB currently supports a ``Strategic potential`` score of ``4.3 / 5``.
 
 That score reflects bridge-layer value: reducing friction between exploratory
 AI work and engineering-grade validation. Future score updates should be based
 on new public evidence, not stronger wording.
+
+The ``4.3 / 5`` threshold is supported by the passing release gate and
+packaged-example maturity contract, plus release proof that aligns GitHub,
+PyPI, the public docs, and the live Hugging Face demo. The score remains below
+``4.5 / 5`` because two attached external fresh-machine proofs, live multi-app
+operator UI evidence, and credentialed operator-gated connector validation are
+not all established yet.
 
 Score movement rule
 -------------------
@@ -186,7 +193,7 @@ evidence closes a listed gap.
    * - Target score
      - Required proof
      - Still not claimed
-   * - ``4.3 / 5``
+   * - ``4.3 / 5`` (current)
      - Final release gate passes with network checks included; packaged
        examples pass the external-beta maturity contract; public docs, PyPI,
        GitHub release, and Hugging Face demo point to the same release state.

--- a/test/test_kpi_evidence_bundle.py
+++ b/test/test_kpi_evidence_bundle.py
@@ -46,10 +46,17 @@ def test_build_bundle_passes_static_public_evidence_contracts() -> None:
     assert bundle["status"] == "pass"
     assert bundle["summary"]["hf_smoke_executed"] is False
     assert bundle["summary"]["score_components"] == {
-        name: f"{score:.1f} / 5"
-        for name, score in module.KPI_COMPONENT_SCORES.items()
+        "Ease of adoption": "4.0 / 5",
+        "Research experimentation": "4.0 / 5",
+        "Engineering prototyping": "4.0 / 5",
+        "Production readiness": "3.2 / 5",
     }
-    assert bundle["summary"]["strategic_potential_score"] == module.STRATEGIC_POTENTIAL_SCORE
+    assert bundle["supported_score"] == "3.8 / 5"
+    assert bundle["summary"]["strategic_potential_score"] == "4.3 / 5"
+    assert (
+        bundle["summary"]["strategic_potential_score_basis"]
+        == module.STRATEGIC_POTENTIAL_SCORE_BASIS
+    )
     assert bundle["summary"]["score_formula"] == module._score_formula()
     assert (
         f"Strategic potential is tracked separately at {module.STRATEGIC_POTENTIAL_SCORE}"

--- a/tools/kpi_evidence_bundle.py
+++ b/tools/kpi_evidence_bundle.py
@@ -29,7 +29,12 @@ KPI_COMPONENT_SCORES = {
 }
 OVERALL_SCORE_RAW = sum(KPI_COMPONENT_SCORES.values(), Decimal("0")) / Decimal(len(KPI_COMPONENT_SCORES))
 SUPPORTED_OVERALL_SCORE = f"{OVERALL_SCORE_RAW.quantize(Decimal('0.1'), rounding=ROUND_HALF_UP)} / 5"
-STRATEGIC_POTENTIAL_SCORE = "4.2 / 5"
+STRATEGIC_POTENTIAL_SCORE = "4.3 / 5"
+STRATEGIC_POTENTIAL_SCORE_BASIS = (
+    "The 4.3 threshold is supported by passing release and packaged-example gates "
+    "plus aligned GitHub, PyPI, docs, and Hugging Face release evidence. The 4.5 "
+    "external fresh-machine and credentialed-connector threshold is not yet met."
+)
 README_SUMMARY_START = "<!-- AGILAB_PUBLIC_KPI_SUMMARY_START -->"
 README_SUMMARY_END = "<!-- AGILAB_PUBLIC_KPI_SUMMARY_END -->"
 TEMPLATE_ONLY_BUILTIN_APPS = {
@@ -2526,6 +2531,7 @@ def build_score_snapshot() -> dict[str, Any]:
                 for name, score in KPI_COMPONENT_SCORES.items()
             },
             "strategic_potential_score": STRATEGIC_POTENTIAL_SCORE,
+            "strategic_potential_score_basis": STRATEGIC_POTENTIAL_SCORE_BASIS,
             "score_formula": _score_formula(),
             "score_rounding": "one decimal, half up",
         },
@@ -2677,6 +2683,7 @@ def build_bundle(
                 for name, score in KPI_COMPONENT_SCORES.items()
             },
             "strategic_potential_score": STRATEGIC_POTENTIAL_SCORE,
+            "strategic_potential_score_basis": STRATEGIC_POTENTIAL_SCORE_BASIS,
             "score_formula": _score_formula(),
             "score_rounding": "one decimal, half up",
         },


### PR DESCRIPTION
## Summary

- Raise the public Strategic potential KPI from 4.2 to 4.3 using the current release, packaged-example, documentation, and Hugging Face evidence.
- Keep the supported overall score at 3.8 and make the 4.3 evidence basis explicit in the generated KPI bundle.
- Align canonical docs, public docs, README surfaces, and regression assertions.

## Linked Issue

- N/A; this is an evidence-backed KPI refresh without a tracked issue.

## Scope

- Affected repo areas: README surfaces, public docs mirror, KPI evidence tooling, and focused tests.
- User-facing impact: public positioning shows Strategic potential 4.3; the overall score remains 3.8.
- Runtime / packaging / docs impact: docs and evidence-reporting only; no runtime or package dependency behavior changes.
- Stability boundary: release/evidence tooling and public documentation.

## Canonical Source Evidence

- Canonical private docs were merged first at jpmorard/thales_agilab commit dda957a784de7e32f538c38d930a3741c6c5893a.
- Both canonical source files match this PR mirror byte-for-byte.

## Validation

- [x] Targeted local tests ran
- [x] CI-relevant checks passed
- [x] Docs updated and validated

Commands / checks run:

```bash
uv --preview-features extra-build-dependencies run python tools/impact_validate.py --base origin/main --no-cache
AGILAB_DOCS_SOURCE=/Users/agi/PycharmProjects/thales_agilab-worktrees/codex-refresh-public-kpis-docs/docs/source uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
AGILAB_DOCS_SOURCE=/Users/agi/PycharmProjects/thales_agilab-worktrees/codex-refresh-public-kpis-docs/docs/source uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_kpi_evidence_bundle.py
AGILAB_DOCS_SOURCE=/Users/agi/PycharmProjects/thales_agilab-worktrees/codex-refresh-public-kpis-docs/docs/source uv --preview-features extra-build-dependencies run --extra ui python tools/kpi_evidence_bundle.py
```

Local results:

- Impact classification: low, seven files.
- Docs workflow parity: passed.
- Focused regression suite: 47 passed.
- KPI evidence bundle: 43/43 passed; Strategic potential 4.3, supported overall score 3.8.
- Hugging Face smoke: not rerun because this PR changes no deployment payload; existing aligned release evidence is consumed by the KPI bundle.

GitHub results after reopen:

- Required policy, Python 3.12/3.14, clean-install Linux/macOS/Windows, Windows core, root tests, verify, and GitGuardian checks: passed.
- Root test suite: run 32977980446, passed.
- Required-check matrix: run 32977980437, passed.
- Windows core tests: run 32977980462, passed.
- Verify: run 32977980585, passed.
- Public demo smoke: skipped by workflow scope; no demo payload changed.

## Review Evidence

- Independent reviewer requested: bsdju, repository maintainer.
- Review decision: protected-main approval pending.
- Independent model or sub-agent review: not used.
- Implementation scope and validation evidence were self-reviewed by Codex.

## Risks

- Known risks or limitations: protected-main approval is the only remaining merge gate.
- Follow-up work: verify the squash commit, remote-main ancestry, and any docs publication workflow after merge.

## Checklist

- [x] No unrelated changes included
- [x] Shared core touched only with explicit approval when required: not applicable; shared core is untouched
- [x] Dependencies updated/removed coherently: not applicable; dependencies are untouched
- [x] Release/tag/PyPI impact considered: docs/evidence-only change; no package publication
- [x] Repository-scope changes stay within the stated stability boundary
- [x] DCO/CLA status is acceptable for this contribution; GitHub checks passed
- [x] Security checklist considered: no secrets, external writes, SSH/cluster, exposure, or credential behavior changed
- [x] New dependency or optional-profile impact includes SBOM / pip-audit evidence or a clear non-release-impact explanation: no dependency changes
- [x] External app/example changes meet public acceptance criteria: not applicable

## Agent Metadata

- Tokki version: 1.0.62
- Agent/runtime: Codex; version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used
