### PR TITLE
test(security): restore agi-cluster coverage

### DIFF
--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -282,6 +282,38 @@ def test_load_capacity_predictor_rejects_missing_trusted_root_by_default(tmp_pat
     assert "without a trusted resource root" in calls["warnings"][0][0]
 
 
+def test_load_capacity_predictor_retrains_when_trusted_open_fails(
+    monkeypatch, tmp_path
+):
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    calls = {"load": 0, "retrain": 0, "warnings": []}
+    log = SimpleNamespace(
+        warning=lambda message, path, reason: calls["warnings"].append(
+            (message, path, reason)
+        )
+    )
+    monkeypatch.setattr(
+        runtime_misc_support,
+        "_open_trusted_capacity_file",
+        lambda *_args, **_kwargs: (None, None, "descriptor verification failed"),
+    )
+
+    loaded = runtime_misc_support.load_capacity_predictor(
+        model_path,
+        load_fn=lambda _stream: calls.__setitem__("load", calls["load"] + 1),
+        retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
+        log=log,
+        trusted_root=model_path.parent,
+    )
+
+    assert loaded is None
+    assert calls["load"] == 0
+    assert calls["retrain"] == 1
+    assert calls["warnings"][0][2] == "descriptor verification failed"
+
+
 def test_load_capacity_predictor_returns_signed_trusted_value(tmp_path):
     model_path = tmp_path / "resources" / "balancer_model.pkl"
     model_path.parent.mkdir()
@@ -918,6 +950,30 @@ def test_posix_group_is_user_private_allows_proven_single_user_group(monkeypatch
     )
 
     assert runtime_misc_support._posix_group_is_user_private(
+        SimpleNamespace(st_gid=1000)
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX account database semantics")
+def test_posix_group_is_user_private_fails_closed_on_lookup_error(monkeypatch):
+    current_user = SimpleNamespace(pw_name="runner", pw_gid=1000)
+
+    def fail_group_lookup(_gid):
+        raise OSError("group database unavailable")
+
+    monkeypatch.setattr(runtime_misc_support.os, "geteuid", lambda: 1000)
+    monkeypatch.setitem(
+        sys.modules,
+        "pwd",
+        SimpleNamespace(getpwuid=lambda _uid: current_user, getpwall=lambda: ()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "grp",
+        SimpleNamespace(getgrgid=fail_group_lookup),
+    )
+
+    assert not runtime_misc_support._posix_group_is_user_private(
         SimpleNamespace(st_gid=1000)
     )
 


### PR DESCRIPTION
## Summary

- Add a fail-closed regression for trusted capacity-model descriptor open failures.
- Add a fail-closed regression for unavailable POSIX group-account lookups.
- Restore the canonical agi-cluster coverage badge to 92% without changing production code or committed badge files.

## Repro

The main coverage run https://github.com/ThalesGroup/agilab/actions/runs/32982729406 failed its committed-badge freshness check because the current agi-cluster XML contained 8,197 covered lines out of 8,917, or 91.9255%. Regeneration would lower `badges/coverage-agi-cluster.svg` from 92% to 91%. The badge-only PR #954 was closed without merge.

## Root Cause

The capacity-model security hardening left two meaningful fail-closed paths uncovered: rejection after a trusted descriptor cannot be opened safely, and rejection when POSIX group membership cannot be verified. The implementation was already fail-closed; the missing regressions reduced measured coverage below the committed 92% boundary.

## Regression Test

- `test_load_capacity_predictor_retrains_when_trusted_open_fails` proves unsafe descriptor-open failure prevents loading, emits the diagnostic, and requests retraining.
- `test_posix_group_is_user_private_fails_closed_on_lookup_error` proves an unavailable group database is treated as shared rather than trusted.
- The seven previously uncovered executable lines now each report one hit in the generated agi-cluster XML.

## Shared-Core Approval

The user explicitly approved this focused shared-core test scope on 2026-08-26. The only changed file is `src/agilab/core/test/test_agi_distributor_runtime_misc_support.py`; no production shared-core implementation changed. Blast radius is limited to agi-cluster security regression coverage.

## Validation

- Focused isolated core test: 77 passed, 1 skipped.
- Full CI-parity agi-node and agi-cluster suite: 1,596 passed, 5 skipped.
- agi-cluster coverage: 8,211 / 8,917 lines, 92.08%.
- Component badge generator tests: 11 passed.
- Coverage badge guard passed for agi-cluster, agi-core, and agilab.
- Badge workflow parity passed with no committed badge drift.
- Ruff, impact validation, staged scope, commit provenance, and pre-push guards passed.
- Initial root-environment pytest suggestion was not applicable to this core package layout and failed during collection with `ModuleNotFoundError: agilab.core`; the authoritative isolated editable-package workflow above passed.
- GitHub checks passed after resignature: root tests, Windows core tests, local-only policy, Python 3.12/3.14 compatibility, Linux/macOS/Windows clean installs, and GitGuardian. Public demo smoke was skipped by workflow as not applicable.
- GitHub commit verification passed for `e973e67158526002a571c1ba7066b734d22e4d42` (`verified: true`, reason `valid`).

## Current Gate

Resolved. The user authorized the controlled resignature and exact `--force-with-lease` update on 2026-08-27. The rewritten commit has the same tree as `990aa1c1aa13466a830983aac94276a07724a09d`, GitHub verifies its SSH signature, all 10 checks are complete with no failures, the effective main rulesets require 0 approving reviews, no review threads are unresolved, and GitHub reports the PR `CLEAN` and `MERGEABLE`. No administrative bypass or automatic merge was used.

## Review Evidence

No sub-agents or separate reviewer model were used. Codex performed the scoped implementation and validation directly.

## Agent Metadata

- Tokki version: 1.0.62
- Agent/runtime: Codex CLI 0.149.1
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
