### PR TITLE
fix(deps): cap Ruff below incompatible 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ proof = ["cryptography>=50.0.0,<51"]
 agents = ["openai>=2.32.0,<4"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]
 offline = ["agilab[local-llm]==2026.07.31"]
-dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<0.17", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<8", "wheel>=0.45.0,<1"]
+dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<0.16", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<8", "wheel>=0.45.0,<1"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- restore the Ruff development dependency upper bound to `<0.16`
- keep the OpenAI, Plotly, and Twine dependency expansions from #957 unchanged
- constrain fresh environments to the latest compatible Ruff 0.15 release

## Repro

On `7ed3ba0`, a fresh resolution selected Ruff 0.16.5. The repository's official `./dev lint` profile then failed with 137 findings, while the same profile passed with Ruff 0.15.17.

## Root Cause

The widened `ruff<0.17` constraint admitted Ruff 0.16, whose effective rule behavior is incompatible with the repository's current lint configuration. No runtime application code caused the failure.

## Regression Test

- `./dev lint` passes with the resolver-selected Ruff 0.15.22
- `test/test_pyproject_dependency_hygiene.py`: 29 passed
- dependency-policy workflow parity profile: passed
- staged impact validation classifies the one-file change as low risk and requires only the dependency-hygiene slice above

The dependency cap itself prevents fresh environments from resolving the incompatible Ruff 0.16 line. Broader validation from the originating dependency review remains green for OpenAI 3.7.0 with HTTPX2, Plotly 7.0.0, package builds, and Twine 7.0.0.

## Validation

- Git diff and staged-scope guards: passed
- local pre-push guards: passed
- browser/UI validation: not applicable; dependency metadata only
- GitHub checks: passed; all applicable checks are green, and public-demo-smoke was skipped as not applicable to this dependency-metadata-only change

## Review Evidence

No separate reviewer model or sub-agent was used. The implementing Codex agent performed the focused diff and validation review.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex; version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used