### PR TITLE
fix(packaging): exclude symlinks from app payloads

### DIFF
--- a/src/agilab/lib/app_project_build_support.py
+++ b/src/agilab/lib/app_project_build_support.py
@@ -125,6 +125,9 @@ def _ignore_payload_artifacts(directory: str, names: list[str]) -> set[str]:
     ignored: set[str] = set()
     for name in names:
         path = Path(directory) / name
+        if path.is_symlink():
+            ignored.add(name)
+            continue
         if path.is_dir() and (name in _EXCLUDED_PAYLOAD_DIRS or name.endswith(".egg-info")):
             ignored.add(name)
             continue

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -1451,6 +1451,40 @@ def test_app_project_payload_copy_excludes_parallel_coverage_artifacts(tmp_path:
     assert not (payload_root / ".coverage.worker.123").exists()
 
 
+def test_app_project_payload_copy_excludes_symlinks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    support = _load_app_project_build_support()
+    source_agilab_root = tmp_path / "source" / "agilab"
+    project_name = "example_project"
+    project_root = source_agilab_root / "apps" / "builtin" / project_name
+    project_root.mkdir(parents=True)
+    (project_root / "README.md").write_text("safe payload\n", encoding="utf-8")
+
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    (external_root / "private.txt").write_text("do not package\n", encoding="utf-8")
+    try:
+        (project_root / "external-link").symlink_to(
+            external_root, target_is_directory=True
+        )
+        (project_root / ".venv").symlink_to(
+            tmp_path / "missing-venv", target_is_directory=True
+        )
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    monkeypatch.setattr(support, "repo_agilab_root", lambda: source_agilab_root)
+
+    support.copy_app_project_payload(project_name, tmp_path / "target")
+
+    payload_root = tmp_path / "target" / project_name
+    assert (payload_root / "README.md").read_text(encoding="utf-8") == "safe payload\n"
+    assert not (payload_root / "external-link").exists()
+    assert not (payload_root / "external-link").is_symlink()
+    assert not (payload_root / ".venv").is_symlink()
+
+
 def test_agi_apps_umbrella_bundles_only_the_base_minimal_app_template() -> None:
     pyproject = tomllib.loads(AGI_APPS_PYPROJECT.read_text(encoding="utf-8"))
     package_data = pyproject["tool"]["setuptools"]["package-data"]


### PR DESCRIPTION
## Summary
- exclude all symlinks before app payload path classification
- prevent dangling virtual-environment links from breaking package builds
- prevent valid links from dereferencing files outside an app project
- add a polluted-workspace regression through the public payload copy entrypoint

## Repro
Before the fix, uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet failed with shutil.Error while copying src/agilab/apps/builtin/mission_decision_project/.venv, a dangling link to an unavailable worker environment.

## Root Cause
The shared ignore callback called Path.is_dir() before deciding whether to exclude an entry. Path.is_dir() follows links and returns false for a dangling link, so the .venv entry escaped the exclusion set. A valid non-excluded directory link could also be dereferenced by shutil.copytree and package data outside the app project.

## Regression Test
test_app_project_payload_copy_excludes_symlinks builds a temporary app project containing both a dangling .venv link and a valid link to an external directory, invokes copy_app_project_payload, and proves neither link enters the payload.

## Validation
- 78 focused packaging tests passed
- polluted-checkout app contract matrix passed
- agi-gui workflow parity profile passed
- Ruff lint and git diff checks passed
- Agent provenance and staged scope guards passed
- All required GitHub checks passed, including root tests, Python compatibility, Windows core tests, clean public installs, and GitGuardian
- Whole-file Ruff format check remains non-gating: both legacy files already produce a 1,426-line formatter rewrite; no formatter delta intersects the new regression hunk

## Publication Gate
- Auto-merge is armed but GitHub reports the PR as BLOCKED by the base policy after every required check passed
- Commit f006ec0 retains AGILAB Codex Agent as author and committer
- The SSH signature validates against the existing jpmorard signing key, but GitHub reports unknown_key for the agent-identity commit
- No administrator bypass has been used; explicit operator approval is required before an admin merge

## Review Evidence
- Reviewer model: gpt-5.6-sol
- Review type: implementation and security self-review
- Result: pass; no unresolved implementation findings
- Sub-agents: not used

## Agent Metadata
- Tokki version: 1.0.63
- Agent/runtime: Codex CLI 0.153.0
- Model: gpt-5.6-sol
- Reasoning effort: xhigh
- /fast mode: not used