### PR TITLE
fix(security): reject linked recursive-copy inputs

### DIFF
--- a/src/agilab/bridge_cli.py
+++ b/src/agilab/bridge_cli.py
@@ -6,6 +6,7 @@ import argparse
 import csv
 import hashlib
 import json
+import os
 import platform
 import re
 import shlex
@@ -566,8 +567,8 @@ def _export_quarto_report_loaded(
     return payload
 
 
-def _copy_project_tree(project_path: Path, destination: Path) -> None:
-    ignore = shutil.ignore_patterns(
+def _project_copy_ignore() -> Callable[[str, list[str]], set[str]]:
+    return shutil.ignore_patterns(
         ".git",
         ".mypy_cache",
         ".pytest_cache",
@@ -578,12 +579,70 @@ def _copy_project_tree(project_path: Path, destination: Path) -> None:
         "dist",
         "*.pyc",
     )
-    shutil.copytree(project_path, destination, ignore=ignore)
+
+
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction and is_junction())
+
+
+def _linked_tree_entries(
+    root: Path,
+    *,
+    ignore: Callable[[str, list[str]], set[str]] | None = None,
+) -> list[Path]:
+    linked: list[Path] = []
+    if _is_link_like(root):
+        return [root]
+    if not root.is_dir():
+        return linked
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        names = [*dirnames, *filenames]
+        ignored = ignore(directory, names) if ignore is not None else set()
+        included_dirs = [name for name in dirnames if name not in ignored]
+        included_files = [name for name in filenames if name not in ignored]
+        directory_path = Path(directory)
+        for name in [*included_dirs, *included_files]:
+            path = directory_path / name
+            if _is_link_like(path):
+                linked.append(path)
+        dirnames[:] = [
+            name for name in included_dirs if not _is_link_like(directory_path / name)
+        ]
+    return sorted(linked)
+
+
+def _require_no_linked_inputs(
+    root: Path,
+    *,
+    label: str,
+    ignore: Callable[[str, list[str]], set[str]] | None = None,
+) -> None:
+    linked = _linked_tree_entries(root, ignore=ignore)
+    if linked:
+        formatted = ", ".join(str(path) for path in linked)
+        raise RuntimeError(
+            f"Cannot export Hugging Face Space: {label} contains symlink or junction entries: "
+            f"{formatted}"
+        )
+
+
+def _copy_project_tree(project_path: Path, destination: Path) -> None:
+    shutil.copytree(
+        project_path,
+        destination,
+        ignore=_project_copy_ignore(),
+        symlinks=True,
+    )
+    _require_no_linked_inputs(destination, label="staged project")
 
 
 def _secret_findings(root: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
-    for path in sorted(root.rglob("*")):
+    paths = [root] if root.is_file() else sorted(root.rglob("*"))
+    for path in paths:
         if not path.is_file() or (
             path.suffix.lower() not in _TEXT_EXTENSIONS
             and path.name.lower() not in _TEXT_EXTENSIONS
@@ -619,14 +678,34 @@ def export_hf_space(
     evidence_path: Path | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
-    project = project_path.expanduser().resolve(strict=False)
-    if not project.is_dir():
-        raise FileNotFoundError(f"Project path does not exist: {project}")
+    project_source = project_path.expanduser()
+    if not project_source.is_dir():
+        raise FileNotFoundError(f"Project path does not exist: {project_source}")
+    _require_no_linked_inputs(
+        project_source,
+        label="project",
+        ignore=_project_copy_ignore(),
+    )
+    project = project_source.resolve(strict=False)
     findings = _secret_findings(project)
     if findings:
         raise RuntimeError(
             f"Cannot export Hugging Face Space with secret-like project inputs: {findings[0]}"
         )
+
+    evidence: Path | None = None
+    if evidence_path is not None:
+        evidence_source = evidence_path.expanduser()
+        if not evidence_source.is_dir() and not evidence_source.is_file():
+            raise FileNotFoundError(f"Evidence path does not exist: {evidence_source}")
+        _require_no_linked_inputs(evidence_source, label="evidence")
+        evidence = evidence_source.resolve(strict=False)
+        evidence_findings = _secret_findings(evidence)
+        if evidence_findings:
+            raise RuntimeError(
+                "Cannot export Hugging Face Space with secret-like evidence inputs: "
+                f"{evidence_findings[0]}"
+            )
 
     output = output_dir.expanduser().resolve(strict=False)
     project_dest = output / "agilab_project"
@@ -640,16 +719,18 @@ def export_hf_space(
     _copy_project_tree(project, project_dest)
 
     evidence_dest = None
-    if evidence_path is not None:
-        evidence = evidence_path.expanduser().resolve(strict=False)
+    if evidence is not None:
         evidence_dest = output / "evidence"
         if evidence_dest.exists():
             shutil.rmtree(evidence_dest)
         if evidence.is_dir():
-            shutil.copytree(evidence, evidence_dest)
+            shutil.copytree(evidence, evidence_dest, symlinks=True)
+            _require_no_linked_inputs(evidence_dest, label="staged evidence")
         elif evidence.is_file():
             evidence_dest.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(evidence, evidence_dest / evidence.name)
+            copied_evidence = evidence_dest / evidence.name
+            shutil.copy2(evidence, copied_evidence, follow_symlinks=False)
+            _require_no_linked_inputs(copied_evidence, label="staged evidence")
 
     (output / "requirements.txt").write_text("agilab[ui]\n", encoding="utf-8")
     (output / "Dockerfile").write_text(

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -187,6 +187,82 @@ def test_hf_space_export_edges_and_secret_scan(tmp_path: Path) -> None:
     assert (output / "evidence" / "nested.txt").is_file()
 
 
+def test_hf_space_export_rejects_project_symlink_before_output_mutation(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "README.md").write_text("# Project\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private payload\n", encoding="utf-8")
+    try:
+        (project / "external.txt").symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+    output = tmp_path / "hf-output"
+    output.mkdir()
+    sentinel = output / "sentinel.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        bridge_cli.export_hf_space(project, output, force=True)
+
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+    assert not (output / "agilab_project").exists()
+
+
+def test_hf_space_export_rejects_unsafe_evidence_before_output_mutation(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "README.md").write_text("# Project\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private payload\n", encoding="utf-8")
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    try:
+        (evidence / "external.txt").symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+    output = tmp_path / "hf-output"
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        bridge_cli.export_hf_space(project, output, evidence_path=evidence, force=True)
+
+    assert not output.exists()
+
+
+def test_hf_space_export_scans_evidence_for_secrets_before_output_mutation(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "README.md").write_text("# Project\n", encoding="utf-8")
+    evidence = tmp_path / "evidence.env"
+    evidence.write_text("HF_TOKEN=private-value\n", encoding="utf-8")
+    output = tmp_path / "hf-output"
+
+    with pytest.raises(RuntimeError, match="secret-like evidence inputs"):
+        bridge_cli.export_hf_space(project, output, evidence_path=evidence, force=True)
+
+    assert not output.exists()
+
+
+def test_hf_space_export_ignores_virtualenv_symlinks(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "README.md").write_text("# Project\n", encoding="utf-8")
+    virtualenv = project / ".venv"
+    virtualenv.mkdir()
+    outside = tmp_path / "python"
+    outside.write_text("binary placeholder\n", encoding="utf-8")
+    try:
+        (virtualenv / "python").symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+    output = tmp_path / "hf-output"
+
+    bridge_cli.export_hf_space(project, output)
+
+    assert (output / "agilab_project/README.md").is_file()
+    assert not (output / "agilab_project/.venv").exists()
+
+
 def test_mlflow_vscode_and_workflow_handoff_exports(tmp_path: Path) -> None:
     manifest_path = _write_manifest(tmp_path)
     manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))

--- a/test/test_hf_space_release_sync.py
+++ b/test/test_hf_space_release_sync.py
@@ -6,6 +6,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "tools" / "hf_space_release_sync.py"
@@ -18,6 +20,28 @@ def _load_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _write_stage_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    for app in (
+        "flight_telemetry_project",
+        "weather_forecast_project",
+        "pytorch_playground_project",
+    ):
+        (repo / "src/agilab/apps/builtin" / app).mkdir(parents=True)
+    (repo / "src/agilab/apps/private_project").mkdir(parents=True)
+    for page in ("view_maps", "view_forecast_analysis", "view_release_decision"):
+        (repo / "src/agilab/apps-pages" / page).mkdir(parents=True)
+    (repo / "docker").mkdir()
+    (repo / "src/agilab/main_page.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo / "src/agilab/apps/private_project/secret.txt").write_text(
+        "private\n", encoding="utf-8"
+    )
+    (repo / "pyproject.toml").write_text("[project]\nname='agilab'\n", encoding="utf-8")
+    (repo / "uv_config.toml").write_text("", encoding="utf-8")
+    (repo / "docker/install.sh").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+    return repo
 
 
 def test_runtime_url_matches_hf_space_subdomain() -> None:
@@ -215,23 +239,9 @@ def test_advanced_profile_excludes_retired_weather_clone() -> None:
 
 def test_stage_space_tree_prunes_private_app_entries_before_validation(tmp_path: Path) -> None:
     module = _load_module()
-    repo = tmp_path / "repo"
+    repo = _write_stage_repo(tmp_path)
     stage = tmp_path / "stage"
     stage.mkdir()
-
-    (repo / "src/agilab/apps/builtin/flight_telemetry_project").mkdir(parents=True)
-    (repo / "src/agilab/apps/builtin/weather_forecast_project").mkdir(parents=True)
-    (repo / "src/agilab/apps/builtin/pytorch_playground_project").mkdir(parents=True)
-    (repo / "src/agilab/apps/private_project").mkdir(parents=True)
-    for page in ("view_maps", "view_forecast_analysis", "view_release_decision"):
-        (repo / "src/agilab/apps-pages" / page).mkdir(parents=True)
-    (repo / "src/agilab").mkdir(parents=True, exist_ok=True)
-    (repo / "docker").mkdir()
-    (repo / "src/agilab/main_page.py").write_text("print('ok')\n", encoding="utf-8")
-    (repo / "src/agilab/apps/private_project/secret.txt").write_text("private\n", encoding="utf-8")
-    (repo / "pyproject.toml").write_text("[project]\nname='agilab'\n", encoding="utf-8")
-    (repo / "uv_config.toml").write_text("", encoding="utf-8")
-    (repo / "docker/install.sh").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
 
     summary = module.stage_space_tree(repo, stage, profile="first-proof")
 
@@ -244,6 +254,48 @@ def test_stage_space_tree_prunes_private_app_entries_before_validation(tmp_path:
     assert (stage / "src/agilab/apps/builtin/flight_telemetry_project").is_dir()
     assert (stage / "src/agilab/apps/builtin/weather_forecast_project").is_dir()
     assert (stage / "src/agilab/apps/builtin/pytorch_playground_project").is_dir()
+
+
+def test_stage_space_tree_rejects_included_symlink_before_stage_mutation(tmp_path: Path) -> None:
+    module = _load_module()
+    repo = _write_stage_repo(tmp_path)
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    sentinel = stage / "sentinel.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private payload\n", encoding="utf-8")
+    linked = repo / "src/agilab/apps/builtin/flight_telemetry_project/external.txt"
+    try:
+        linked.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+
+    with pytest.raises(RuntimeError, match="source tree contains symlinks"):
+        module.stage_space_tree(repo, stage, profile="first-proof")
+
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+    assert not (stage / "src").exists()
+
+
+def test_stage_space_tree_ignores_excluded_app_symlink(tmp_path: Path) -> None:
+    module = _load_module()
+    repo = _write_stage_repo(tmp_path)
+    external_app = tmp_path / "external-app"
+    external_app.mkdir()
+    (external_app / "private.txt").write_text("private\n", encoding="utf-8")
+    try:
+        (repo / "src/agilab/apps/installed_project").symlink_to(
+            external_app, target_is_directory=True
+        )
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+
+    module.stage_space_tree(repo, stage, profile="first-proof")
+
+    assert not (stage / "src/agilab/apps/installed_project").exists()
 
 
 def test_hosted_smoke_receives_profile(monkeypatch, tmp_path: Path) -> None:

--- a/test/test_repo_footprint.py
+++ b/test/test_repo_footprint.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools import repo_footprint
+
+
+@pytest.mark.parametrize("preserve", ["../outside.txt", "/tmp/outside.txt", "."])
+def test_realign_local_rejects_unconfined_preserve_path_before_git_mutation(
+    tmp_path, monkeypatch, preserve: str
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(repo_footprint, "_require_repo", lambda _repo: repo)
+    monkeypatch.setattr(repo_footprint, "_repo_root", lambda path: path)
+    monkeypatch.setattr(
+        repo_footprint,
+        "_git",
+        lambda _repo, *args, **_kwargs: git_calls.append(tuple(args)),
+    )
+    args = SimpleNamespace(
+        repo=str(repo),
+        preserve=[preserve],
+        preserve_dir=str(tmp_path / "preserved"),
+        target_ref="origin/main",
+        fetch=False,
+        remote_name="origin",
+        gc=False,
+        apply=True,
+    )
+
+    with pytest.raises(ValueError, match="preserve path"):
+        repo_footprint._realign_local(args)
+
+    assert git_calls == []
+
+
+def test_realign_local_rejects_symlinked_preserve_tree_before_git_mutation(
+    tmp_path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "private.txt").write_text("private\n", encoding="utf-8")
+    linked = repo / "linked"
+    try:
+        linked.symlink_to(outside, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+    git_calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(repo_footprint, "_require_repo", lambda _repo: repo)
+    monkeypatch.setattr(repo_footprint, "_repo_root", lambda path: path)
+    monkeypatch.setattr(
+        repo_footprint,
+        "_git",
+        lambda _repo, *args, **_kwargs: git_calls.append(tuple(args)),
+    )
+    args = SimpleNamespace(
+        repo=str(repo),
+        preserve=["linked"],
+        preserve_dir=str(tmp_path / "preserved"),
+        target_ref="origin/main",
+        fetch=False,
+        remote_name="origin",
+        gc=False,
+        apply=True,
+    )
+
+    with pytest.raises(ValueError, match="symlink"):
+        repo_footprint._realign_local(args)
+
+    assert git_calls == []
+    assert linked.is_symlink()
+
+
+def test_realign_local_rejects_link_in_existing_snapshot_before_git_mutation(
+    tmp_path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "docs"
+    source.mkdir(parents=True)
+    (source / "guide.md").write_text("guide\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    preserve_dir = tmp_path / "preserved"
+    snapshot = preserve_dir / "docs"
+    snapshot.mkdir(parents=True)
+    try:
+        (snapshot / "linked").symlink_to(outside, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
+    git_calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(repo_footprint, "_require_repo", lambda _repo: repo)
+    monkeypatch.setattr(repo_footprint, "_repo_root", lambda path: path)
+    monkeypatch.setattr(
+        repo_footprint,
+        "_git",
+        lambda _repo, *args, **_kwargs: git_calls.append(tuple(args)),
+    )
+    args = SimpleNamespace(
+        repo=str(repo),
+        preserve=["docs"],
+        preserve_dir=str(preserve_dir),
+        target_ref="origin/main",
+        fetch=False,
+        remote_name="origin",
+        gc=False,
+        apply=True,
+    )
+
+    with pytest.raises(ValueError, match="preserve snapshot.*symlink"):
+        repo_footprint._realign_local(args)
+
+    assert git_calls == []
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"

--- a/test/test_sync_agent_skills.py
+++ b/test/test_sync_agent_skills.py
@@ -241,7 +241,7 @@ def test_top_level_symlinked_skill_is_rejected_before_mirror_mutation(
 
     with pytest.raises(
         SystemExit,
-        match=r"Refusing top-level symlinked skill entries.*streamlit skills --global",
+        match=r"Refusing symlinked skill entries.*streamlit skills --global",
     ):
         module.main(args)
 
@@ -249,20 +249,28 @@ def test_top_level_symlinked_skill_is_rejected_before_mirror_mutation(
     assert (mirror_skill / "SKILL.md").read_bytes() == mirror_before
 
 
-def test_check_passes_for_symlinked_directory_content_after_sync(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize("args", [["--check"], ["--all"], ["--skills", "alpha"]])
+def test_nested_symlinked_skill_content_is_rejected_before_mirror_mutation(
+    tmp_path, monkeypatch, args
+) -> None:
     module = _load_module()
     claude_root, codex_root = _fake_repo(module, monkeypatch, tmp_path)
     _tokki_absent(module, monkeypatch)
     skill_dir = _write_skill(claude_root, "alpha")
+    mirror_skill = _write_skill(codex_root, "alpha", body="Mirror sentinel.")
+    mirror_before = (mirror_skill / "SKILL.md").read_bytes()
     shared = tmp_path / "shared"
     shared.mkdir()
     (shared / "inner.md").write_text("shared content\n", encoding="utf-8")
-    (skill_dir / "linkdir").symlink_to(shared, target_is_directory=True)
+    try:
+        (skill_dir / "linkdir").symlink_to(shared, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks unavailable: {error}")
 
-    assert module.main(["--skills", "alpha"]) == 0
-    assert (codex_root / "alpha" / "linkdir" / "inner.md").is_file()
-    assert not (codex_root / "alpha" / "linkdir").is_symlink()
-    assert module.main(["--check"]) == 0
+    with pytest.raises(SystemExit, match=r"Refusing symlinked skill entries.*alpha/linkdir"):
+        module.main(args)
+
+    assert (mirror_skill / "SKILL.md").read_bytes() == mirror_before
 
 
 def test_check_mode_flags_executable_bit_drift(tmp_path, monkeypatch, capsys) -> None:

--- a/tools/hf_space_release_sync.py
+++ b/tools/hf_space_release_sync.py
@@ -15,7 +15,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -367,8 +367,37 @@ def require_profile_dirs(repo_root: Path, profile: str, apps: Sequence[str], pag
         raise RuntimeError(f"profile {profile!r} references missing entries: {', '.join(missing)}")
 
 
-def require_no_symlinked_sources(source_root: Path) -> None:
-    symlinks = [str(path) for path in source_root.rglob("*") if path.is_symlink()]
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction and is_junction())
+
+
+def require_no_symlinked_sources(
+    source_root: Path,
+    *,
+    ignore: Callable[[str, list[str]], set[str]] | None = None,
+) -> None:
+    symlinks: list[str] = []
+    if _is_link_like(source_root):
+        symlinks.append(str(source_root))
+    elif source_root.is_dir():
+        for directory, dirnames, filenames in os.walk(source_root, followlinks=False):
+            names = [*dirnames, *filenames]
+            ignored = ignore(directory, names) if ignore is not None else set()
+            included_dirs = [name for name in dirnames if name not in ignored]
+            included_files = [name for name in filenames if name not in ignored]
+            directory_path = Path(directory)
+            for name in [*included_dirs, *included_files]:
+                path = directory_path / name
+                if _is_link_like(path):
+                    symlinks.append(str(path))
+            dirnames[:] = [
+                name
+                for name in included_dirs
+                if not _is_link_like(directory_path / name)
+            ]
     if symlinks:
         formatted = "\n  - ".join(sorted(symlinks))
         raise RuntimeError(f"refusing HF deploy: source tree contains symlinks\n  - {formatted}")
@@ -436,9 +465,16 @@ def stage_space_tree(repo_root: Path, stage_dir: Path, *, profile: str) -> dict[
     if not (repo_root / "src/agilab/main_page.py").is_file():
         raise RuntimeError(f"not an AGILAB checkout: {repo_root}")
     require_profile_dirs(repo_root, profile, apps, pages)
+    copy_ignore_fn = copy_ignore_for_profile(repo_root, apps, pages)
+    require_no_symlinked_sources(repo_root / "src", ignore=copy_ignore_fn)
 
     write_profile_assets(stage_dir, profile, apps, pages)
-    shutil.copytree(repo_root / "src", stage_dir / "src", ignore=copy_ignore_for_profile(repo_root, apps, pages))
+    shutil.copytree(
+        repo_root / "src",
+        stage_dir / "src",
+        ignore=copy_ignore_fn,
+        symlinks=True,
+    )
     shutil.copy2(repo_root / "pyproject.toml", stage_dir / "pyproject.toml")
     shutil.copy2(repo_root / "uv_config.toml", stage_dir / "uv_config.toml")
     (stage_dir / "docker").mkdir()

--- a/tools/repo_footprint.py
+++ b/tools/repo_footprint.py
@@ -327,12 +327,51 @@ def _history_rewrite(args: argparse.Namespace) -> int:
     return 0
 
 
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction and is_junction())
+
+
+def _require_no_linked_entries(path: Path, *, label: str) -> None:
+    linked = [path] if _is_link_like(path) else []
+    if path.is_dir() and not _is_link_like(path):
+        linked.extend(candidate for candidate in path.rglob("*") if _is_link_like(candidate))
+    if linked:
+        formatted = ", ".join(str(candidate) for candidate in sorted(linked))
+        raise ValueError(f"{label} contains a symlink or junction: {formatted}")
+
+
+def _validate_preserve_path(repo: Path, preserve_dir: Path, rel: Path) -> tuple[Path, Path]:
+    if rel.is_absolute() or not rel.parts or ".." in rel.parts:
+        raise ValueError(f"preserve path must be a confined relative path: {rel}")
+
+    repo_root = repo.resolve()
+    preserve_root = preserve_dir.resolve(strict=False)
+    target = repo_root / rel
+    snapshot = preserve_root / rel
+    for label, root, candidate in (
+        ("preserve path", repo_root, target),
+        ("preserve snapshot", preserve_root, snapshot),
+    ):
+        current = root
+        for part in candidate.relative_to(root).parts:
+            current /= part
+            if _is_link_like(current):
+                raise ValueError(f"{label} contains a symlink or junction: {current}")
+        resolved = candidate.resolve(strict=False)
+        if resolved == root or not resolved.is_relative_to(root):
+            raise ValueError(f"{label} escapes its root: {rel}")
+    return target, snapshot
+
+
 def _copy_preserved(src: Path, dst: Path) -> None:
     if src.is_dir():
-        shutil.copytree(src, dst, dirs_exist_ok=True)
+        shutil.copytree(src, dst, dirs_exist_ok=True, symlinks=True)
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dst)
+    shutil.copy2(src, dst, follow_symlinks=False)
 
 
 def _realign_local(args: argparse.Namespace) -> int:
@@ -343,6 +382,9 @@ def _realign_local(args: argparse.Namespace) -> int:
         if args.preserve_dir
         else Path(tempfile.mkdtemp(prefix=f"{repo.name}-preserve-"))
     )
+    validated_paths = [
+        (rel, *_validate_preserve_path(repo, preserve_dir, rel)) for rel in preserve_paths
+    ]
 
     print("Local realign plan")
     print("------------------")
@@ -360,22 +402,27 @@ def _realign_local(args: argparse.Namespace) -> int:
     preserved: list[tuple[Path, Path]] = []
     preserve_dir.mkdir(parents=True, exist_ok=True)
 
-    for rel in preserve_paths:
-        target = (repo / rel).resolve()
+    for rel, target, snapshot in validated_paths:
         if not target.exists():
             print(f"skip missing preserve path: {rel}")
             continue
-        snapshot = preserve_dir / rel
+        _require_no_linked_entries(target, label=f"preserve path {rel}")
+        if snapshot.exists():
+            _require_no_linked_entries(snapshot, label=f"preserve snapshot {rel}")
         snapshot.parent.mkdir(parents=True, exist_ok=True)
         _copy_preserved(target, snapshot)
-        preserved.append((snapshot, repo / rel))
+        _require_no_linked_entries(snapshot, label=f"preserve snapshot {rel}")
+        preserved.append((snapshot, rel))
 
     if args.fetch:
         _git(repo, "fetch", args.remote_name, "--prune", "--tags")
 
     _git(repo, "reset", "--hard", args.target_ref)
 
-    for snapshot, target in preserved:
+    for snapshot, rel in preserved:
+        target, _snapshot = _validate_preserve_path(repo, preserve_dir, rel)
+        if target.exists():
+            _require_no_linked_entries(target, label=f"restore target {rel}")
         _copy_preserved(snapshot, target)
 
     if args.gc:

--- a/tools/sync_agent_skills.py
+++ b/tools/sync_agent_skills.py
@@ -27,14 +27,18 @@ SKIP_NAMES = {"README.md", ".DS_Store"}
 TOKKI_LIST_TIMEOUT_SECONDS = 120
 
 
-def reject_top_level_skill_symlinks(root: Path) -> None:
-    """Fail before external installer links can pollute repo skill roots."""
-    symlinks = sorted(path.name for path in root.iterdir() if path.is_symlink())
+def reject_skill_symlinks(root: Path) -> None:
+    """Fail before linked content can pollute repo-managed skill mirrors."""
+    symlinks = [Path(".")] if root.is_symlink() else []
+    if root.is_dir() and not root.is_symlink():
+        symlinks.extend(
+            sorted(path.relative_to(root) for path in root.rglob("*") if path.is_symlink())
+        )
     if not symlinks:
         return
     raise SystemExit(
-        f"Refusing top-level symlinked skill entries in {root}: "
-        f"{', '.join(symlinks)}. Install external skills outside the repo "
+        f"Refusing symlinked skill entries in {root}: "
+        f"{', '.join(str(path) for path in symlinks)}. Install external skills outside the repo "
         "(for Streamlit, use `streamlit skills --global`) and keep "
         "repo-managed skills as real directories."
     )
@@ -49,10 +53,8 @@ def iter_skill_dirs(root: Path) -> list[Path]:
 
 
 def iter_skill_files(skill_dir: Path) -> list[Path]:
-    # Follow directory symlinks so the check sees the same tree that
-    # sync_skill's copytree(symlinks=False) materializes into the mirror.
     files: list[Path] = []
-    for dirpath, dirnames, filenames in os.walk(skill_dir, followlinks=True):
+    for dirpath, dirnames, filenames in os.walk(skill_dir, followlinks=False):
         dirnames[:] = [name for name in dirnames if name not in SKIP_NAMES]
         for name in filenames:
             if name in SKIP_NAMES:
@@ -66,6 +68,7 @@ def _is_executable(path: Path) -> bool:
 
 
 def sync_skill(source: Path, destination_root: Path) -> Path:
+    reject_skill_symlinks(source)
     destination = destination_root / source.name
     if destination.exists():
         shutil.rmtree(destination)
@@ -73,7 +76,13 @@ def sync_skill(source: Path, destination_root: Path) -> Path:
         source,
         destination,
         ignore=shutil.ignore_patterns(*SKIP_NAMES),
+        symlinks=True,
     )
+    try:
+        reject_skill_symlinks(destination)
+    except SystemExit:
+        shutil.rmtree(destination)
+        raise
     return destination
 
 
@@ -250,7 +259,7 @@ def main(argv: list[str]) -> int:
 
     for skills_root in (CLAUDE_ROOT, PROJECT_AGENT_SKILLS_ROOT):
         if skills_root.exists() or skills_root.is_symlink():
-            reject_top_level_skill_symlinks(skills_root)
+            reject_skill_symlinks(skills_root)
     skill_dirs = iter_skill_dirs(CLAUDE_ROOT)
     if args.skills:
         selected = set(args.skills)


### PR DESCRIPTION
## Summary\n- reject included symlinks and junctions before Hugging Face release staging\n- reject linked project/evidence inputs and scan evidence for secret-like content before public export\n- reject nested links in repo-managed skills instead of materializing their targets\n- confine repo realignment preserve paths and reject linked source, snapshot, or restore trees\n- preserve expected behavior for explicitly ignored virtualenv and private-app paths\n\n## Repro\nRecursive copies used the default dereferencing behavior. The HF release guard ran only after copying, nested skill links were intentionally materialized, and preserve paths were not confined before reset-related work.\n\n## Root Cause\nThe copy boundaries validated names or staged output too late, but did not preflight every included source entry before mutation. Python copy helpers therefore followed linked targets outside the intended tree.\n\n## Regression Test\nAdded polluted-filesystem regressions covering:\n- included HF source links with an unchanged stage sentinel\n- project and evidence links with no partial public export\n- evidence secret scanning\n- nested skill links with unchanged mirrors\n- absolute, parent, root, source-link, and pre-existing snapshot-link preserve paths\n- explicitly ignored virtualenv and private-app links\n\n## Validation\n- targeted pytest slice: passed\n- Ruff check on changed files: passed with the test suite's pre-existing E402 exception\n- git diff check: passed\n- all required GitHub checks: passed, including root-tests and clean public installs\n- skills profile local checks: 33 skills validated and generated outputs unchanged\n- Tokki skill visibility check: skipped because the external protected Tokki runtime fails closed on modified protected build inputs\n\n## Merge Status\nAuto-merge is armed. Branch protection still blocks the PR because the required-signatures ruleset reports the commit signature key as unknown_key. The fingerprint matches the key registered on the authenticated owner account, but the commit identity is Codex-Agent, so GitHub cannot associate that account with the signing key. No administrative bypass was used.\n\n## Review Evidence\nNo separate reviewer model or sub-agent was used.\n\n## Agent Metadata\n- Tokki version: unavailable (protected runtime integrity gate)\n- Agent/runtime: Codex, version unavailable\n- Model: GPT-5\n- Reasoning effort: unknown\n- /fast mode: not used\n
