### PR TITLE
fix(cluster): reject linked uv source inputs

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/uv_source_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/uv_source_support.py
@@ -3,7 +3,7 @@ import os
 import posixpath
 import shutil
 from pathlib import Path, PurePosixPath
-from typing import Any, Optional, Set
+from typing import Any, Callable, Optional, Set
 
 import tomlkit
 
@@ -183,9 +183,60 @@ def rewrite_uv_sources_paths_for_copied_pyproject(
             log.info("Rewrote uv source '%s' path: %s -> %s", name, old or "<unset>", new)
 
 
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction and is_junction())
+
+
+def _require_no_linked_uv_source(
+    source_root: Path,
+    *,
+    ignore: Callable[[str, list[str]], set[str]] | None = None,
+) -> None:
+    linked: list[Path] = []
+    if _is_link_like(source_root):
+        linked.append(source_root)
+    elif source_root.is_dir():
+        for directory, dirnames, filenames in os.walk(source_root, followlinks=False):
+            names = [*dirnames, *filenames]
+            ignored = ignore(directory, names) if ignore is not None else set()
+            included_dirs = [name for name in dirnames if name not in ignored]
+            included_files = [name for name in filenames if name not in ignored]
+            directory_path = Path(directory)
+            for name in [*included_dirs, *included_files]:
+                path = directory_path / name
+                if _is_link_like(path):
+                    linked.append(path)
+            dirnames[:] = [
+                name
+                for name in included_dirs
+                if not _is_link_like(directory_path / name)
+            ]
+    if linked:
+        formatted = ", ".join(str(path) for path in sorted(linked))
+        raise ValueError(f"uv source tree contains symlinks or junctions: {formatted}")
+
+
 def copy_uv_source_tree(src_path: Path, dest_path: Path) -> None:
     """Copy a local uv source dependency into a self-contained staging area."""
-    if dest_path.exists():
+    ignore = shutil.ignore_patterns(
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        "build",
+        "dist",
+    )
+    _require_no_linked_uv_source(src_path, ignore=ignore if src_path.is_dir() else None)
+
+    if _is_link_like(dest_path):
+        if dest_path.is_dir() and not dest_path.is_symlink():
+            dest_path.rmdir()
+        else:
+            dest_path.unlink()
+    elif dest_path.exists():
         if dest_path.is_dir():
             shutil.rmtree(dest_path, ignore_errors=True)
         else:
@@ -195,18 +246,24 @@ def copy_uv_source_tree(src_path: Path, dest_path: Path) -> None:
                 pass
 
     if src_path.is_dir():
-        ignore = shutil.ignore_patterns(
-            ".venv",
-            "__pycache__",
-            ".pytest_cache",
-            ".mypy_cache",
-            "build",
-            "dist",
+        shutil.copytree(
+            src_path,
+            dest_path,
+            ignore=ignore,
+            dirs_exist_ok=True,
+            symlinks=True,
         )
-        shutil.copytree(src_path, dest_path, ignore=ignore, dirs_exist_ok=True)
     else:
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src_path, dest_path)
+        shutil.copy2(src_path, dest_path, follow_symlinks=False)
+    try:
+        _require_no_linked_uv_source(dest_path)
+    except ValueError:
+        if dest_path.is_dir() and not _is_link_like(dest_path):
+            shutil.rmtree(dest_path, ignore_errors=True)
+        elif dest_path.exists() or _is_link_like(dest_path):
+            dest_path.unlink(missing_ok=True)
+        raise
 
 
 def _stage_uv_source_dependency(

--- a/src/agilab/core/test/test_agi_distributor_uv_source_support.py
+++ b/src/agilab/core/test/test_agi_distributor_uv_source_support.py
@@ -438,6 +438,48 @@ def test_copy_uv_source_tree_replaces_existing_file_destination(tmp_path):
     assert destination.read_text(encoding="utf-8") == "VALUE = 1\n"
 
 
+def test_copy_uv_source_tree_rejects_symlink_before_destination_mutation(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "payload.txt").write_text("payload\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private payload\n", encoding="utf-8")
+    try:
+        (source / "external.txt").symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    sentinel = destination / "sentinel.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="uv source tree contains symlinks"):
+        uv_source_support.copy_uv_source_tree(source, destination)
+
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+    assert not (destination / "external.txt").exists()
+
+
+def test_copy_uv_source_tree_ignores_virtualenv_symlinks(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "payload.txt").write_text("payload\n", encoding="utf-8")
+    virtualenv = source / ".venv"
+    virtualenv.mkdir()
+    outside = tmp_path / "python"
+    outside.write_text("binary placeholder\n", encoding="utf-8")
+    try:
+        (virtualenv / "python").symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"file symlinks unavailable: {error}")
+    destination = tmp_path / "destination"
+
+    uv_source_support.copy_uv_source_tree(source, destination)
+
+    assert (destination / "payload.txt").read_text(encoding="utf-8") == "payload\n"
+    assert not (destination / ".venv").exists()
+
+
 def test_missing_uv_source_paths_reports_unresolved_entries(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     (tmp_path / "_uv_sources" / "ok").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary\n- preflight local uv source dependencies for symlinks and junctions before destination mutation\n- preserve exclusions for .venv, caches, build, and dist trees\n- copy without dereferencing links if the source changes during traversal, then fail closed and clean the staged destination\n- safely remove pre-existing linked staging destinations\n\n## Shared-Core Approval\nThe user explicitly requested "fix" after the audit named this agi-cluster file and its blast radius. That instruction is recorded as approval for this scoped shared-core change. No agi-core owner-protected path is touched.\n\n## Repro\nA local uv path dependency containing a symlink to a file outside its source root was copied with shutil.copytree's default dereferencing behavior. The existing destination was removed before this source condition could be rejected.\n\n## Root Cause\nThe staging helper filtered common generated directories but had no link-aware preflight. Recursive and file copies therefore followed linked source targets across the intended dependency boundary.\n\n## Regression Test\nThe focused regression proves:\n- an included source symlink is rejected before an existing destination sentinel is modified\n- a symlink inside an excluded .venv remains ignored and is not staged\n\n## Validation\n- focused uv source support tests: 35 passed\n- full src/agilab/core/test suite: passed\n- shared-core strict typing: passed\n- Ruff check on touched files: passed\n- staged scope and diff checks: passed\n- all required GitHub checks: passed, including root-tests and clean public installs\n\n## Merge Status\nAuto-merge is armed. Branch protection still blocks the PR because the required-signatures ruleset reports the commit signature key as unknown_key. The fingerprint matches the key registered on the authenticated owner account, but the commit identity is Codex-Agent, so GitHub cannot associate that account with the signing key. No administrative bypass was used.\n\n## Review Evidence\nNo separate reviewer model or sub-agent was used.\n\n## Agent Metadata\n- Tokki version: unavailable (protected runtime integrity gate)\n- Agent/runtime: Codex, version unavailable\n- Model: GPT-5\n- Reasoning effort: unknown\n- /fast mode: not used\n
