### PR TITLE
fix: close weekly audit boundary gaps

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -335,6 +335,7 @@ jobs:
         env:
           EXPECTED_APPS: ${{ needs.plan_ui_robot_matrix.outputs.expected_apps }}
           EXPECTED_SHARDS: ${{ needs.plan_ui_robot_matrix.outputs.expected_shards }}
+          MATRIX_RESULT: ${{ needs.ui-robot-matrix.result }}
         run: |
           if [ -z "${EXPECTED_APPS}" ] || [ -z "${EXPECTED_SHARDS}" ]; then
             echo "UI robot matrix plan outputs are missing" >&2
@@ -346,6 +347,7 @@ jobs:
             --root test-results/ui-robot-matrix-artifacts \
             --expected-shards "${EXPECTED_SHARDS}" \
             --expected-apps "${EXPECTED_APPS}" \
+            --upstream-result "${MATRIX_RESULT}" \
             --output test-results/ui-robot-matrix-aggregate/aggregate.json \
             --summary-markdown test-results/ui-robot-matrix-aggregate/summary.md \
             | tee test-results/ui-robot-matrix-aggregate/aggregate.txt

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/generator.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/generator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 from urllib.error import URLError
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from .diagnostic import CASE_SCHEMA, validate_case_payload
 
@@ -140,6 +140,27 @@ Constraints:
   TeSciA accepts student_answer later when a learner submits their response.
 - Prefer concrete AGILAB diagnostics over generic software advice.
 """
+
+
+class _LoopbackRedirectHandler(HTTPRedirectHandler):
+    """Revalidate every redirect before urllib opens the next endpoint."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> Request | None:
+        _validate_local_endpoint(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def urlopen(request: Request, *, timeout: float) -> Any:
+    """Open a validated local request while keeping redirects loopback-only."""
+    return build_opener(_LoopbackRedirectHandler()).open(request, timeout=timeout)
 
 
 def _post_json(

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/generator.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/generator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 from urllib.error import URLError
 from urllib.parse import urlsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 from .diagnostic import CASE_SCHEMA, validate_case_payload
 
@@ -160,7 +160,9 @@ class _LoopbackRedirectHandler(HTTPRedirectHandler):
 
 def urlopen(request: Request, *, timeout: float) -> Any:
     """Open a validated local request while keeping redirects loopback-only."""
-    return build_opener(_LoopbackRedirectHandler()).open(request, timeout=timeout)
+    return build_opener(ProxyHandler({}), _LoopbackRedirectHandler()).open(
+        request, timeout=timeout
+    )
 
 
 def _post_json(

--- a/src/agilab/lib/app_project_build_support.py
+++ b/src/agilab/lib/app_project_build_support.py
@@ -121,11 +121,24 @@ def app_project_spec(project_name: str) -> dict[str, str]:
     raise KeyError(project_name)
 
 
+def _is_link_like(path: Path) -> bool:
+    """Return whether ``path`` can redirect traversal outside the payload tree."""
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction is not None and is_junction())
+
+
+def _require_unlinked_tree_root(path: Path, *, label: str) -> None:
+    if _is_link_like(path):
+        raise ValueError(f"{label} must not be a symlink or junction: {path}")
+
+
 def _ignore_payload_artifacts(directory: str, names: list[str]) -> set[str]:
     ignored: set[str] = set()
     for name in names:
         path = Path(directory) / name
-        if path.is_symlink():
+        if _is_link_like(path):
             ignored.add(name)
             continue
         if path.is_dir() and (name in _EXCLUDED_PAYLOAD_DIRS or name.endswith(".egg-info")):
@@ -177,6 +190,7 @@ def copy_app_project_payload(project_name: str, target_root: Path) -> list[Path]
     source_root = repo_agilab_root() / "apps" / "builtin" / project_name
     if not source_root.exists():
         return []
+    _require_unlinked_tree_root(source_root, label="App project payload root")
     target_root.mkdir(parents=True, exist_ok=True)
     destination = target_root / project_name
     if destination.exists():
@@ -193,6 +207,7 @@ def copy_agi_apps_umbrella_payload(target_root: Path) -> None:
     apps_target_root = target_root / "agilab" / "apps"
     examples_target_root = target_root / "agilab" / "examples"
 
+    _require_unlinked_tree_root(apps_source_root, label="Apps payload root")
     apps_target_root.mkdir(parents=True, exist_ok=True)
     for file_name in ("README.md", "install.py"):
         source = apps_source_root / file_name
@@ -204,6 +219,7 @@ def copy_agi_apps_umbrella_payload(target_root: Path) -> None:
         source = apps_source_root / "builtin" / project_name
         if not source.exists():
             continue
+        _require_unlinked_tree_root(source, label=f"Built-in app payload root {project_name}")
         destination = builtin_target_root / project_name
         if destination.exists():
             shutil.rmtree(destination)
@@ -211,6 +227,7 @@ def copy_agi_apps_umbrella_payload(target_root: Path) -> None:
         _sanitize_pyprojects(destination)
 
     if examples_source_root.exists():
+        _require_unlinked_tree_root(examples_source_root, label="Examples payload root")
         if examples_target_root.exists():
             shutil.rmtree(examples_target_root)
         shutil.copytree(

--- a/src/agilab/lib/app_project_build_support.py
+++ b/src/agilab/lib/app_project_build_support.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import shutil
+import stat
 from pathlib import Path
 
 
@@ -134,6 +136,30 @@ def _require_unlinked_tree_root(path: Path, *, label: str) -> None:
         raise ValueError(f"{label} must not be a symlink or junction: {path}")
 
 
+def _copy_stable_regular_file(source: Path, destination: Path, *, label: str) -> None:
+    try:
+        path_stat = source.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise ValueError(f"{label} must be a stable regular file: {source}") from exc
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise ValueError(f"{label} must be a stable regular file: {source}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(source, flags)
+    except OSError as exc:
+        raise ValueError(f"{label} must be a stable regular file: {source}") from exc
+    with os.fdopen(descriptor, "rb") as source_handle:
+        opened_stat = os.fstat(source_handle.fileno())
+        if not stat.S_ISREG(opened_stat.st_mode) or not os.path.samestat(
+            path_stat, opened_stat
+        ):
+            raise ValueError(f"{label} changed before it could be copied: {source}")
+        with destination.open("wb") as destination_handle:
+            shutil.copyfileobj(source_handle, destination_handle)
+    destination.chmod(stat.S_IMODE(opened_stat.st_mode))
+
+
 def _ignore_payload_artifacts(directory: str, names: list[str]) -> set[str]:
     ignored: set[str] = set()
     for name in names:
@@ -212,7 +238,11 @@ def copy_agi_apps_umbrella_payload(target_root: Path) -> None:
     for file_name in ("README.md", "install.py"):
         source = apps_source_root / file_name
         if source.exists():
-            shutil.copy2(source, apps_target_root / file_name)
+            _copy_stable_regular_file(
+                source,
+                apps_target_root / file_name,
+                label="App payload file",
+            )
 
     builtin_target_root = apps_target_root / "builtin"
     for project_name in BASE_BUILTIN_TEMPLATE_PROJECTS:

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -1485,6 +1485,36 @@ def test_app_project_payload_copy_excludes_symlinks(
     assert not (payload_root / ".venv").is_symlink()
 
 
+def test_app_project_payload_copy_rejects_symlinked_root(tmp_path: Path, monkeypatch) -> None:
+    support = _load_app_project_build_support()
+    project_name = "linked_project"
+    source_agilab_root = tmp_path / "source" / "agilab"
+    project_root = source_agilab_root / "apps" / "builtin" / project_name
+    external_root = tmp_path / "external-project"
+    external_root.mkdir(parents=True)
+    (external_root / "README.md").write_text("outside payload\n", encoding="utf-8")
+    project_root.parent.mkdir(parents=True)
+    try:
+        project_root.symlink_to(external_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    monkeypatch.setattr(support, "repo_agilab_root", lambda: source_agilab_root)
+    target_root = tmp_path / "target"
+
+    with pytest.raises(ValueError, match="must not be a symlink or junction"):
+        support.copy_app_project_payload(project_name, target_root)
+
+    assert not target_root.exists()
+
+
+def test_app_project_payload_link_check_recognizes_junctions(tmp_path: Path, monkeypatch) -> None:
+    support = _load_app_project_build_support()
+    monkeypatch.setattr(Path, "is_junction", lambda self: self == tmp_path, raising=False)
+
+    assert support._is_link_like(tmp_path) is True
+
+
 def test_agi_apps_umbrella_bundles_only_the_base_minimal_app_template() -> None:
     pyproject = tomllib.loads(AGI_APPS_PYPROJECT.read_text(encoding="utf-8"))
     package_data = pyproject["tool"]["setuptools"]["package-data"]

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -1555,6 +1555,60 @@ def test_agi_apps_umbrella_copy_keeps_only_minimal_app_builtin_payload(tmp_path:
     assert not list((builtin_root / "minimal_app_project").rglob("*.c"))
 
 
+@pytest.mark.parametrize("file_name", ["README.md", "install.py"])
+def test_agi_apps_umbrella_copy_rejects_linked_root_files(
+    tmp_path: Path, monkeypatch, file_name: str
+) -> None:
+    support = _load_app_project_build_support()
+    source_agilab_root = tmp_path / "source" / "agilab"
+    apps_root = source_agilab_root / "apps"
+    apps_root.mkdir(parents=True)
+    external = tmp_path / "external.txt"
+    external.write_text("do not package\n", encoding="utf-8")
+    try:
+        (apps_root / file_name).symlink_to(external)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"file symlinks are unavailable: {exc}")
+    monkeypatch.setattr(support, "repo_agilab_root", lambda: source_agilab_root)
+
+    with pytest.raises(ValueError, match="stable regular file"):
+        support.copy_agi_apps_umbrella_payload(tmp_path / "target")
+
+    assert not (tmp_path / "target" / "agilab" / "apps" / file_name).exists()
+
+
+def test_agi_apps_umbrella_copy_rejects_source_swap_before_open(
+    tmp_path: Path, monkeypatch
+) -> None:
+    support = _load_app_project_build_support()
+    source_agilab_root = tmp_path / "source" / "agilab"
+    apps_root = source_agilab_root / "apps"
+    apps_root.mkdir(parents=True)
+    source = apps_root / "README.md"
+    source.write_text("safe payload\n", encoding="utf-8")
+    external = tmp_path / "external.txt"
+    external.write_text("do not package\n", encoding="utf-8")
+    monkeypatch.setattr(support, "repo_agilab_root", lambda: source_agilab_root)
+    real_open = support.os.open
+    swapped = False
+
+    def swap_before_open(path, flags, *args):
+        nonlocal swapped
+        if not swapped and Path(path) == source:
+            source.unlink()
+            source.symlink_to(external)
+            swapped = True
+        return real_open(path, flags, *args)
+
+    monkeypatch.setattr(support.os, "open", swap_before_open)
+
+    with pytest.raises(ValueError, match="stable regular file"):
+        support.copy_agi_apps_umbrella_payload(tmp_path / "target")
+
+    assert swapped is True
+    assert not (tmp_path / "target" / "agilab" / "apps" / "README.md").exists()
+
+
 def test_agilab_apps_init_exposes_builtin_namespace_without_stale_docstring_code() -> None:
     module_path = ROOT / "src/agilab/apps/__init__.py"
     module_name = "agilab_apps_init_contract_test"

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -567,6 +567,8 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     assert "uv --preview-features extra-build-dependencies run python tools/ui_robot_matrix_aggregate.py" in text
     assert '--expected-shards "${EXPECTED_SHARDS}"' in text
     assert '--expected-apps "${EXPECTED_APPS}"' in text
+    assert "MATRIX_RESULT: ${{ needs.ui-robot-matrix.result }}" in text
+    assert '--upstream-result "${MATRIX_RESULT}"' in text
     assert "--output test-results/ui-robot-matrix-aggregate/aggregate.json" in text
     assert "--summary-markdown test-results/ui-robot-matrix-aggregate/summary.md" in text
     assert "ui-robot-matrix-aggregate-${{ github.run_attempt }}" in text

--- a/test/test_sync_agent_skills.py
+++ b/test/test_sync_agent_skills.py
@@ -273,6 +273,25 @@ def test_nested_symlinked_skill_content_is_rejected_before_mirror_mutation(
     assert (mirror_skill / "SKILL.md").read_bytes() == mirror_before
 
 
+def test_nested_junction_backed_skill_content_is_rejected(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    skill_root = tmp_path / "alpha"
+    junction = skill_root / "junction"
+    junction.mkdir(parents=True)
+    original_is_link_like = module._is_link_like
+    monkeypatch.setattr(
+        module,
+        "_is_link_like",
+        lambda path: path == junction or original_is_link_like(path),
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match=r"Refusing symlinked skill entries.*including junctions.*junction",
+    ):
+        module.reject_skill_symlinks(skill_root)
+
+
 def test_check_mode_flags_executable_bit_drift(tmp_path, monkeypatch, capsys) -> None:
     module = _load_module()
     claude_root, codex_root = _fake_repo(module, monkeypatch, tmp_path)

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -8,7 +8,9 @@ import os
 import runpy
 import subprocess
 import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
 import tomllib
 from types import SimpleNamespace
 
@@ -709,6 +711,32 @@ def test_tescia_generator_rejects_non_loopback_endpoints(
         generator._post_json(endpoint, {"x": 1}, 1.0)
 
     assert opened == []
+
+
+def test_standalone_post_rejects_non_loopback_redirect(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(APP_SRC))
+    from tescia_diagnostic import generator
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.send_response(302)
+            self.send_header("Location", "http://192.0.2.1/blocked")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        endpoint = f"http://127.0.0.1:{server.server_port}/redirect"
+        with pytest.raises(generator.DiagnosticCaseGenerationError, match="loopback"):
+            generator._post_json(endpoint, {"x": 1}, 1.0)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 def test_tescia_app_args_reject_invalid_generation_config(monkeypatch) -> None:

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -739,6 +739,43 @@ def test_standalone_post_rejects_non_loopback_redirect(monkeypatch) -> None:
         thread.join(timeout=2)
 
 
+def test_standalone_post_bypasses_environment_proxy_for_loopback(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(APP_SRC))
+
+    from tescia_diagnostic import generator
+
+    class LocalHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", "0"))
+            self.rfile.read(length)
+            body = b'{"source": "loopback"}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), LocalHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+    monkeypatch.setenv("http_proxy", "http://127.0.0.1:9")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    try:
+        endpoint = f"http://127.0.0.1:{server.server_port}/generate"
+        assert generator._post_json(endpoint, {"prompt": "local"}, 1.0) == {
+            "source": "loopback"
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_tescia_app_args_reject_invalid_generation_config(monkeypatch) -> None:
     monkeypatch.syspath_prepend(str(APP_SRC))
 

--- a/test/test_ui_robot_matrix_aggregate.py
+++ b/test/test_ui_robot_matrix_aggregate.py
@@ -147,7 +147,7 @@ def test_build_aggregate_summarizes_all_shards(tmp_path: Path) -> None:
     for shard in ("core", "state", "quality", "layout"):
         _write_shard(tmp_path, shard)
 
-    report = module.build_aggregate(tmp_path)
+    report = module.build_aggregate(tmp_path, upstream_result="success")
     markdown = module.render_markdown(report)
 
     assert report["schema"] == module.SCHEMA
@@ -162,6 +162,18 @@ def test_build_aggregate_summarizes_all_shards(tmp_path: Path) -> None:
     assert report["summary"]["failure_artifact_retry_count"] == 0
     assert report["summary"]["trend"]["failed_page_count"] == 0
     assert "| core | PASS |" in markdown
+
+
+def test_build_aggregate_without_upstream_evidence_fails_closed(tmp_path: Path) -> None:
+    module = _load_module()
+    for shard in module.DEFAULT_EXPECTED_SHARDS:
+        _write_shard(tmp_path, shard)
+
+    report = module.build_aggregate(tmp_path)
+
+    assert report["upstream_result"] == "unknown"
+    assert report["success"] is False
+    assert module._build_parser().parse_args([]).upstream_result == "unknown"
 
 
 def test_build_aggregate_unions_partitioned_app_inventory(tmp_path: Path) -> None:
@@ -179,6 +191,7 @@ def test_build_aggregate_unions_partitioned_app_inventory(tmp_path: Path) -> Non
 
     report = module.build_aggregate(
         tmp_path,
+        upstream_result="success",
         expected_shards=("core-01", "core-02"),
         expected_apps=(
             "data_quality_gate_project",
@@ -211,6 +224,7 @@ def test_build_aggregate_fails_closed_on_malformed_shard_inventory(tmp_path: Pat
 
     report = module.build_aggregate(
         tmp_path,
+        upstream_result="success",
         expected_shards=("core-01",),
         expected_apps=("data_quality_gate_project", "flight_telemetry_project"),
     )
@@ -233,6 +247,7 @@ def test_build_aggregate_fails_when_expected_inventory_is_unproven(tmp_path: Pat
 
     report = module.build_aggregate(
         tmp_path,
+        upstream_result="success",
         expected_shards=("core-01", "state-01"),
         expected_apps=("data_quality_gate_project", "flight_telemetry_project"),
     )
@@ -251,7 +266,7 @@ def test_build_aggregate_includes_extra_shards_after_expected_shards(tmp_path: P
     for shard in ("core", "state", "quality", "layout", "experimental"):
         _write_shard(tmp_path, shard)
 
-    report = module.build_aggregate(tmp_path)
+    report = module.build_aggregate(tmp_path, upstream_result="success")
 
     assert report["success"] is True
     assert report["extra_shards"] == ["experimental"]
@@ -290,7 +305,9 @@ def test_build_aggregate_uses_shard_manifest_discovery(tmp_path: Path, monkeypat
         raise AssertionError(f"legacy summary discovery should not run for {root}")
 
     monkeypatch.setattr(module, "discover_shard_summary_paths", fail_summary_discovery)
-    report = module.build_aggregate(tmp_path, expected_shards=("core",))
+    report = module.build_aggregate(
+        tmp_path, expected_shards=("core",), upstream_result="success"
+    )
 
     assert manifest["schema"] == module.SHARD_MANIFEST_SCHEMA
     assert manifest["screenshot_count"] == 1
@@ -317,7 +334,9 @@ def test_manifest_discovery_reports_shard_with_missing_summary_as_failed(tmp_pat
         raise AssertionError(f"legacy summary discovery should not run for {root}")
 
     monkeypatch.setattr(module, "discover_shard_summary_paths", fail_summary_discovery)
-    report = module.build_aggregate(tmp_path, expected_shards=("core",))
+    report = module.build_aggregate(
+        tmp_path, expected_shards=("core",), upstream_result="success"
+    )
 
     assert report["success"] is False
     assert report["failed_shards"] == ["core"]
@@ -331,7 +350,7 @@ def test_build_aggregate_reports_missing_and_failed_shards(tmp_path: Path) -> No
     _write_shard(tmp_path, "core")
     _write_shard(tmp_path, "state", success=False, failed_count=1, exit_code="1", retry_artifacts=True)
 
-    report = module.build_aggregate(tmp_path)
+    report = module.build_aggregate(tmp_path, upstream_result="success")
 
     assert report["success"] is False
     assert report["missing_shards"] == ["quality", "layout"]
@@ -360,7 +379,7 @@ def test_build_aggregate_marks_missing_trend_or_nonzero_exit_as_failed(tmp_path:
     _write_shard(tmp_path, "quality")
     _write_shard(tmp_path, "layout")
 
-    report = module.build_aggregate(tmp_path)
+    report = module.build_aggregate(tmp_path, upstream_result="success")
 
     assert report["success"] is False
     assert report["failed_shards"] == ["core", "state"]
@@ -517,7 +536,9 @@ def test_render_markdown_includes_failure_replay_command(tmp_path: Path) -> None
     _write_shard(tmp_path, "quality")
     _write_shard(tmp_path, "layout")
 
-    markdown = module.render_markdown(module.build_aggregate(tmp_path))
+    markdown = module.render_markdown(
+        module.build_aggregate(tmp_path, upstream_result="success")
+    )
 
     assert "Bundle: `" in markdown
     assert (
@@ -615,7 +636,9 @@ def test_render_markdown_reports_missing_shards_and_empty_samples(tmp_path: Path
     module = _load_module()
     _write_shard(tmp_path, "core")
 
-    markdown = module.render_markdown(module.build_aggregate(tmp_path))
+    markdown = module.render_markdown(
+        module.build_aggregate(tmp_path, upstream_result="success")
+    )
 
     assert "### Missing Shards" in markdown
     assert "`state`" in markdown
@@ -637,6 +660,8 @@ def test_main_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
             str(output),
             "--summary-markdown",
             str(markdown),
+            "--upstream-result",
+            "success",
             "--compact",
         ]
     )
@@ -726,6 +751,8 @@ def test_module_entrypoint_writes_compact_aggregate(tmp_path: Path, monkeypatch,
             str(tmp_path / "artifacts"),
             "--expected-shards",
             "core",
+            "--upstream-result",
+            "success",
             "--output",
             str(output),
             "--compact",

--- a/test/test_ui_robot_matrix_aggregate.py
+++ b/test/test_ui_robot_matrix_aggregate.py
@@ -419,6 +419,18 @@ def test_discovery_prefers_latest_rerun_attempt_per_shard(tmp_path: Path) -> Non
     assert manifests["quality"][0] == quality_retry / module.SHARD_MANIFEST_FILENAME
 
 
+def test_aggregate_fails_when_current_matrix_failed_despite_complete_artifacts(tmp_path: Path) -> None:
+    module = _load_module()
+    for shard in module.DEFAULT_EXPECTED_SHARDS:
+        _write_shard(tmp_path, shard)
+
+    report = module.build_aggregate(tmp_path, upstream_result="failure")
+
+    assert report["upstream_result"] == "failure"
+    assert report["success"] is False
+    assert "Upstream matrix: `failure`" in module.render_markdown(report)
+
+
 def test_discovery_helpers_ignore_invalid_inputs(tmp_path: Path) -> None:
     module = _load_module()
     bad_manifest = tmp_path / "bad" / "manifest.json"

--- a/tools/sync_agent_skills.py
+++ b/tools/sync_agent_skills.py
@@ -27,18 +27,31 @@ SKIP_NAMES = {"README.md", ".DS_Store"}
 TOKKI_LIST_TIMEOUT_SECONDS = 120
 
 
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction is not None and is_junction())
+
+
 def reject_skill_symlinks(root: Path) -> None:
     """Fail before linked content can pollute repo-managed skill mirrors."""
-    symlinks = [Path(".")] if root.is_symlink() else []
-    if root.is_dir() and not root.is_symlink():
-        symlinks.extend(
-            sorted(path.relative_to(root) for path in root.rglob("*") if path.is_symlink())
-        )
-    if not symlinks:
+    linked_paths = [Path(".")] if _is_link_like(root) else []
+    if root.is_dir() and not linked_paths:
+        for directory, dirnames, filenames in os.walk(root, followlinks=False):
+            dirnames.sort()
+            filenames.sort()
+            directory_path = Path(directory)
+            for name in (*dirnames, *filenames):
+                path = directory_path / name
+                if _is_link_like(path):
+                    linked_paths.append(path.relative_to(root))
+            dirnames[:] = [name for name in dirnames if not _is_link_like(directory_path / name)]
+    if not linked_paths:
         return
     raise SystemExit(
-        f"Refusing symlinked skill entries in {root}: "
-        f"{', '.join(str(path) for path in symlinks)}. Install external skills outside the repo "
+        f"Refusing symlinked skill entries in {root} (including junctions): "
+        f"{', '.join(str(path) for path in sorted(linked_paths))}. Install external skills outside the repo "
         "(for Streamlit, use `streamlit skills --global`) and keep "
         "repo-managed skills as real directories."
     )

--- a/tools/ui_robot_matrix_aggregate.py
+++ b/tools/ui_robot_matrix_aggregate.py
@@ -434,8 +434,10 @@ def build_aggregate(
     *,
     expected_shards: Sequence[str] = DEFAULT_EXPECTED_SHARDS,
     expected_apps: Sequence[str] = (),
+    upstream_result: str = "success",
 ) -> dict[str, Any]:
     root = root.resolve(strict=False)
+    upstream_result = str(upstream_result).strip().lower() or "unknown"
     expected_app_inventory = sorted(
         set(str(app).strip() for app in expected_apps if str(app).strip())
     )
@@ -527,7 +529,8 @@ def build_aggregate(
         float(trend["total_duration_seconds"]) / max(1, int(trend["page_count"]))
     )
     success = (
-        bool(shards)
+        upstream_result == "success"
+        and bool(shards)
         and not missing_shards
         and not failed_shards
         and bool(trend["success"])
@@ -560,6 +563,7 @@ def build_aggregate(
         "schema": SCHEMA,
         "generated_at": utc_now_iso(),
         "success": success,
+        "upstream_result": upstream_result,
         "root": root.as_posix(),
         "expected_shards": list(expected_shards),
         "expected_apps": expected_app_inventory,
@@ -592,6 +596,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "## UI robot matrix aggregate",
         "",
         f"- Status: `{status}`",
+        f"- Upstream matrix: `{report.get('upstream_result', 'unknown')}`",
         f"- Shards: `{summary.get('shard_count', 0)}/{summary.get('expected_shard_count', 0)}`",
         f"- Apps: `{summary.get('app_count', 0)}`",
         f"- Pages: `{summary.get('page_count', 0)}`",
@@ -687,6 +692,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--expected-shards", default=",".join(DEFAULT_EXPECTED_SHARDS))
     parser.add_argument("--expected-apps", default="")
+    parser.add_argument("--upstream-result", default="success")
     parser.add_argument(
         "--output",
         type=Path,
@@ -723,6 +729,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.root,
         expected_shards=_parse_expected_shards(args.expected_shards),
         expected_apps=_parse_expected_apps(args.expected_apps),
+        upstream_result=args.upstream_result,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(

--- a/tools/ui_robot_matrix_aggregate.py
+++ b/tools/ui_robot_matrix_aggregate.py
@@ -434,7 +434,7 @@ def build_aggregate(
     *,
     expected_shards: Sequence[str] = DEFAULT_EXPECTED_SHARDS,
     expected_apps: Sequence[str] = (),
-    upstream_result: str = "success",
+    upstream_result: str = "unknown",
 ) -> dict[str, Any]:
     root = root.resolve(strict=False)
     upstream_result = str(upstream_result).strip().lower() or "unknown"
@@ -692,7 +692,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--expected-shards", default=",".join(DEFAULT_EXPECTED_SHARDS))
     parser.add_argument("--expected-apps", default="")
-    parser.add_argument("--upstream-result", default="success")
+    parser.add_argument("--upstream-result", default="unknown")
     parser.add_argument(
         "--output",
         type=Path,


### PR DESCRIPTION
## Summary

- Reject symlinked or junction-backed recursive app payload roots and skill entries before traversal.
- Revalidate every standalone AI redirect so a loopback URL cannot redirect to a non-loopback host.
- Make UI robot aggregate success depend on the current matrix job result, preventing stale successful artifacts from masking a failed rerun.

## Repro

- A built-in app project root symlink was followed by the payload copy, copying external content.
- A validated loopback standalone AI URL could return a redirect that urllib followed to a non-loopback endpoint.
- The aggregate downloaded artifacts across run attempts and could report success from an older shard when the current rerun failed before uploading its replacement.

## Root Cause

- Recursive copy guards inspected descendants but not each copy root, and link detection did not include Windows junctions.
- Endpoint validation ran only before the initial request; the default urllib redirect handler did not revalidate redirect targets.
- Aggregate success was derived only from discovered artifacts and did not incorporate needs.ui-robot-matrix.result.

## Regression Test

- Added root-symlink rejection and simulated junction classification coverage for app payloads.
- Added nested junction traversal rejection coverage for skill synchronization.
- Added a live loopback HTTP redirect regression that targets a non-loopback address and is rejected before follow-up.
- Added aggregate and workflow assertions proving a failed current matrix result cannot be reported as success even when complete prior artifacts exist.

## Validation

- Focused and affected-contract pytest slice passed.
- Ruff checks passed for all touched Python files.
- ./dev app-contracts passed.
- Skills workflow parity passed.
- ./dev scope --staged, impact validation, commit provenance, and pre-push guards passed.
- Real Windows junction creation was not available on this macOS host; the regression simulates Path.is_junction while production calls that API directly.

## Review Evidence

- Reviewer: Codex, same-agent implementation review.
- Result: all three weekly-audit findings addressed; no unresolved code findings.
- Sub-agents: not used.
- Files edited by reviewer: yes, as implementing agent.

## Agent Metadata

- Tokki version: 1.0.63
- Agent/runtime: Codex CLI 0.153.2
- Model name: unknown
- Reasoning effort: unknown
- /fast mode: not used

## Follow-up Hardening and Final Validation

- Follow-up commit b3874475 disables environment proxy routing for loopback AI calls, reuses the stable regular-file payload guard, and makes missing upstream aggregate evidence fail closed.
- Targeted pytest: 177 passed.
- Ruff, app contracts, and agi-gui workflow parity passed.
- The impact-selected built-in app runner was not applicable because tescia_diagnostic_project is not a registered app-local target; the central TeSciA test suite passed.
- GitHub CI: all seven required checks passed on head b3874475c9d3ea8ce33bb28c477f4e9f6ad306a8.
- Concurrent review evidence: AGILAB Codex Agent (model unknown) edited and committed the follow-up hardening; the current Codex session reviewed and validated the resulting snapshot.