### PR TITLE
chore(badges): refresh GitHub activity signal

### DIFF
--- a/badges/commit-activity.svg
+++ b/badges/commit-activity.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="174" height="20" role="img" aria-label="commit activity: 6/month">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="commit activity: 14/month">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="174" height="20" rx="3" fill="#fff"/>
+  <rect width="181" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="115" height="20" fill="#555"/>
-  <rect x="115" width="59" height="20" fill="#007ec6"/>
-  <rect width="174" height="20" fill="url(#b)"/>
+  <rect x="115" width="66" height="20" fill="#007ec6"/>
+  <rect width="181" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">commit activity</text>
   <text x="57.5" y="14">commit activity</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">6/month</text>
-  <text x="144.5" y="14">6/month</text>
+  <text x="148.0" y="15" fill="#010101" fill-opacity=".3">14/month</text>
+  <text x="148.0" y="14">14/month</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary

- refresh the GitHub commit-activity badge from the live repository signal
- update the displayed value from `6/month` to `14/month`
- preserve the current stars badge unchanged

## Maintenance Evidence

- Before: `./dev maintenance` reported stat badge drift, with 10 pass, 3 warn, 0 fail.
- After: strict stat badge check reports no drift; `./dev maintenance` reports 11 pass, 2 warn, 0 fail.
- Focused tests for the stat badge generator and maintenance dashboard passed.
- Staged impact classification: low risk, one changed file.
- Coverage badge generation: not applicable; this PR changes a repository-stat badge, not coverage data.

- GitHub CI: 8 checks succeeded; public-demo-smoke was skipped by workflow design because it runs only for scheduled or manual dispatches, not pull requests.

## Review Evidence

- Reviewer: Codex CLI 0.153.2, GPT-5
- Result: self-review completed; no findings
- Findings addressed: not applicable
- Sub-agents: none

## Agent Metadata

- Tokki version: 1.0.63
- Agent/runtime: Codex CLI 0.153.2
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used

