### PR TITLE
fix: validate UI binds and normalize proof paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ Use this runbook whenever you:
 - **uv everywhere**: Invoke Python entry points through `uv` (`uv --preview-features extra-build-dependencies run python …`,
   `uv --preview-features extra-build-dependencies run --extra ui streamlit …` for source UI launches) so dependencies resolve inside the managed environments that
   ship with AGILab.
+- **Direct Streamlit binds**: Pass `--server.address=127.0.0.1` for local source
+  launches. An unset Streamlit address binds all interfaces; runtime guards must
+  inspect the effective Streamlit configuration, including CLI overrides, rather
+  than treating `AGILAB_UI_HOST` or environment preferences as the actual bind.
 - **Command speed policy**: Use raw `rg`, `sed`, and small file reads for cheap local inspection where wrapper startup would dominate. Use `tokki run -- ...` for Git writes, pushes, merges, tests, builds, installs, network operations, long logs, slow/noisy commands, and any state-changing or policy-sensitive command.
 - **High-frequency command shortcuts**: Use `./dev <shortcut>` for repeated
   local validation loops and `./dev --print-only <shortcut>` when you need the

--- a/src/agilab/evidence/first_proof_cli.py
+++ b/src/agilab/evidence/first_proof_cli.py
@@ -214,9 +214,11 @@ def default_manifest_path(active_app: Path) -> Path:
 
 
 def resolve_manifest_path(active_app: Path, manifest_out: str | None) -> Path:
-    if manifest_out:
-        return Path(manifest_out).expanduser()
-    return default_manifest_path(active_app)
+    destination = (
+        Path(manifest_out) if manifest_out else default_manifest_path(active_app)
+    )
+    # Artifact paths are collected from this directory and must not depend on cwd.
+    return destination.expanduser().resolve(strict=False)
 
 
 def _apps_path_for_active_app(active_app: Path) -> Path:

--- a/src/agilab/security/ui_public_bind_guard.py
+++ b/src/agilab/security/ui_public_bind_guard.py
@@ -18,6 +18,10 @@ PUBLIC_BIND_CONTROL_ENVS = (
     "AGILAB_TLS_TERMINATED",
     "STREAMLIT_AUTH_REQUIRED",
 )
+_UNAVAILABLE_CONFIG_MESSAGE = (
+    "AGILAB cannot determine the active Streamlit server.address. "
+    "Restart with a supported Streamlit runtime and an explicit --server.address."
+)
 
 
 class PublicBindPolicyError(RuntimeError):
@@ -33,20 +37,24 @@ def configured_streamlit_host(
     *,
     streamlit_config_getter: Callable[[str], object] | None = None,
 ) -> str:
-    env = environ or os.environ
+    """Select a launch address, or inspect the effective address of a running UI."""
+    if streamlit_config_getter is not None:
+        try:
+            config_host = streamlit_config_getter("server.address")
+        except Exception:
+            raise PublicBindPolicyError(_UNAVAILABLE_CONFIG_MESSAGE) from None
+        # Streamlit binds all interfaces when server.address is unset. Its
+        # effective configuration already includes CLI overrides of env values.
+        runtime_host = "" if config_host is None else str(config_host).strip()
+        return runtime_host or "0.0.0.0"
+
+    # The launcher explicitly passes this selected address to Streamlit.
+    env = os.environ if environ is None else environ
     env_host = str(
         env.get("AGILAB_UI_HOST") or env.get("STREAMLIT_SERVER_ADDRESS") or ""
     ).strip()
     if env_host:
         return env_host
-
-    if streamlit_config_getter is not None:
-        try:
-            config_host = streamlit_config_getter("server.address")
-        except Exception:
-            config_host = None
-        if config_host is not None and str(config_host).strip():
-            return str(config_host).strip()
 
     return DEFAULT_STREAMLIT_HOST
 
@@ -68,7 +76,7 @@ def host_is_exposed(host: str) -> bool:
 
 
 def public_bind_has_controls(environ: Mapping[str, str] | None = None) -> bool:
-    env = environ or os.environ
+    env = os.environ if environ is None else environ
     return truthy(env.get(PUBLIC_BIND_OK_ENV)) and any(
         truthy(env.get(name)) for name in PUBLIC_BIND_CONTROL_ENVS
     )
@@ -77,7 +85,7 @@ def public_bind_has_controls(environ: Mapping[str, str] | None = None) -> bool:
 def public_bind_error_message(host: str) -> str:
     return (
         f"AGILAB refuses to bind the Streamlit UI on non-loopback host {host!r} without explicit protection. "
-        "Use the default 127.0.0.1 bind, or set AGILAB_PUBLIC_BIND_OK=1 together with "
+        "Launch with --server.address=127.0.0.1, or set AGILAB_PUBLIC_BIND_OK=1 together with "
         "an auth/TLS indicator such as AGILAB_TLS_TERMINATED=1. These flags are operator "
         "attestations, not proof: AGILAB does not verify that authentication or TLS is "
         "actually in place. For shared/public deployments, also archive "
@@ -124,6 +132,8 @@ def enforce_public_bind_policy_or_stop(
     if streamlit_config_getter is None:
         streamlit_config_getter = streamlit_config_getter_from_module(streamlit_module)
     try:
+        if streamlit_config_getter is None:
+            raise PublicBindPolicyError(_UNAVAILABLE_CONFIG_MESSAGE)
         return enforce_public_bind_policy(
             environ,
             streamlit_config_getter=streamlit_config_getter,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -214,7 +214,19 @@ def create_temp_app_project(tmp_path):
 
 
 @pytest.fixture
-def run_page_app_test(monkeypatch, tmp_path):
+def streamlit_loopback_config(monkeypatch):
+    """Give in-memory AppTests an explicit bind config without opening a server."""
+    from copy import copy
+    from streamlit import config
+
+    options = config.get_config_options()
+    monkeypatch.setitem(options, "server.address", copy(options["server.address"]))
+    config.set_option("server.address", "127.0.0.1")
+    return config
+
+
+@pytest.fixture
+def run_page_app_test(monkeypatch, tmp_path, streamlit_loopback_config):
     """Run a Streamlit page AppTest with a temporary active app and isolated shares."""
 
     def _run(page_path: str, project_dir: Path, export_root: Path | None = None, timeout: int = 20) -> AppTest:

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -21,6 +21,8 @@ import pytest
 import psutil
 
 
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
+
 MODULE_PATH = Path("src/agilab/pages/4_ANALYSIS.py")
 STATE_MODULE_PATH = Path("src/agilab/analysis_page_state.py")
 

--- a/test/test_first_launch_robot.py
+++ b/test/test_first_launch_robot.py
@@ -7,6 +7,10 @@ import sys
 from pathlib import Path
 import types
 
+import pytest
+from streamlit import config
+from streamlit.testing.v1.util import patch_config_options
+
 
 MODULE_PATH = Path("tools/first_launch_robot.py").resolve()
 
@@ -61,6 +65,19 @@ def test_first_launch_robot_passes_static_first_surface(tmp_path: Path) -> None:
     assert persisted["status"] == "pass", json.dumps(
         persisted, indent=2, sort_keys=True
     )
+
+
+@pytest.mark.parametrize("address", [None, "0.0.0.0", "::"])
+def test_first_launch_robot_isolates_and_restores_bind_config(address) -> None:
+    module = _load_module()
+    original_argv = list(sys.argv)
+
+    with patch_config_options({"server.address": address}):
+        report = module.build_report(target_seconds=90.0, timeout=90.0)
+        assert config.get_option("server.address") == address
+
+    assert sys.argv == original_argv
+    assert report["status"] == "pass", json.dumps(report, indent=2, sort_keys=True)
 
 
 def test_first_launch_robot_helpers_cover_empty_values_and_docs_import_failure(

--- a/test/test_first_proof_cli.py
+++ b/test/test_first_proof_cli.py
@@ -532,6 +532,70 @@ def test_main_human_success_reports_manifest_and_next_steps(monkeypatch, tmp_pat
     assert manifest_path.is_file()
 
 
+@pytest.mark.parametrize("destination", ["manifest-option", "relative-log-root"])
+def test_main_relative_manifest_destination_produces_verifiable_artifacts(
+    monkeypatch, tmp_path: Path, capsys, destination: str
+) -> None:
+    from agilab.evidence import evidence_contract
+
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    active_app = tmp_path / module.FIRST_PROOF_PROJECT
+    active_app.mkdir()
+    (active_app / "pyproject.toml").write_text(
+        "[project]\nname = 'flight-telemetry'\n", encoding="utf-8"
+    )
+    argv = ["--active-app", str(active_app), "--json"]
+    if destination == "manifest-option":
+        relative_manifest = Path("reports") / "run_manifest.json"
+        argv.extend(["--manifest-out", str(relative_manifest)])
+    else:
+        monkeypatch.setenv("AGILAB_LOG_ABS", "relative-log")
+        relative_manifest = (
+            Path("relative-log") / "execute" / "flight_telemetry" / "run_manifest.json"
+        )
+    manifest_path = tmp_path / relative_manifest
+    artifact_path = manifest_path.parent / "metrics.json"
+
+    def fake_run_proof(commands):
+        artifact_path.parent.mkdir(parents=True)
+        artifact_path.write_text('{"accuracy": 1.0}\n', encoding="utf-8")
+        return [
+            module.ProofStepResult(
+                label=command.label,
+                description=command.description,
+                argv=list(command.argv),
+                returncode=0,
+                duration_seconds=0.5,
+                stdout="",
+                env=command.env,
+            )
+            for command in commands
+        ]
+
+    monkeypatch.setattr(module, "run_proof", fake_run_proof)
+    monkeypatch.setattr(module, "write_agilab_path_marker", lambda: None)
+    monkeypatch.setattr(
+        evidence_contract.shutil, "which", lambda _executable: sys.executable
+    )
+
+    assert module.main(argv) == 0
+    payload = json.loads(capsys.readouterr().out)
+    other_directory = tmp_path / "elsewhere"
+    other_directory.mkdir()
+    monkeypatch.chdir(other_directory)
+    verification = evidence_contract.verify_manifest(manifest_path)
+
+    assert verification["status"] == "pass", verification
+    assert payload["run_manifest_path"] == str(manifest_path)
+    manifest = module.run_manifest.load_run_manifest(manifest_path)
+    assert {Path(artifact.path) for artifact in manifest.artifacts} == {
+        manifest_path,
+        artifact_path,
+    }
+
+
 def test_run_proof_stops_on_first_failure() -> None:
     module = _load_module()
     commands = module.build_proof_commands(module.default_active_app(), with_install=True, with_ui=True)

--- a/test/test_orchestrate_distribution.py
+++ b/test/test_orchestrate_distribution.py
@@ -422,7 +422,7 @@ def test_orchestrate_distribution_import_fallback_sets_networkx_error():
     assert "agilab[ui]" in warnings[0]
 
 
-def test_orchestrate_page_import_survives_missing_networkx():
+def test_orchestrate_page_import_survives_missing_networkx(streamlit_loopback_config):
     module_name = "agilab_page_orchestrate_missing_networkx"
     module_path = Path("src/agilab/pages/2_ORCHESTRATE.py")
     original_import = __import__

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -18,6 +18,8 @@ import pytest
 from streamlit.errors import StreamlitAPIException
 from streamlit.testing.v1 import AppTest
 
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/test/test_pipeline_page_helpers.py
+++ b/test/test_pipeline_page_helpers.py
@@ -11,6 +11,9 @@ import pytest
 from streamlit.errors import StreamlitAPIException
 
 
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
+
+
 class _SessionState(dict):
     def __getattr__(self, name: str):
         try:

--- a/test/test_pipeline_service_guard.py
+++ b/test/test_pipeline_service_guard.py
@@ -7,6 +7,10 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
+
 
 def _ensure_agilab_package_path() -> None:
     src_path = str(Path("src").resolve())

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -14,6 +14,8 @@ import pytest
 from pathspec.gitignore import GitIgnoreSpec
 
 
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
+
 MODULE_PATH = Path("src/agilab/pages/PROJECT_EDITOR.py")
 SAMPLE_HELPER_PATH = Path("src/agilab/notebook_import_sample.py")
 BUILTIN_APPS_ROOT = Path("src/agilab/apps/builtin")

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -27,6 +27,7 @@ APP_ARGS_FORM = "src/agilab/apps/builtin/flight_telemetry_project/src/app_args_f
 DEFAULT_APPTEST_TIMEOUT = 20
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ENV_TEMPLATE_PATH = Path("src/agilab/core/agi-env/src/agi_env/resources/.agilab/.env")
+pytestmark = pytest.mark.usefixtures("streamlit_loopback_config")
 
 
 def _import_agilab_module(module_name: str):
@@ -1037,7 +1038,14 @@ def test_agilab_warm_query_cluster_failure_keeps_old_env_until_recovery(
     assert remembered_apps[-1] == target_project.resolve()
 
 
-def test_agilab_main_page_refuses_unprotected_public_bind(mock_ui_env):
+@pytest.mark.parametrize(
+    ("actual_host", "env_host"),
+    [("0.0.0.0", ""), (None, ""), ("0.0.0.0", "127.0.0.1"), (None, "127.0.0.1")],
+)
+def test_agilab_main_page_refuses_unprotected_public_bind(
+    mock_ui_env, streamlit_loopback_config, actual_host, env_host
+):
+    streamlit_loopback_config.set_option("server.address", actual_host)
     home_root = mock_ui_env["apps_dir"].parent
     at = _app_test("src/agilab/main_page.py")
 
@@ -1045,7 +1053,8 @@ def test_agilab_main_page_refuses_unprotected_public_bind(mock_ui_env):
         os.environ,
         {
             "HOME": str(home_root),
-            "STREAMLIT_SERVER_ADDRESS": "0.0.0.0",
+            "AGILAB_UI_HOST": env_host,
+            "STREAMLIT_SERVER_ADDRESS": env_host,
             "AGILAB_PUBLIC_BIND_OK": "",
             "AGILAB_TLS_TERMINATED": "",
         },

--- a/test/test_ui_public_bind_guard.py
+++ b/test/test_ui_public_bind_guard.py
@@ -35,29 +35,70 @@ def test_configured_streamlit_host_reads_direct_streamlit_config_when_env_is_emp
     )
 
 
-def test_configured_streamlit_host_uses_streamlit_address_env_and_ignores_broken_config():
+def test_configured_streamlit_host_uses_streamlit_address_env_for_launch():
     assert (
         configured_streamlit_host({"STREAMLIT_SERVER_ADDRESS": " 0.0.0.0 "})
         == "0.0.0.0"
     )
 
-    def _broken_config(_key: str):
-        raise RuntimeError("streamlit config unavailable")
 
+@pytest.mark.parametrize("env_key", ["AGILAB_UI_HOST", "STREAMLIT_SERVER_ADDRESS"])
+def test_effective_streamlit_config_takes_precedence_over_env_host(env_key):
     assert (
-        configured_streamlit_host({}, streamlit_config_getter=_broken_config)
-        == DEFAULT_STREAMLIT_HOST
+        configured_streamlit_host(
+            {env_key: "127.0.0.1"},
+            streamlit_config_getter=lambda key: "0.0.0.0",
+        )
+        == "0.0.0.0"
+    )
+    with pytest.raises(PublicBindPolicyError, match="0.0.0.0"):
+        enforce_public_bind_policy(
+            {env_key: "127.0.0.1"}, streamlit_config_getter=lambda key: "0.0.0.0"
+        )
+
+
+@pytest.mark.parametrize("host", [None, "", "  "])
+def test_unset_effective_streamlit_address_requires_public_controls(host):
+    with pytest.raises(PublicBindPolicyError, match="0.0.0.0"):
+        enforce_public_bind_policy({}, streamlit_config_getter=lambda key: host)
+    assert (
+        enforce_public_bind_policy(
+            {"AGILAB_PUBLIC_BIND_OK": "1", "AGILAB_TLS_TERMINATED": "1"},
+            streamlit_config_getter=lambda key: host,
+        )
+        == "0.0.0.0"
     )
 
 
-def test_env_host_takes_precedence_over_streamlit_config():
+def test_effective_streamlit_loopback_overrides_public_launch_preference():
     assert (
-        configured_streamlit_host(
-            {"AGILAB_UI_HOST": "127.0.0.1"},
-            streamlit_config_getter=lambda key: "0.0.0.0",
+        enforce_public_bind_policy(
+            {"AGILAB_UI_HOST": "0.0.0.0"},
+            streamlit_config_getter=lambda key: "127.0.0.1",
         )
         == "127.0.0.1"
     )
+
+
+def test_runtime_config_unavailable_fails_closed():
+    def broken_config(_key: str):
+        raise RuntimeError("private configuration detail")
+
+    with pytest.raises(PublicBindPolicyError, match="server.address") as caught:
+        enforce_public_bind_policy(
+            {"AGILAB_UI_HOST": "127.0.0.1"}, streamlit_config_getter=broken_config
+        )
+    assert "private configuration detail" not in str(caught.value)
+
+
+def test_explicit_empty_environment_ignores_inherited_bind_and_controls(monkeypatch):
+    monkeypatch.setenv("AGILAB_UI_HOST", "0.0.0.0")
+    monkeypatch.setenv("AGILAB_PUBLIC_BIND_OK", "1")
+    monkeypatch.setenv("AGILAB_TLS_TERMINATED", "1")
+    assert configured_streamlit_host({}) == DEFAULT_STREAMLIT_HOST
+    assert not public_bind_has_controls({})
+    with pytest.raises(PublicBindPolicyError):
+        enforce_public_bind_policy({}, streamlit_config_getter=lambda key: "0.0.0.0")
 
 
 def test_public_bind_requires_explicit_ok_and_auth_or_tls_indicator():
@@ -83,7 +124,9 @@ def test_non_loopback_interface_binds_are_refused_without_controls(host):
         enforce_public_bind_policy({"AGILAB_UI_HOST": host})
 
 
-@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.1.1", "::1", "[::1]", "localhost"])
+@pytest.mark.parametrize(
+    "host", ["127.0.0.1", "127.0.1.1", "::1", "[::1]", "localhost"]
+)
 def test_loopback_binds_never_require_controls(host):
     assert enforce_public_bind_policy({"AGILAB_UI_HOST": host}) == host
 
@@ -135,23 +178,33 @@ def test_public_bind_guard_or_stop_reports_error_before_stopping():
     assert FakeStreamlit.stopped is True
 
 
-def test_public_bind_guard_or_stop_uses_streamlit_get_option_when_available():
+@pytest.mark.parametrize("actual_host", [None, "0.0.0.0"])
+def test_public_bind_guard_or_stop_uses_streamlit_get_option_when_available(
+    actual_host,
+):
     class FakeStreamlit:
         stopped = False
 
         @staticmethod
-        def get_option(key: str) -> str:
+        def get_option(key: str) -> str | None:
             assert key == "server.address"
-            return "0.0.0.0"
+            return actual_host
 
         @classmethod
         def stop(cls) -> None:
             cls.stopped = True
 
     with pytest.raises(PublicBindPolicyError, match="0.0.0.0"):
-        enforce_public_bind_policy_or_stop(FakeStreamlit, {})
+        enforce_public_bind_policy_or_stop(
+            FakeStreamlit, {"AGILAB_UI_HOST": "127.0.0.1"}
+        )
 
     assert FakeStreamlit.stopped is True
+
+
+def test_direct_entrypoint_without_config_getter_fails_closed():
+    with pytest.raises(PublicBindPolicyError, match="server.address"):
+        enforce_public_bind_policy_or_stop(object(), {"AGILAB_UI_HOST": "127.0.0.1"})
 
 
 def test_streamlit_config_getter_prefers_get_option_over_legacy_config_get():

--- a/tools/first_launch_robot.py
+++ b/tools/first_launch_robot.py
@@ -157,6 +157,7 @@ def build_report(
 ) -> dict[str, Any]:
     _suppress_streamlit_bare_mode_log_warning()
     from streamlit.testing.v1 import AppTest
+    from streamlit.testing.v1.util import patch_config_options
 
     start = time.perf_counter()
     previous_argv = list(sys.argv)
@@ -168,8 +169,11 @@ def build_report(
         str(apps_path),
     ]
     try:
-        app = AppTest.from_file(str(about_page), default_timeout=timeout)
-        app.run(timeout=timeout)
+        # AppTest opens no server. Model the documented local launch without
+        # inheriting a wildcard bind or changing the caller's configuration.
+        with patch_config_options({"server.address": "127.0.0.1"}):
+            app = AppTest.from_file(str(about_page), default_timeout=timeout)
+            app.run(timeout=timeout)
     finally:
         sys.argv = previous_argv
 


### PR DESCRIPTION
## Summary

- Validate direct Streamlit sessions against the effective runtime bind configuration, and fail closed when that configuration cannot be read. Keep launcher defaults explicitly loopback-bound.
- Normalize first-proof manifest destinations before deriving artifact paths so relative output locations remain verifiable from another working directory.
- Add polluted-environment regressions, isolate AppTest and import-only page-test bind configuration, and document the explicit direct-launch loopback flag in `AGENTS.md`; adjacent existing guidance is preserved.

## Scope and authorization

The maintainer requested the two audit fixes and subsequently authorized release and publication. This PR covers the shared UI security helper, first-proof producer, their tests, launch guidance, and the first-launch robot configuration required to validate the guard. Release metadata is prepared separately.

## Repro

The focused guard regressions failed against the audited base (11 failures), as did both producer-to-verifier regressions for relative manifest output (2 failures). These tests now pass. Diagnostic logs and browser artifacts remain local; no sensitive configuration or standalone exposure demonstration is published.

CI follow-up: head `96995d8` reported 296 import-only page-helper failures across six test modules, all from `PublicBindPolicyError`. Before the repair, `env STREAMLIT_SERVER_ADDRESS=0.0.0.0 ./dev test test/test_pipeline_service_guard.py` reproduced all three pipeline-service import failures locally.

## Root Cause

The direct-page guard treated launch environment preferences as authoritative instead of using Streamlit's effective runtime configuration. Separately, the first-proof producer saved artifact paths relative to the working directory, while the verifier interpreted them relative to the manifest directory.

The initial CI run also exposed an unset address in the standalone first-launch AppTest harness. Both `local-only-policy` and `root-tests` failed on that harness after the effective-bind fix. The robot now models a local loopback launch inside a temporary Streamlit testing configuration; production bind enforcement is preserved.

The next CI run exposed the same missing test setup in PROJECT, ORCHESTRATE, WORKFLOW, and ANALYSIS helper suites. These tests import guarded page entrypoints without starting a server, so they must opt into the existing temporary `streamlit_loopback_config` fixture. The repair changes six test files; production bind enforcement and the fixture implementation are unchanged.

## Regression Test

- Effective runtime configuration takes precedence over conflicting environment preferences; missing, blank, and unreadable configuration is handled conservatively.
- Explicitly supplied empty environment mappings cannot inherit ambient public-bind controls.
- Relative `--manifest-out` and relative `AGILAB_LOG_ABS` locations survive the real producer/writer/verifier path and verification from a different working directory.
- AppTest and import-only page-test fixtures explicitly model a loopback listener and restore the previous Streamlit configuration after each test.
- The standalone robot passes with unset, IPv4 wildcard, and IPv6 wildcard caller configuration and restores that configuration and `sys.argv` afterward.

## Validation

```bash
./dev test test/test_ui_public_bind_guard.py test/test_lab_run.py test/test_first_proof_cli.py test/test_evidence_contract.py test/test_run_manifest.py test/test_ui_pages.py
# 227 passed, 64 warnings
./dev test test/test_ci_workflow.py test/test_view_maps_3d.py::test_view_maps_3d_warns_when_no_dataset_exists
# 21 passed
python3 tools/agent_instruction_contract.py --check
python3 tools/agent_commit_provenance_guard.py --check-config
./dev impact --staged
./dev scope --staged
git diff --cached --check
```

- **248 final targeted tests passed.** Instruction, provenance, impact, scope, and whitespace checks passed before commit.
- **5/5 real Chromium scenarios passed** against a temporary minimal harness importing the production guard (Streamlit 1.59.0; Chromium 151.0.7922.34). The actual listener remained loopback-only; negative cases supplied simulated effective configuration. No console warnings/errors, page errors, failed requests, or HTTP 4xx/5xx responses were recorded. Screenshots were inspected. This validates the guard's browser behavior, not full application navigation.
- Ruff passed for the changed product modules and focused test modules. `test/conftest.py` retains two independently baseline-confirmed existing violations: unused `shutil` (F401) and the `agi_env` import placement (E402). Its scoped check passed with only those baseline codes excluded; unrelated cleanup was not included.
- Full release and cluster validation: not applicable to this targeted fix. GitHub platform and Python compatibility results for the final PR head are recorded below.
- Push hooks passed. Owner, docs mirror, release-proof, and app-contract hooks were intentionally skipped by the changed-input classifier because their inputs were unchanged.

CI test-isolation follow-up (`c4f8616`):

- 385 targeted tests passed with `STREAMLIT_SERVER_ADDRESS=0.0.0.0`, covering the six repaired modules, `test_ui_public_bind_guard.py`, and `test_first_launch_robot.py`.
- The canonical `python -m tools.testing.root_test_runner` run under that deliberately polluted setting reported 5,982 passed, 9 failed, and 14 skipped. All repaired page suites passed. The nine other failures came from the wildcard launcher setting and local canonical-docs drift.
- All 126 tests in the four affected environment-dependent modules passed after clearing `STREAMLIT_SERVER_ADDRESS` and setting `AGILAB_DOCS_SOURCE` to a separate snapshot of this commit's unchanged docs. This confirms the local environment causes; the dirty sibling docs were not modified. The rerun covered `test_lab_run.py`, `test_kpi_evidence_bundle.py`, `test_security_check.py`, and `test_production_readiness_report.py`.
- Ruff introduced zero diagnostics compared with `96995d8`. The six files have 36 existing diagnostics; the newly imported pytest fixture marker in `test_pipeline_service_guard.py` passes Ruff.
- Scope, whitespace, and agent commit-provenance checks passed. The patch changes only six test files. No additional browser validation was run because this follow-up changes test setup only; existing product/browser evidence above remains applicable. Existing root-suite skip policies are unchanged.

## Delivery status

- Latest CI repair: `c4f8616` (import-only page-helper bind isolation). On 2026-09-07, all nine applicable GitHub checks passed for `c4f86165446aafd34a4db3a6d00bde7dd99c0fdc`.
- Earlier follow-up: `96995d8` (first-launch robot bind isolation).
- Follow-up local validation: 44 tests passed across `test/test_first_launch_robot.py` and `test/test_ui_public_bind_guard.py`, using `uv --preview-features extra-build-dependencies run --extra dev --extra ui python -m pytest --import-mode=importlib -q -o addopts=''` in an isolated `.venv-dev`.
- Maintenance validation passed against an isolated checkout of the committed canonical docs. Warnings remain for the coverage target, repository-stat badge freshness, and TODO hotspots.
- GitHub validation: [root-tests](https://github.com/ThalesGroup/agilab/actions/runs/34120290572/job/101736552811), [Windows core tests](https://github.com/ThalesGroup/agilab/actions/runs/34120290504/job/101736552760), and [CI compatibility/install checks](https://github.com/ThalesGroup/agilab/actions/runs/34120290505) passed. The CI run includes `local-only-policy`, Python 3.12/3.14 compatibility, and clean public installs on Ubuntu, macOS, and Windows. GitGuardian also passed.
- GitHub skipped `public-demo-smoke`: `.github/workflows/ci.yml` runs this job only for `schedule` or `workflow_dispatch`, so it is not applicable to this PR event.
- Merged on 2026-09-07 as [5398611](https://github.com/ThalesGroup/agilab/commit/5398611c3e1799563e1aab766e820151f743ffd9). GitHub reports the squash commit signature as `verified: true`, `reason: valid`. Its tree (`4823f67096a9fcce7e4697ed68d59c25fe15be95`) exactly matches the tested PR head `c4f8616`.
- The normal CLI merge was rejected by branch policy. The maintainer-authorized repair used the repository's existing administrator-role override for a squash merge pinned to `c4f86165446aafd34a4db3a6d00bde7dd99c0fdc`, after verifying all seven required checks passed, the branch was current with `main`, and there were no unresolved review threads. No ruleset or signing configuration was changed, and original commit history was not rewritten. GitHub automatically deleted the remote feature branch.
- Merge regression check: read the resulting commit from the GitHub API and assert `verification.verified`, `verification.reason == valid`, and equality with the reviewed tree. This is the direct validation for this operational repair; product tests were not repeated because the tree is unchanged.
- Historical PR commits retain their original signatures: `12f6268` and `96995d8` report `unknown_key`; `c4f8616` reports `unsigned`. These commits were preserved in the PR history; the new commit on `main` is the verified squash described above.

## Review Evidence

Sub-agents used the inherited parent model; exact model identifiers and reasoning settings were not exposed.

- Evidence contributor: implemented the manifest fix and regressions, then validated the guard in Chromium; edited files.
- Runtime reviewer: independently reviewed manifest normalization and verifier behavior; review-only, no remaining findings.
- Security reviewer and test contributor: reviewed effective-bind enforcement, added the isolated AppTest fixture and page regressions; edited tests, no remaining product blockers.
- Primary Codex agent integrated the changes, checked the complete staged scope, and ran the final combined validation. Both confirmed audit findings are addressed.
- Release follow-up: primary agent only; no additional sub-agents were used. The first-launch harness follow-up and its regressions are included.

- CI test-isolation follow-up: primary Codex agent (GPT-6; exact variant and reasoning effort unavailable), no additional sub-agents. Reviewed all 296 failing node IDs, reused the existing fixture across the six affected test modules, and completed the local regression and environment-isolation checks described above.
- PR evidence refresh: primary Codex agent (GPT-6; exact variant and reasoning effort unavailable), no sub-agents. Verified the current PR head, GitHub checks, skipped-job condition, and active signature requirement; documentation update only.
- Signature repair: primary Codex agent (GPT-6; exact variant and reasoning effort unavailable), no sub-agents. No stronger reviewer model was exposed. Performed the operational checks and verified the resulting GitHub signature and tree; no product code changed.

## Agent Metadata

- Tokki: `1.0.63`
- Agent/runtime: Codex API agent; runtime version unavailable
- Model: GPT-6 for the release follow-up and PR evidence refresh; exact variant unavailable. Earlier contributors' exact models were not exposed.
- Reasoning effort: unavailable
- `/fast` mode: unknown; not exposed
