### PR TITLE
fix(tescia): validate assessment inputs and preserve case artifacts

### DIFF
--- a/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
@@ -60,6 +60,15 @@ The default input is
 JSON batch with classroom metadata and a `submissions` list containing
 `student_id`, `case_id`, and answer fields.
 
+Regression-test entries must be JSON objects. Their optional `automated` and
+`discriminator` flags must be JSON booleans (`true` or `false`), not strings or
+numbers. An omitted flag means `false`. Invalid entries are rejected before
+scoring so malformed data cannot inflate a learner's score.
+
+Custom mathematics curricula may set `required_min_cases_per_id` to a positive
+JSON integer. Omitting it keeps the default of one case per curriculum item;
+invalid values are rejected instead of silently lowering the coverage threshold.
+
 ## Expected Outputs
 
 The app writes per-case diagnostic reports, summary CSV files,
@@ -68,6 +77,13 @@ report, and classroom artifacts such as progress, heatmap, needs-attention,
 student, curriculum, learning-path, and intervention CSV files. Reports include
 `decision_status`, `decision_action`, and decision triggers when a case defines a
 deterministic guard.
+
+Lowercase alphanumeric case IDs with single `_` or `-` separators (up to 96
+characters) keep their existing artifact filenames. Other nonblank string IDs
+use a readable prefix and a stable SHA256 suffix so punctuation or letter-case
+differences do not cause reports to overwrite one another. Reports retain the
+original case ID, and rerunning the same case reuses its filename. Explicitly
+empty or whitespace-only IDs are rejected.
 
 ## Change One Thing
 

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/curriculum.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/curriculum.py
@@ -58,11 +58,12 @@ def curriculum_id_counts(cases: Sequence[Mapping[str, Any]]) -> dict[str, int]:
 
 
 def required_min_cases_per_id(curriculum: Mapping[str, Any]) -> int:
-    try:
-        value = int(curriculum.get("required_min_cases_per_id", 1))
-    except (TypeError, ValueError):
-        value = 1
-    return max(value, 1)
+    value = curriculum.get("required_min_cases_per_id", 1)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(
+            "Math curriculum coverage required_min_cases_per_id must be a positive integer."
+        )
+    return value
 
 
 def validate_math_program_2026(curriculum: Mapping[str, Any]) -> None:
@@ -81,10 +82,7 @@ def validate_math_program_2026(curriculum: Mapping[str, Any]) -> None:
     required = curriculum.get("required_program_ids")
     if not isinstance(required, list) or not required:
         raise ValueError("Math curriculum coverage must declare required_program_ids.")
-    if required_min_cases_per_id(curriculum) < 1:
-        raise ValueError(
-            "Math curriculum coverage required_min_cases_per_id must be at least 1."
-        )
+    required_min_cases_per_id(curriculum)
     seen: set[str] = set()
     for item in required:
         if not isinstance(item, Mapping):

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/diagnostic.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/diagnostic.py
@@ -295,6 +295,18 @@ def _validate_student_answer(case: Mapping[str, Any], *, case_id: str) -> None:
         )
 
 
+def _validate_regression_tests(tests: Sequence[Any], *, case_id: str) -> None:
+    for index, row in enumerate(tests):
+        location = f"Case {case_id!r} regression_tests[{index}]"
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{location} must be an object.")
+        for field in ("automated", "discriminator"):
+            if field in row and not isinstance(row[field], bool):
+                raise ValueError(
+                    f"{location} field {field!r} must be a boolean when provided."
+                )
+
+
 def validate_case_payload(
     payload: Mapping[str, Any], *, expected_case_count: int | None = None
 ) -> dict[str, Any]:
@@ -342,6 +354,7 @@ def validate_case_payload(
             raise ValueError(
                 f"Case {case_id!r} must include at least two regression tests."
             )
+        _validate_regression_tests(tests, case_id=case_id)
         _validate_string_list(
             case.get("curriculum_ids"), field="curriculum_ids", case_id=case_id
         )
@@ -420,11 +433,8 @@ def evidence_quality(case: Mapping[str, Any]) -> float:
 
 
 def regression_coverage(case: Mapping[str, Any]) -> float:
-    tests = [
-        row
-        for row in _as_list(case.get("regression_tests"))
-        if isinstance(row, Mapping)
-    ]
+    tests = _as_list(case.get("regression_tests"))
+    _validate_regression_tests(tests, case_id=str(case.get("case_id", "")))
     if not tests:
         return 0.0
     discriminators = sum(1 for row in tests if bool(row.get("discriminator")))

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/exports.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/domain/exports.py
@@ -2,10 +2,28 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
+
+
+def case_artifact_stem(case_id: str) -> str:
+    """Keep canonical IDs readable and preserve every other ID in a stable name.
+
+    Hashed names use a reserved separator and lowercase ASCII so distinct IDs
+    remain distinct on case-insensitive and Unicode-normalizing filesystems.
+    The bounded prefix also leaves room for the worker's report suffixes.
+    """
+    if not isinstance(case_id, str) or not case_id.strip():
+        raise ValueError("case_id must be a non-empty string for artifact export")
+    if len(case_id) <= 96 and re.fullmatch(r"[a-z0-9]+(?:[-_][a-z0-9]+)*", case_id):
+        return case_id
+    prefix = re.sub(r"[^a-z0-9_-]+", "_", case_id.lower()).strip("_-")
+    prefix = prefix[:48] or "tescia_case"
+    return f"{prefix}~{hashlib.sha256(case_id.encode('utf-8')).hexdigest()}"
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -104,10 +122,9 @@ def diagnostic_report_to_markdown(report: Mapping[str, Any]) -> str:
 
 
 def write_correction_sheet(report: Mapping[str, Any], output_dir: str | Path) -> Path:
-    case_id = str(report.get("case_id") or "tescia_case").strip() or "tescia_case"
-    safe_stem = "".join(
-        ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in case_id
-    )
+    """Export a sheet, retaining the legacy default only for an absent case ID."""
+    case_id = report.get("case_id")
+    safe_stem = case_artifact_stem("tescia_case" if case_id is None else case_id)
     output_path = Path(output_dir) / f"{safe_stem}_correction.md"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(diagnostic_report_to_markdown(report), encoding="utf-8")
@@ -125,6 +142,7 @@ def write_correction_index(paths: Sequence[Path], output_dir: str | Path) -> Pat
 
 
 __all__ = [
+    "case_artifact_stem",
     "diagnostic_report_to_markdown",
     "write_correction_index",
     "write_correction_sheet",

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
@@ -22,7 +22,11 @@ from tescia_diagnostic.classroom import (
 )
 from tescia_diagnostic.curriculum import build_math_program_2026_coverage_report
 from tescia_diagnostic.diagnostic import diagnose_case, summarize_report, validate_case_payload
-from tescia_diagnostic.exports import write_correction_index, write_correction_sheet
+from tescia_diagnostic.exports import (
+    case_artifact_stem,
+    write_correction_index,
+    write_correction_sheet,
+)
 from tescia_diagnostic.reduction import write_reduce_artifact
 
 logger = logging.getLogger(__name__)
@@ -34,9 +38,7 @@ def _artifact_dir(env: object, leaf: str) -> Path:
 
 
 def _sanitize_slug(value: str) -> str:
-    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value.strip())
-    cleaned = "_".join(part for part in cleaned.split("_") if part)
-    return cleaned or "tescia_case"
+    return case_artifact_stem(value)
 
 
 def _write_json(path: Path, payload: Any) -> None:

--- a/test/test_tescia_artifact_names.py
+++ b/test/test_tescia_artifact_names.py
@@ -1,0 +1,157 @@
+"""Distinct TeSciA case identities must retain distinct exported evidence."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+APP_SRC = (
+    Path(__file__).resolve().parents[1]
+    / "src/agilab/apps/builtin/tescia_diagnostic_project/src"
+)
+SAMPLE_CASES = APP_SRC / "tescia_diagnostic/sample_data/tescia_diagnostic_cases.json"
+
+
+@pytest.fixture
+def app_modules(monkeypatch):
+    monkeypatch.syspath_prepend(str(APP_SRC))
+    from tescia_diagnostic import exports
+    from tescia_diagnostic_worker import tescia_diagnostic_worker as worker_module
+
+    return exports, worker_module
+
+
+@pytest.mark.parametrize(
+    ("first_id", "second_id"),
+    [
+        ("case/a", "case_a"),
+        ("case.a", "case?a"),
+        ("case", "CASE"),
+        ("a__b", "a_b"),
+        (" case ", "case"),
+        ("é", "e\u0301"),
+    ],
+)
+def test_distinct_case_ids_keep_separate_corrections(
+    app_modules, tmp_path, first_id, second_id
+):
+    exports, worker_module = app_modules
+    first = exports.write_correction_sheet({"case_id": first_id}, tmp_path)
+    second = exports.write_correction_sheet({"case_id": second_id}, tmp_path)
+
+    assert first.name.casefold() != second.name.casefold()
+    assert worker_module._sanitize_slug(first_id).casefold() != (
+        worker_module._sanitize_slug(second_id).casefold()
+    )
+    assert f"- Case id: `{first_id}`" in first.read_text(encoding="utf-8")
+    assert f"- Case id: `{second_id}`" in second.read_text(encoding="utf-8")
+
+
+def test_bundled_case_filenames_are_unchanged(app_modules, tmp_path):
+    exports, worker_module = app_modules
+    cases = json.loads(SAMPLE_CASES.read_text(encoding="utf-8"))["cases"]
+    for case in cases:
+        case_id = case["case_id"]
+        assert worker_module._sanitize_slug(case_id) == case_id
+        assert exports.write_correction_sheet(case, tmp_path).name == (
+            f"{case_id}_correction.md"
+        )
+
+
+@pytest.mark.parametrize("case_id", ["a" * 400, "épreuve/" * 80])
+def test_artifact_basenames_are_bounded_ascii(app_modules, tmp_path, case_id):
+    exports, worker_module = app_modules
+    path = exports.write_correction_sheet({"case_id": case_id}, tmp_path)
+    stem = worker_module._sanitize_slug(case_id)
+
+    assert path.name.isascii()
+    assert len(path.name.encode("ascii")) <= 160
+    assert len(f"{stem}_diagnostic_summary.csv".encode("ascii")) <= 160
+    assert path.parent == tmp_path
+    assert path.name == f"{stem}_correction.md"
+
+
+def test_retries_are_stable_and_generated_names_have_a_reserved_namespace(
+    app_modules, tmp_path
+):
+    exports, worker_module = app_modules
+    report = {"case_id": "case/a"}
+    first = exports.write_correction_sheet(report, tmp_path)
+    assert exports.write_correction_sheet(report, tmp_path) == first
+    assert len(list(tmp_path.glob("*_correction.md"))) == 1
+
+    generated_stem = first.name.removesuffix("_correction.md")
+    other = exports.write_correction_sheet({"case_id": generated_stem}, tmp_path)
+    assert other.name.casefold() != first.name.casefold()
+    assert worker_module._sanitize_slug(report["case_id"]) == generated_stem
+
+
+@pytest.mark.parametrize("case_id", ["", "  "])
+def test_explicit_blank_case_ids_are_rejected(app_modules, tmp_path, case_id):
+    exports, worker_module = app_modules
+    with pytest.raises(ValueError, match="case_id"):
+        exports.write_correction_sheet({"case_id": case_id}, tmp_path)
+    with pytest.raises(ValueError, match="case_id"):
+        worker_module._sanitize_slug(case_id)
+
+    for report in ({}, {"case_id": None}):
+        assert exports.write_correction_sheet(report, tmp_path).name == (
+            "tescia_case_correction.md"
+        )
+
+
+def test_worker_keeps_both_artifact_bundles_complete_on_retry(app_modules, tmp_path):
+    _exports, worker_module = app_modules
+    payload = json.loads(SAMPLE_CASES.read_text(encoding="utf-8"))
+    original = payload["cases"][0]
+    case_ids = {"case/a", "case_a", "CASE_A"}
+    source_file = tmp_path / "cases.json"
+    source_file.write_text(
+        json.dumps(
+            {
+                **payload,
+                "cases": [{**original, "case_id": value} for value in sorted(case_ids)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    worker = worker_module.TesciaDiagnosticWorker()
+    worker._worker_id = 0
+    worker.data_out = tmp_path / "reports"
+    worker.artifact_dir = tmp_path / "export"
+    worker._current_args = lambda: SimpleNamespace(reset_target=True)
+    frame = worker.work_pool(source_file)
+
+    worker.work_done(frame)
+    worker.work_done(frame)
+
+    for root in (worker.data_out, worker.artifact_dir):
+        reports = sorted(root.glob("*/*_diagnostic_report.json"))
+        assert len(reports) == len(case_ids)
+        assert {
+            json.loads(path.read_text(encoding="utf-8"))["case_id"] for path in reports
+        } == case_ids
+        summaries = sorted(root.glob("*/*_diagnostic_summary.csv"))
+        assert len(summaries) == len(case_ids)
+        summary_ids = set()
+        for path in summaries:
+            with path.open(newline="", encoding="utf-8") as stream:
+                rows = list(csv.DictReader(stream))
+            assert len(rows) == 1
+            summary_ids.add(rows[0]["case_id"])
+        assert summary_ids == case_ids
+        with (root / "tescia_diagnostic_summary.csv").open(
+            newline="", encoding="utf-8"
+        ) as stream:
+            assert {row["case_id"] for row in csv.DictReader(stream)} == case_ids
+        corrections = sorted((root / "correction_sheets").glob("*_correction.md"))
+        assert len(corrections) == len(case_ids)
+        index = (root / "correction_sheets/correction_sheets_index.md").read_text(
+            encoding="utf-8"
+        )
+        assert all(f"]({path.name})" in index for path in corrections)

--- a/test/test_tescia_curriculum_validation.py
+++ b/test/test_tescia_curriculum_validation.py
@@ -1,0 +1,106 @@
+"""Coverage thresholds must not silently weaken curriculum quality checks."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+APP_SRC = (
+    Path(__file__).resolve().parents[1]
+    / "src/agilab/apps/builtin/tescia_diagnostic_project/src"
+)
+
+
+@pytest.fixture
+def curriculum_module(monkeypatch):
+    monkeypatch.syspath_prepend(str(APP_SRC))
+    return importlib.import_module("tescia_diagnostic.curriculum")
+
+
+def _cases_per_curriculum_id(module, curriculum, count=1):
+    return [
+        {"case_id": f"case-{index}-{variant}", "curriculum_ids": [program_id]}
+        for index, program_id in enumerate(
+            sorted(module.required_curriculum_ids(curriculum))
+        )
+        for variant in range(count)
+    ]
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    [
+        0,
+        -1,
+        True,
+        False,
+        1.0,
+        2.9,
+        float("nan"),
+        float("inf"),
+        "2",
+        "bad",
+        "",
+        None,
+        [],
+        {},
+    ],
+)
+def test_explicit_invalid_curriculum_threshold_is_rejected(curriculum_module, threshold):
+    curriculum = curriculum_module.load_math_program_2026()
+    curriculum["required_min_cases_per_id"] = threshold
+
+    with pytest.raises(ValueError, match="required_min_cases_per_id"):
+        curriculum_module.required_min_cases_per_id(curriculum)
+    with pytest.raises(ValueError, match="required_min_cases_per_id"):
+        curriculum_module.validate_math_program_2026(curriculum)
+
+
+@pytest.mark.parametrize("threshold", [1, 2, 100])
+def test_positive_integer_curriculum_threshold_is_preserved(curriculum_module, threshold):
+    curriculum = curriculum_module.load_math_program_2026()
+    curriculum["required_min_cases_per_id"] = threshold
+
+    curriculum_module.validate_math_program_2026(curriculum)
+    assert curriculum_module.required_min_cases_per_id(curriculum) == threshold
+
+
+def test_omitted_curriculum_threshold_defaults_to_one(curriculum_module):
+    curriculum = curriculum_module.load_math_program_2026()
+    curriculum.pop("required_min_cases_per_id")
+    cases = _cases_per_curriculum_id(curriculum_module, curriculum)
+
+    assert curriculum_module.required_min_cases_per_id(curriculum) == 1
+    report = curriculum_module.build_math_program_2026_coverage_report(cases, curriculum)
+    assert report["required_min_cases_per_id"] == 1
+    assert report["quality_passed"] is True
+    assert report["undercovered_curriculum_ids"] == []
+
+
+def test_invalid_threshold_cannot_produce_passing_coverage(curriculum_module):
+    curriculum = curriculum_module.load_math_program_2026()
+    cases = _cases_per_curriculum_id(curriculum_module, curriculum)
+    curriculum["required_min_cases_per_id"] = "invalid"
+
+    with pytest.raises(ValueError, match="required_min_cases_per_id"):
+        curriculum_module.build_math_program_2026_coverage_report(cases, curriculum)
+
+
+def test_bundled_curriculum_requires_two_cases_per_id(curriculum_module):
+    curriculum = curriculum_module.load_math_program_2026()
+    assert curriculum["required_min_cases_per_id"] == 2
+    cases = _cases_per_curriculum_id(curriculum_module, curriculum)
+
+    report = curriculum_module.build_math_program_2026_coverage_report(cases, curriculum)
+    assert report["quality_passed"] is False
+    assert report["missing_curriculum_ids"] == []
+    assert report["undercovered_curriculum_ids"] == sorted(
+        curriculum_module.required_curriculum_ids(curriculum)
+    )
+
+    cases = _cases_per_curriculum_id(curriculum_module, curriculum, count=2)
+    report = curriculum_module.build_math_program_2026_coverage_report(cases, curriculum)
+    assert report["quality_passed"] is True
+    assert report["undercovered_curriculum_ids"] == []

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -1459,15 +1459,11 @@ def test_tescia_math_program_2026_rejects_invalid_curriculum_contracts(
         "missing domain",
     )
 
-    import tescia_diagnostic.curriculum as curriculum_module
+    with pytest.raises(ValueError, match="required_min_cases_per_id"):
+        validate_math_program_2026({**valid, "required_min_cases_per_id": 0})
 
-    monkeypatch.setattr(
-        curriculum_module, "required_min_cases_per_id", lambda _curriculum: 0
-    )
-    with pytest.raises(ValueError, match="must be at least 1"):
-        curriculum_module.validate_math_program_2026(valid)
-
-    assert required_min_cases_per_id({"required_min_cases_per_id": "bad"}) == 1
+    with pytest.raises(ValueError, match="required_min_cases_per_id"):
+        required_min_cases_per_id({"required_min_cases_per_id": "bad"})
     assert case_curriculum_ids({"curriculum_ids": "prog"}) == []
     assert curriculum_id_counts([{"curriculum_ids": ["prog", "prog"]}]) == {"prog": 1}
 
@@ -2327,9 +2323,9 @@ def test_tescia_printable_exports_handle_missing_optional_sections(
     assert "No feedback." in markdown
     assert "No weak assumptions recorded." in markdown
     assert "No regression plan recorded." in markdown
-    assert (
-        write_correction_sheet(report, tmp_path).name == "messy_case_id_correction.md"
-    )
+    correction_name = write_correction_sheet(report, tmp_path).name
+    assert correction_name.startswith("messy_case_id~")
+    assert correction_name.endswith("_correction.md")
     assert (
         write_correction_index([], tmp_path)
         .read_text(encoding="utf-8")
@@ -3137,7 +3133,8 @@ def test_tescia_worker_helper_and_empty_paths(monkeypatch, tmp_path) -> None:
         "export",
         "leaf",
     )
-    assert _sanitize_slug("  ") == "tescia_case"
+    with pytest.raises(ValueError, match="case_id"):
+        _sanitize_slug("  ")
 
     worker = TesciaDiagnosticWorker()
     worker.env = _FakeEnv(tmp_path)

--- a/test/test_tescia_regression_flags.py
+++ b/test/test_tescia_regression_flags.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+APP_SRC = (
+    Path(__file__).resolve().parents[1]
+    / "src/agilab/apps/builtin/tescia_diagnostic_project/src"
+)
+
+
+@pytest.fixture
+def diagnostic_modules(monkeypatch):
+    monkeypatch.syspath_prepend(str(APP_SRC))
+    from tescia_diagnostic.domain import diagnostic, generator
+
+    return diagnostic, generator
+
+
+@pytest.fixture
+def case_payload():
+    sample = APP_SRC / "tescia_diagnostic/sample_data/tescia_diagnostic_cases.json"
+    payload = json.loads(sample.read_text(encoding="utf-8"))
+    payload["cases"] = payload["cases"][:1]
+    return payload
+
+
+@pytest.mark.parametrize("entrypoint", ["validate_case_payload", "diagnose_case"])
+@pytest.mark.parametrize("field", ["automated", "discriminator"])
+@pytest.mark.parametrize("value", ["false", "true", 0, 1, None])
+def test_regression_flags_reject_non_boolean_values(
+    diagnostic_modules, case_payload, entrypoint, field, value
+):
+    diagnostic, _ = diagnostic_modules
+    case = case_payload["cases"][0]
+    case["regression_tests"][0][field] = value
+    argument = case_payload if entrypoint == "validate_case_payload" else case
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{case['case_id']}.*regression_tests\[0\].*{field}.*boolean",
+    ):
+        getattr(diagnostic, entrypoint)(argument)
+
+
+@pytest.mark.parametrize("entrypoint", ["validate_case_payload", "diagnose_case"])
+@pytest.mark.parametrize("row", [None, "invalid test", 0, []])
+def test_regression_tests_require_object_rows(
+    diagnostic_modules, case_payload, entrypoint, row
+):
+    diagnostic, _ = diagnostic_modules
+    case = case_payload["cases"][0]
+    case["regression_tests"][0] = row
+    argument = case_payload if entrypoint == "validate_case_payload" else case
+
+    with pytest.raises(
+        ValueError, match=rf"{case['case_id']}.*regression_tests\[0\].*object"
+    ):
+        getattr(diagnostic, entrypoint)(argument)
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected_coverage"),
+    [
+        ({}, 0.0),
+        ({"automated": False, "discriminator": False}, 0.0),
+        ({"automated": True}, 0.35),
+        ({"discriminator": True}, 0.65),
+        ({"automated": True, "discriminator": True}, 1.0),
+    ],
+)
+def test_regression_flags_preserve_boolean_scoring_and_optional_defaults(
+    diagnostic_modules, case_payload, flags, expected_coverage
+):
+    diagnostic, _ = diagnostic_modules
+    for row in case_payload["cases"][0]["regression_tests"]:
+        row.pop("automated", None)
+        row.pop("discriminator", None)
+        row.update(flags)
+
+    case = diagnostic.validate_case_payload(case_payload)["cases"][0]
+    assert diagnostic.regression_coverage(case) == expected_coverage
+    report = diagnostic.diagnose_case(case)
+    assert report["regression_coverage"] == expected_coverage
+    expected_status = "actionable" if expected_coverage >= 0.6 else "needs_more_evidence"
+    assert report["status"] == expected_status
+
+
+@pytest.mark.parametrize("field", ["automated", "discriminator"])
+def test_generator_rejects_string_false_regression_flags(
+    diagnostic_modules, case_payload, field
+):
+    _, generator = diagnostic_modules
+    case = case_payload["cases"][0]
+    case["regression_tests"][0][field] = "false"
+
+    def fake_post_json(_url, _payload, _timeout):
+        return {"output_text": json.dumps(case_payload)}
+
+    with pytest.raises(
+        generator.DiagnosticCaseGenerationError,
+        match=rf"{case['case_id']}.*regression_tests\[0\].*{field}.*boolean",
+    ):
+        generator.generate_cases_with_engine(
+            provider="gpt-oss",
+            endpoint="http://127.0.0.1:8000/v1/responses",
+            model="fixture",
+            topic="regression evidence",
+            case_count=1,
+            post_json=fake_post_json,
+        )
+
+
+def test_valid_bundled_case_keeps_its_diagnostic_scores(diagnostic_modules, case_payload):
+    diagnostic, _ = diagnostic_modules
+    case = diagnostic.validate_case_payload(case_payload)["cases"][0]
+
+    report = diagnostic.diagnose_case(case)
+
+    assert report["status"] == "actionable"
+    assert report["regression_coverage"] == 1.0
+    assert report["case_quality_score"] == 94.0
+    assert report["student_score"] == 99.7
+    assert report["selected_fix"]["id"] == "mount_scheduler_share_with_sshfs"


### PR DESCRIPTION
## Summary

Improve TeSciA's handling of custom diagnostic cases without changing the bundled exercises or their scores:

- Reject malformed regression-test rows and nonboolean `automated` / `discriminator` flags before scoring, including direct calls to `diagnose_case()` and generated case responses. Omitted flags still mean false.
- Require an explicit curriculum coverage minimum to be a positive JSON integer. An omitted minimum still defaults to one; the bundled curriculum still requires two.
- Use one app-local filename helper for worker reports and correction sheets so punctuation, case, and Unicode variants do not overwrite another case's evidence. Short canonical lowercase IDs keep their filenames; other nonblank string IDs receive bounded names with a stable SHA256 suffix.
- Document these input and filename rules in the app README.

## Scope and authorization

The maintainer requested **“improve tescia_diagnostic_project and push.”** This PR contains only TeSciA app code, its README, and focused tests. It was developed in a separate worktree from current `origin/main`. Pending documentation wording changes and unrelated book edits are excluded. No shared-core files, dependency bounds, package versions, release assets, or UI controls changed. The maintainer's subsequent cleanup request authorizes completing this PR; package publication remains a separate release step.

## Repro

Before the fixes, focused local reproductions showed that malformed regression flags could increase a diagnostic score, invalid curriculum thresholds could produce a passing coverage report, and distinct case IDs could overwrite the same correction sheet. New regression tests captured these cases before implementation.

## Root Cause

- Regression flags were passed through Python truthiness without validating their JSON types.
- The coverage minimum was coerced to an integer and clamped or defaulted before validation could reject it.
- The worker and correction exporter independently removed characters from case IDs, allowing different IDs to produce the same filename.

## Regression Test

- Parameterized invalid flag types and rows, optional defaults, unchanged valid scoring, and generated-response rejection through a mocked transport.
- Invalid curriculum values, positive/default values, and real report-level one-versus-two-case coverage checks.
- Slash/underscore, punctuation, case, Unicode, whitespace, long-name, and reserved-name-namespace cases; deterministic retries; unchanged bundled filenames; complete worker JSON/CSV/correction bundles in both output locations.
- Replaced the old tests that expected silent threshold coercion and lossy artifact names with assertions for the corrected behavior.

## Validation

```bash
./dev test test/test_tescia_diagnostic_project.py test/test_tescia_curriculum_validation.py test/test_tescia_regression_flags.py test/test_tescia_artifact_names.py test/test_app_installer_packaging.py
# 219 passed, 1 existing runpy warning
```

- The four TeSciA test modules also passed in a fresh environment resolved from the app's own `pyproject.toml`, explicitly using Python 3.13: **136 passed**, with the same existing warning.
- The built-in app runner does not register TeSciA because its tests live in the central test directory. The app-environment run above supplies the requested validation without bypassing tests.
- Built the `agi-app-tescia-diagnostic` wheel and verified that its README and all four changed Python files exactly match the current source. Executed the extracted wheel's modules to validate all 24 bundled cases, reject malformed flags and thresholds, and preserve distinct correction sheets across retries.
- Compared complete diagnostic reports for all 24 bundled cases with the base implementation: unchanged.
- Project-configured Ruff, whitespace, impact, scope, and agent provenance checks passed. The change is one app scope.

### Validation limits

- An initial unconstrained app-environment run selected free-threaded Python 3.14 and failed while building `polars-runtime-32==1.44.1` with the local stable Rust toolchain. That interpreter combination remains unvalidated; the explicit Python 3.13 app-environment run passed. No dependency or toolchain policy was changed.
- Real model calls, remote clusters, and browser UI validation: not applicable to these app-local input and output changes. Generated-response tests use a mocked transport; local worker tests exercise actual worker methods with isolated fixtures.
- Existing artifacts are not migrated or deleted. Previously noncanonical case IDs use the new filenames on subsequent runs.

## Review Evidence

Sub-agents used the inherited parent model; exact model identifiers were not exposed.

- Diagnostic contributor: implemented flag validation and tests; independently reviewed the curriculum change and approved it.
- Curriculum contributor: implemented threshold validation and tests; independently reviewed the diagnostic change, reran its regressions, and compared all bundled reports with the base implementation; approved.
- Artifact contributor: implemented shared app-local filename generation and worker/export regressions.
- Primary Codex agent reviewed the filename implementation and integration, updated the README, and completed the combined tests, app-environment run, and wheel verification.

All three contributors edited files. No remaining findings in the selected scope.

## Delivery status

Merged as `e7509bf32496740e5b527f045015329cbe9bd6c3` after all applicable checks passed on the current branch head. Verified the GitHub signature and an identical tree to the reviewed head `143a53a46138d491c13d53e5972131bc60909e00`. No repository protections or signing configuration were changed.

## Agent Metadata

- Tokki: `1.0.63`
- Agent/runtime: Codex API agent; runtime version unavailable
- Model: original contributor model identifiers unavailable; current cleanup reviewer GPT-6, exact variant unavailable
- Reasoning effort: unavailable
- `/fast` mode: unknown; not exposed
