### PR TITLE
chore(badges): align cluster coverage with CI

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="166" height="20" role="img" aria-label="agi-cluster coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="166" height="20" role="img" aria-label="agi-cluster coverage: 91%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="67.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="67.0" y="14">agi-cluster coverage</text>
-  <text x="150.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="150.0" y="14">92%</text>
+  <text x="150.0" y="15" fill="#010101" fill-opacity=".3">91%</text>
+  <text x="150.0" y="14">91%</text>
 </g>
 </svg>


### PR DESCRIPTION
Correct the committed agi-cluster coverage badge from 92% to 91%, matching the successful main coverage test results. The other six generated coverage badges are unchanged.

## Repro

Main [coverage run 34124465896](https://github.com/ThalesGroup/agilab/actions/runs/34124465896) passed its test jobs but failed the final committed-badge freshness check. The complete downloaded five-component XML artifact set reproduced the stale cluster SVG locally.

## Root Cause

The committed cluster badge lagged the measured 8,231 covered lines out of 8,954. The existing generator truncates the measured 91.93% to 91%.

## Regression Test

Regenerated all seven coverage badges from the complete five-component XML set; only the cluster SVG changed. Eleven badge-generator tests, the badge-only coverage guard, full badges workflow parity, scope, impact, whitespace, provenance, and pre-push checks passed. All applicable current-head PR checks passed; the public-demo smoke is intentionally skipped on PR events.

The subsequent [main coverage workflow](https://github.com/ThalesGroup/agilab/actions/runs/34126986222) passed all jobs, including final badge freshness. No new workflow dispatch was needed because the workflow includes coverage SVGs in its push paths.

## Review Evidence

Primary Codex agent verified artifact provenance, regenerated the complete badge set, and reviewed the one-file diff. No remaining findings. No sub-agents were used; no stronger reviewer model was exposed.

## Delivery status

Merged as `994fe0b3b4b87863a1a5bcb7c6210dcc179be72e` after all applicable checks passed on the current branch head. Verified the GitHub signature and an identical tree to the reviewed head `2cd2bb43ff4180ab151ea7ce90b573bbe534e19e`. No repository protections or signing configuration were changed.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex API agent; runtime version unavailable
- Model: GPT-6; exact variant unavailable
- Reasoning effort: unavailable
- `/fast`: unknown; not exposed
