### PR TITLE
docs: clarify newcomer and notebook guidance

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
     "release-proof.rst": "44237e6e21591932e0518ccf8696ebfaffeea8ffd101c2bd4012e492ce585065"
   },
-  "source_digest_sha256": "6d98bf9749bf8d945b5f51a856427c14c7c65b5b30290820eddb2807959b7d66",
+  "source_digest_sha256": "65c694e07fae319f244c660a6bbf6945be265d40fc72b5ab7b6152c49ed5936d",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "6d98bf9749bf8d945b5f51a856427c14c7c65b5b30290820eddb2807959b7d66"
+  "target_digest_sha256": "65c694e07fae319f244c660a6bbf6945be265d40fc72b5ab7b6152c49ed5936d"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ MLflow when that integration is enabled. The notebook export is an ``agi-core``
 runtime handoff: you can continue to run the saved project and stage contract
 with only the stable core runtime, without depending on the AGILAB UI or
 distributed worker layer. That stable, production-grade core technology remains
-the smallest supported handoff surface.
+the minimal supported runtime for exported notebooks.
 
 If you are new to AGILab, choose one route first:
 
@@ -20,12 +20,12 @@ If you are new to AGILab, choose one route first:
 - **Use the API/notebook**: follow :doc:`notebook-quickstart` for the smaller
   ``AgiEnv`` / ``AGI.run(...)`` surface.
 
-The fastest adoption ladder is browser preview, one local first-proof lane,
-evidence manifest, then expansion into package mode, external apps, or cluster
-work.
+Start with a browser preview, then run and verify one local example and save its
+run manifest. From there, explore package mode, external apps, or cluster
+execution.
 
-Golden ML loop
---------------
+Recommended ML workflow
+-----------------------
 
 AGILAB's strongest workflow is deliberately evidence-first:
 

--- a/docs/source/newcomer-guide.rst
+++ b/docs/source/newcomer-guide.rst
@@ -10,8 +10,9 @@ want to prove notebook import first, use the landing page's
 no file to find or upload. Use PROJECT -> ``Create`` -> ``From notebook`` later
 when the notebook is on your machine.
 
-This page gives the mental model only. :doc:`quick-start` owns the exact
-commands. :doc:`newcomer-troubleshooting` owns the first-failure path.
+This page explains the main concepts. See :doc:`quick-start` for the exact
+commands and :doc:`newcomer-troubleshooting` for help troubleshooting your first
+run.
 
 Fast adoption ladder
 --------------------

--- a/docs/source/notebook-quickstart.rst
+++ b/docs/source/notebook-quickstart.rst
@@ -4,8 +4,8 @@ agi-core Demo
 Use this page only when you intentionally want the notebook path first.
 
 If you want the main AGILAB product path first, use :doc:`quick-start` and run
-the built-in ``flight_telemetry_project`` from the web UI. This page is the smallest
-published-package notebook route for the built-in Minimal App example app.
+the built-in ``flight_telemetry_project`` from the web UI. This page shows how to
+run the built-in Minimal App example in a notebook using published packages.
 
 Start here
 ----------
@@ -37,7 +37,7 @@ The first notebook does only one thing:
 What success looks like
 -----------------------
 
-You are past the notebook newcomer hurdle when both are true:
+Your first notebook run is complete when:
 
 - the notebook run finishes without error
 - you can inspect fresh output under ``~/log/execute/minimal_app``


### PR DESCRIPTION
Clarify the newcomer and notebook guides: the landing page now describes a concrete preview-to-local-run sequence, and the notebook guide distinguishes its Minimal App example from the web UI's flight telemetry route.

The public mirror matches canonical docs commit `5e841ee` in the private source repository. Its later uncommitted package rename is separate ongoing work. No screenshots or visible UI labels changed.

## Validation

- Full local docs workflow parity passed, including Sphinx generation.
- Confirmed the updated wording in all three generated HTML pages.
- Mirror stamp, scope, impact, whitespace, provenance, and pre-push guards passed. The canonical check used an exact archive of the committed source to exclude unrelated uncommitted edits.
- Updated from current main. All applicable GitHub checks passed for `a38e647c2940f75094344d27d735c9198ba6b80d`; the public-demo smoke is intentionally skipped on PR events. The [automatic Pages deployment](https://github.com/ThalesGroup/agilab/actions/runs/34132694958) succeeded; all three published HTML pages contain the validated new wording.

## Review Evidence

Primary Codex agent reviewed the source diff, mirror provenance, and generated pages. No remaining findings. No sub-agents were used; no stronger reviewer model was exposed.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex API agent; runtime version unavailable
- Model: GPT-6; exact variant unavailable
- Reasoning effort: unavailable
- `/fast`: unknown; not exposed

## Delivery status

Merged as `a3bd9727379a01f0e3dba874b4779d2fd07ea947`. Verified its GitHub signature and tree equality with the reviewed head.
