### PR TITLE
docs: prepare Learning and Assessment release target

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
     "release-proof.rst": "272127b3bd36f4d945d4d673b044e87842cf603bdef0f91e2407d8402041e5d2"
   },
-  "source_digest_sha256": "f2cb4d77187b075c6df8b49df349309ebea86c562f86c446c4b2a02354c5816c",
+  "source_digest_sha256": "bd6789595db52e7f1a6300ae2dce195b26870f7e9fbf302b9c7647a9c12a594d",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "f2cb4d77187b075c6df8b49df349309ebea86c562f86c446c4b2a02354c5816c"
+  "target_digest_sha256": "bd6789595db52e7f1a6300ae2dce195b26870f7e9fbf302b9c7647a9c12a594d"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,10 +50,13 @@ through the local Streamlit UI, a hosted Hugging Face backend, or browser-native
 If the local first proof fails, use :doc:`newcomer-troubleshooting` before
 branching into cluster mode, external app repositories, or broader workflows.
 
-For release-level evidence, use :doc:`release-proof`; it points to the
-`latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.31>`__,
-package proof, CI guardrails, and hosted demo status.
+For release-level evidence, use :doc:`release-proof` for the currently
+published version, package proof, CI guardrails, and hosted demo status.
+
+The `latest public GitHub release
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07>`__ link is
+prepared for this source version. Until publication completes, use the
+verified release links in :doc:`release-proof`.
 
 This documentation then expands into architecture, service mode, API
 references, and example projects.

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -775,18 +775,22 @@ def test_docs_index_links_to_release_matching_source_state() -> None:
 
     linked_url, linked_tag = links[0]
     relation = release["source_version_relation"]
-    # Advancing the checkout does not publish a release. The landing page must
-    # keep linking to the published release recorded by the evidence manifest.
-    assert linked_url == LATEST_RELEASE_URL
-    published_version = Version(release["package_version"])
-    assert Version(linked_tag.removeprefix("v").replace("_", ".")) == published_version
     source_version = Version(source["project"]["version"])
+    published_version = Version(release["package_version"])
+    linked_version = Version(linked_tag.removeprefix("v").replace("_", "."))
     if relation == "exact":
-        assert source_version == published_version
+        assert linked_url == LATEST_RELEASE_URL
+        assert linked_version == source_version == published_version
         return
 
+    # Source docs prepare the release target; the proof keeps the published
+    # version until publication. The landing page must make that distinction.
     assert relation == "ahead"
     assert source_version > published_version
+    assert linked_url != LATEST_RELEASE_URL
+    assert linked_version == source_version
+    assert "prepared for this source version" in text
+    assert "currently" in text and "published version" in text
 
 
 def test_public_docs_expose_three_clear_adoption_routes() -> None:


### PR DESCRIPTION
The source documentation now prepares the v2026.09.07 release link required by the publishing workflow. It explicitly directs readers to release-proof for the currently published version and evidence until publication completes.

## Repro

The first Learning and Assessment publication run stopped at “Validate managed docs release tag before publication”: the source index still targeted v2026.07.31.

## Root Cause

The source-ahead documentation test had conflated the prepared source release target with the version recorded in published release evidence. The existing release workflow requires the source target to be prepared before upload.

## Regression Test

- 312 publishing, documentation-link, release-proof, and mirror tests pass; two filesystem-dependent mirror tests skip on this macOS filesystem.
- The exact publishing-workflow release-link assertion passes for v2026.09.07.
- Targeted Ruff and the complete local documentation workflow, including Sphinx, pass. All required GitHub checks pass on b1b60766a4c518500a694d85ec97604f5f8e9f74; the hosted public-demo smoke was skipped by GitHub.
- The canonical private source is committed as jpmorard/thales_agilab@75e477c and its public mirror stamp is refreshed.
- Published release-proof data stays on the verified v2026.07.31 release until publication. The publishing gate itself is unchanged.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex CLI 0.153.4
- Model: GPT-6
- Reasoning effort: unknown
- /fast mode: unknown
- Sub-agents: not used
- Review: no stronger model is available in this environment; local review and regression validation completed.
