### PR TITLE
fix(tests): unblock release dependency preflight

### DIFF
--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -21,6 +21,7 @@ if str(SRC_PACKAGE) not in _agilab_package.__path__:
     _agilab_package.__path__.insert(0, str(SRC_PACKAGE))
 
 from package_split_contract import (  # noqa: E402
+    APP_PROJECT_PACKAGE_SPECS,
     PACKAGE_NAMES,
     ROOT_EXTRA_INTERNAL_REQUIREMENTS,
     is_self_extra_alias,
@@ -685,8 +686,6 @@ def test_shared_core_runtime_dependencies_are_not_copied_meta_stacks() -> None:
 
 
 def test_promoted_app_packages_depend_on_runtime_pair_not_core_bundle() -> None:
-    from tools.package_split_contract import APP_PROJECT_PACKAGE_SPECS
-
     # Compatibility distributions forward to a full app package; only app
     # payload providers own the runtime pair directly.
     package_pyprojects = sorted(


### PR DESCRIPTION
The Learning & Assessment release stopped in dependency-policy preflight because a test imported `tools.package_split_contract` even though the module bootstraps `tools/` directly on `sys.path`. Import `APP_PROJECT_PACKAGE_SPECS` with the existing top-level `package_split_contract` imports so the console-script pytest invocation works without the repository root on the import path.

## Repro

Release run [34141096985](https://github.com/ThalesGroup/agilab/actions/runs/34141096985) failed in `test_promoted_app_packages_depend_on_runtime_pair_not_core_bundle` with `ModuleNotFoundError: No module named 'tools'`. The exact local workflow profile reproduced the same failure before this change.

## Root Cause

The nested import used a different package namespace from the test module's existing import bootstrap. Invoking pytest as a console script exposed the mismatch.

## Regression Test

- `UV_PROJECT_ENVIRONMENT=.venv-dev uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy`: 29 passed after the fix.
- Targeted Ruff and `git diff --check`: passed.
- Nearby package-contract tests use the same direct-module import convention.
- Existing regression assertions and dependency policy remain unchanged.
- Scope, impact, agent provenance, and pre-push checks passed.
- All required GitHub checks passed on `4952b77`, including root-tests and Windows core tests. The public-demo smoke was skipped by GitHub.
- Release wheel checks: all four selected wheels build with `python -m build --installer uv`; their internal dependency metadata is consistent. Packaged first-proof runs successfully outside the checkout.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex CLI 0.153.4
- Model: GPT-6
- Reasoning effort: unknown
- /fast mode: unknown
- Sub-agents: not used
- Review: no stronger model is available in this environment; local diff review and regression validation completed.
