### PR TITLE
fix(proof): configure local Streamlit probes in fresh clones

### DIFF
--- a/test/test_newcomer_first_proof.py
+++ b/test/test_newcomer_first_proof.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -36,6 +37,68 @@ def test_build_proof_commands_defaults_to_preinit_and_ui_smoke() -> None:
     assert "AppTest.from_file" in commands[2].argv[-1]
     assert str(module.DEFAULT_ACTIVE_APP) in commands[2].argv[-1]
 
+
+
+@pytest.mark.parametrize(
+    ("page_code", "expected_returncode", "expected_message"),
+    [
+        pytest.param(
+            "import streamlit as st\n"
+            "from agilab.ui_public_bind_guard import enforce_public_bind_policy_or_stop\n"
+            "enforce_public_bind_policy_or_stop(st)\n"
+            'st.session_state["env"] = "proof-env"\n',
+            0,
+            "newcomer-ui-smoke: OK",
+            id="inherited-public-address",
+        ),
+        pytest.param(
+            "import streamlit as st\n"
+            'st.error("UI smoke stopped at the setup guard")\n'
+            "st.stop()\n",
+            1,
+            "UI smoke stopped at the setup guard",
+            id="rendered-stop-diagnostic",
+        ),
+    ],
+)
+def test_ui_smoke_subprocess_is_local_and_reports_stopped_pages(
+    tmp_path: Path,
+    monkeypatch,
+    page_code: str,
+    expected_returncode: int,
+    expected_message: str,
+) -> None:
+    pytest.importorskip("streamlit")
+    module = _load_module()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    page_root = tmp_path / "src" / "agilab"
+    (page_root / "pages").mkdir(parents=True)
+    (page_root / "main_page.py").write_text(page_code, encoding="utf-8")
+    (page_root / "pages" / "2_ORCHESTRATE.py").write_text(
+        "import streamlit as st\n"
+        'assert st.session_state["env"] == "proof-env"\n',
+        encoding="utf-8",
+    )
+    command = module._ui_smoke_command(tmp_path / "apps" / "proof_project")
+    env = {**os.environ, "STREAMLIT_SERVER_ADDRESS": "0.0.0.0"}
+    env.pop("AGILAB_PUBLIC_BIND_OK", None)
+    env.update(command.env)
+    source_root = str(MODULE_PATH.parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in (source_root, env.get("PYTHONPATH", "")) if path
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", command.argv[-1]],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    output = completed.stdout + completed.stderr
+    assert completed.returncode == expected_returncode, output
+    assert expected_message in output
 
 def test_build_proof_commands_with_install_adds_install_and_seed_checks() -> None:
     module = _load_module()

--- a/test/test_source_clone_regression.py
+++ b/test/test_source_clone_regression.py
@@ -443,6 +443,10 @@ import sys
 from types import SimpleNamespace
 
 from agi_env import AgiEnv
+from streamlit import config as streamlit_config
+
+# Import the editor page under the same local UI contract as the AppTest probes.
+streamlit_config.set_option("server.address", "127.0.0.1")
 
 root = Path.cwd()
 marker = "NOTEBOOK_IMPORT_RELEASE_SMOKE"
@@ -595,7 +599,11 @@ import tomllib
 
 from agi_cluster.agi_distributor import AGI, RunRequest
 from agi_env import AgiEnv
+from streamlit import config as streamlit_config
 from streamlit.testing.v1 import AppTest
+
+# This subprocess exercises pages through AppTest without a server bootstrap.
+streamlit_config.set_option("server.address", "127.0.0.1")
 
 root = Path.cwd()
 marker = "NOTEBOOK_IMPORT_EXECUTE_ANALYSIS_SMOKE"

--- a/tools/newcomer_first_proof.py
+++ b/tools/newcomer_first_proof.py
@@ -238,7 +238,11 @@ def _ui_smoke_code(active_app: Path) -> str:
         f"""
         import sys
         from pathlib import Path
+        from streamlit import config as streamlit_config
         from streamlit.testing.v1 import AppTest
+
+        # AppTest does not run the CLI configuration bootstrap.
+        streamlit_config.set_option("server.address", "127.0.0.1")
 
         about_page = Path({str(about_page)!r})
         orchestrate_page = Path({str(orchestrate_page)!r})
@@ -253,7 +257,13 @@ def _ui_smoke_code(active_app: Path) -> str:
             raise AssertionError(f"Main page exceptions: {{about_errors}}")
 
         if "env" not in about.session_state:
-            raise AssertionError("Main page did not initialise AgiEnv in session_state.")
+            rendered_errors = " | ".join(str(item.value) for item in about.error)
+            omitted_chars = max(0, len(rendered_errors) - 1000)
+            raise AssertionError(
+                "Main page did not initialise AgiEnv in session_state. "
+                f"Rendered errors: {{rendered_errors[:1000] or 'none'}} "
+                f"(rendered_error_omitted_chars={{omitted_chars}})."
+            )
 
         env = about.session_state["env"]
         orchestrate = AppTest.from_file(str(orchestrate_page), default_timeout=90)


### PR DESCRIPTION
Fresh-clone release proof stopped before the main page initialized AgiEnv because its AppTest subprocess had no effective local Streamlit address. Configure `server.address=127.0.0.1` inside the proof subprocesses, including notebook import and ANALYSIS probes. When a page stops before initialization, include its rendered errors in the diagnostic, capped at 1,000 characters with an omitted-character count.

## Repro

[Release run 34144539732](https://github.com/ThalesGroup/agilab/actions/runs/34144539732) passed dependency policy, then failed the fresh-clone proof with “Main page did not initialise AgiEnv in session_state.” Two small subprocess regressions reproduced the missing initialization and missing stop diagnostic.

## Root Cause

The pytest configuration fixture applies to the parent process. AppTest subprocesses do not run the Streamlit CLI configuration bootstrap; setting an environment variable alone left the effective address unset in the reproduced launch. The UI security guard correctly rejected the resulting public bind. The notebook editor import and ANALYSIS probe had the same configuration assumption.

The fix configures the test processes explicitly. Runtime UI pages and the security guard are unchanged.

## Regression Test

- Targeted proof/helper tests: 21 passed; the one slow fresh-clone test is run separately through the release-proof profile.
- The new real-AppTest subprocess tests cover an inherited public-address environment and a page stopped with a rendered error.
- Targeted Ruff, diff whitespace, scope, impact, and commit provenance checks passed.
- `UV_PROJECT_ENVIRONMENT=.venv-dev uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile release-proof`: passed.
- GitHub checks: all 7 required checks passed on `2936807b1db51fe1f3994aa1fe6f51f572b4af95`, including root-tests, both Python compatibility checks, and clean-public-install on Linux, macOS, and Windows. Windows core tests and GitGuardian also passed.
- `public-demo-smoke`: GitHub skipped; not applicable to this proof-subprocess-only change.

## Review Evidence

Local diff review by GPT-6 found no additional issue. No stronger model is available in this environment. No sub-agents were used.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex CLI 0.153.4
- Model: GPT-6
- Reasoning effort: unknown
- /fast mode: unknown

## Merge Status

All seven required checks passed on `2936807b1db51fe1f3994aa1fe6f51f572b4af95`. Normal squash merge is rejected because GitHub reports `UNKNOWN_KEY` for the head signature, although the SSH signing key is registered. On 2026-09-07, the publishing owner explicitly authorized a one-time administrator squash merge of PR #980 to resume the pending Learning & Assessment publication. The merge is pinned to that checked head. Repository signature rules remain enabled.

## Publication Follow-through

Merged as `5d60124b8699803198fd692969328dce262083b3` with the explicitly approved one-time administrator exception. The complete local `./dev release` passed from a clean isolated clone using committed canonical docs and the declared first-publication exception. [Release run 34148757505](https://github.com/ThalesGroup/agilab/actions/runs/34148757505) passed audit, plan, Python 3.13 tests (including fresh-clone first-proof and notebook import/export), release evidence, supply-chain evidence, and all four package builds.

The publishing owner authorized a one-time release approval exception on 2026-09-08. The original required reviewer team, self-review restriction, and deployment branch policies were restored and verified immediately after approval. All four scoped packages (`agi-app-learning-assessment`, `agi-app-tescia-diagnostic`, `agi-apps`, `agilab`) are public on PyPI at 2026.9.7. A clean public install with the transition package and packaged `first-proof` passed. [GitHub Release v2026.09.07](https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07) contains 20 assets, and the release-status verifier passed with zero PyPI failures. The release tag is pinned to the checked merge SHA.

Attempt 2 recovered GitHub Release asset publication after the publishing owner created the protected tag using existing authority. Hugging Face deployment and hosted validation passed at commit `c102870edcb18d51d8c5225c13b2ae90357f4c7a`. The final `publish-release-proof` job remains failed: its review branch starts from current main, where PR #981 changed the docs index URL to `/releases/latest`, while `assert_public_docs_index_release_link` accepts only a pinned release tag. A read-only local reproduction fails on current main and passes on the validated release source. This shared release-tool compatibility issue needs a separately scoped correction; immutable proof assets and the follow-up proof PR are not yet published.

The separate tag-triggered run 34198861067 ended before cancellation could take effect: its audit rejected the tagged checkout for being behind newer main by one commit. All publication jobs in that duplicate run were skipped. It did not republish packages.
