### PR TITLE
docs: correct publication status and latest-release link

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
     "release-proof.rst": "272127b3bd36f4d945d4d673b044e87842cf603bdef0f91e2407d8402041e5d2"
   },
-  "source_digest_sha256": "bd6789595db52e7f1a6300ae2dce195b26870f7e9fbf302b9c7647a9c12a594d",
+  "source_digest_sha256": "dcfdaf2b4ee2a25f40848dea46758c77d97e99a949a485f171217307996fb245",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "bd6789595db52e7f1a6300ae2dce195b26870f7e9fbf302b9c7647a9c12a594d"
+  "target_digest_sha256": "dcfdaf2b4ee2a25f40848dea46758c77d97e99a949a485f171217307996fb245"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,10 +53,8 @@ branching into cluster mode, external app repositories, or broader workflows.
 For release-level evidence, use :doc:`release-proof` for the currently
 published version, package proof, CI guardrails, and hosted demo status.
 
-The `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07>`__ link is
-prepared for this source version. Until publication completes, use the
-verified release links in :doc:`release-proof`.
+Download published assets from the `latest public GitHub release
+<https://github.com/ThalesGroup/agilab/releases/latest>`__.
 
 This documentation then expands into architecture, service mode, API
 references, and example projects.

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -17,10 +17,11 @@ The same reuse catalog also covers analysis views, so notebook-first work can
 discover both an existing app project and an existing visualization before it
 turns into a new maintained surface.
 
-Status legend:
+Package route legend:
 
-- ``PyPI app package``: promoted by the current release plan and installable as
-  a standalone ``agi-app-*`` payload.
+- ``PyPI app package``: selected by the current release plan for standalone
+  ``agi-app-*`` distribution. Installation requires a published package;
+  entries awaiting their first publication are marked below.
 - ``Release artifact``: built as an app payload artifact, but not currently
   promoted to PyPI by the release plan.
 - ``Source built-in``: present in the public source checkout for development,
@@ -32,7 +33,7 @@ Status legend:
 
    * - Project
      - Package
-     - Status
+     - Package route
      - When to use it
    * - ``flight_telemetry_project``
      - ``agi-app-flight-telemetry``
@@ -97,7 +98,9 @@ Status legend:
    * - ``learning_assessment_project``
      - ``agi-app-learning-assessment``
      - PyPI app package
-     - Learning & Assessment: evidence-scored diagnostic and self-evaluation
+     - **Not yet published on PyPI.** Use this app from the source checkout
+       until its first package release. Learning & Assessment provides
+       evidence-scored diagnostic and self-evaluation
        cases, including the original TeSciA collection, with 2026 math
        coverage, a 12-case 2026 data-scientist interview evaluation spanning
        modern ML, RAG, agents, LLM evaluation, uncertainty, and token-cost

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -760,37 +760,18 @@ def test_changelog_documents_current_public_release() -> None:
     assert "create or update the" in changelog
 
 
-def test_docs_index_links_to_release_matching_source_state() -> None:
+def test_docs_index_links_to_latest_published_release() -> None:
     text = Path("docs/source/index.rst").read_text(encoding="utf-8")
-    release = _release_proof_manifest()["release"]
-    source = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     links = re.findall(
         r"`latest public GitHub release\s*"
-        r"<(https://github\.com/ThalesGroup/agilab/releases/tag/(v[^>]+))>`__",
+        r"<(https://github\.com/ThalesGroup/agilab/releases/[^>]+)>`__",
         text,
     )
 
-    assert "latest public GitHub release" in text
-    assert len(links) == 1
-
-    linked_url, linked_tag = links[0]
-    relation = release["source_version_relation"]
-    source_version = Version(source["project"]["version"])
-    published_version = Version(release["package_version"])
-    linked_version = Version(linked_tag.removeprefix("v").replace("_", "."))
-    if relation == "exact":
-        assert linked_url == LATEST_RELEASE_URL
-        assert linked_version == source_version == published_version
-        return
-
-    # Source docs prepare the release target; the proof keeps the published
-    # version until publication. The landing page must make that distinction.
-    assert relation == "ahead"
-    assert source_version > published_version
-    assert linked_url != LATEST_RELEASE_URL
-    assert linked_version == source_version
-    assert "prepared for this source version" in text
-    assert "currently" in text and "published version" in text
+    # Source versions can advance before publication. Resolve the latest
+    # published assets without constructing a tag from the source version.
+    assert links == ["https://github.com/ThalesGroup/agilab/releases/latest"]
+    assert ":doc:`release-proof`" in text
 
 
 def test_public_docs_expose_three_clear_adoption_routes() -> None:


### PR DESCRIPTION
The documentation landing page linked to an unpublished release tag, and the app catalog described a package as installable before its first PyPI publication. Use GitHub's stable latest-release URL, clarify that catalog routes describe distribution intent, and mark Learning & Assessment as awaiting publication.

## Repro

At validation time, the source-version release link and the `agi-app-learning-assessment` PyPI endpoint returned 404.

## Root Cause

The docs inferred artifact availability from the source version and release plan before publication completed.

## Regression Test

Updated the existing landing-page regression to require `/releases/latest` independently of the source version. All 49 tests in `test/test_public_demo_links.py` pass. The docs workflow parity build, canonical mirror/stamp checks, and rendered homepage/catalog checks pass. Manual HTTP checks confirm that the stable release URL returns 200 and the new package is still unpublished.

GitHub skips `public-demo-smoke` on pull requests because that job runs only on schedule or manual dispatch. All required PR checks passed on aaf2daf02efa50b5347cdf578c703ad919f2accf, including the full root suite (GitHub run 34148845807). The Windows suite and repository verification also passed.

The docs build retains one pre-existing orphan-page warning in the unchanged inference-report license inventory. No stronger reviewer model was available; the diff was reviewed locally.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex; runtime version unavailable
- Model: GPT-6; exact runtime identifier unavailable
- Reasoning effort: unavailable
- /fast mode: unknown
