### PR TITLE
fix(release): preserve stable latest navigation in proof guards

### DIFF
--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -1895,8 +1895,9 @@ def test_public_release_reference_refresh_reseals_v3_public_owned_evidence(
     assert ok, message
 
 
+@pytest.mark.parametrize("release_path", ["tag/v2026.07.30", "latest"])
 def test_guard_release_refresh_does_not_rewrite_managed_docs_index(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, release_path
 ) -> None:
     module = _load_pypi_publish()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
@@ -1905,7 +1906,7 @@ def test_guard_release_refresh_does_not_rewrite_managed_docs_index(
     original = (
         "Canonical mirror content must remain unchanged.\n"
         "`latest public GitHub release\n"
-        "<https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.30>`__.\n"
+        f"<https://github.com/ThalesGroup/agilab/releases/{release_path}>`__.\n"
     )
     public_index.write_text(original, encoding="utf-8")
 
@@ -1998,7 +1999,38 @@ def test_guard_rejects_matching_historical_url_when_latest_link_is_stale(
         module.assert_public_docs_index_release_link("v2026.07.30")
 
 
-def test_replace_latest_release_url_updates_only_marker_bound_link() -> None:
+@pytest.mark.parametrize(
+    "release_paths",
+    [
+        (),
+        ("latest", "latest"),
+        ("latest", "tag/v2026.07.30"),
+        ("latest-extra",),
+        ("latest?tag=v2026.07.30",),
+    ],
+)
+def test_guard_rejects_missing_ambiguous_or_invalid_release_links(
+    tmp_path, monkeypatch, release_paths
+) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    public_index = tmp_path / "docs" / "source" / "index.rst"
+    public_index.parent.mkdir(parents=True)
+    public_index.write_text(
+        "".join(
+            "`latest public GitHub release\n"
+            f"<https://github.com/ThalesGroup/agilab/releases/{path}>`__.\n"
+            for path in release_paths
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="public docs index is not prepared"):
+        module.assert_public_docs_index_release_link("v2026.07.30")
+
+
+@pytest.mark.parametrize("release_path", ["tag/v2026.07.29", "latest"])
+def test_replace_latest_release_url_updates_only_marker_bound_link(release_path) -> None:
     module = _load_pypi_publish()
     historical_url = (
         "https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.28"
@@ -2006,16 +2038,19 @@ def test_replace_latest_release_url_updates_only_marker_bound_link() -> None:
     text = (
         f"Historical release: {historical_url}\n\n"
         "`latest public GitHub release\n"
-        "<https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.29>`__.\n"
+        f"<https://github.com/ThalesGroup/agilab/releases/{release_path}>`__.\n"
     )
     expected_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.30"
 
     updated = module._replace_latest_release_url(text, expected_url)
 
     assert historical_url in updated
-    assert (
-        "`latest public GitHub release\n" f"<{expected_url}>`__."
-    ) in updated
+    if release_path == "latest":
+        assert updated == text
+    else:
+        assert (
+            "`latest public GitHub release\n" f"<{expected_url}>`__."
+        ) in updated
 
 
 def test_update_docs_index_release_link_requires_canonical_docs_repo(tmp_path, monkeypatch) -> None:

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -352,9 +352,10 @@ PUBLIC_RELEASE_METADATA_PATHS: tuple[str, ...] = (
 GITHUB_RELEASE_URL_RE = re.compile(
     r"https://github\.com/ThalesGroup/agilab/releases/tag/v[0-9A-Za-z._-]+"
 )
+LATEST_PUBLIC_GITHUB_RELEASE_URL = "https://github.com/ThalesGroup/agilab/releases/latest"
 LATEST_PUBLIC_GITHUB_RELEASE_LINK_RE = re.compile(
     rf"(?P<prefix>`latest public GitHub release\s*<)"
-    rf"(?P<url>{GITHUB_RELEASE_URL_RE.pattern})"
+    rf"(?P<url>{GITHUB_RELEASE_URL_RE.pattern}|{re.escape(LATEST_PUBLIC_GITHUB_RELEASE_URL)})"
     r"(?P<suffix>>`__)"
 )
 
@@ -2356,6 +2357,9 @@ def _replace_latest_release_url(text: str, release_url: str) -> str:
         match = _latest_public_github_release_link(text)
     except ValueError as exc:
         raise SystemExit(f"ERROR: docs/source/index.rst {exc}") from exc
+    if match.group("url") == LATEST_PUBLIC_GITHUB_RELEASE_URL:
+        # The landing page may use stable navigation; release proof pins the tag.
+        return text
     return text[: match.start("url")] + release_url + text[match.end("url") :]
 
 
@@ -2364,7 +2368,8 @@ def _latest_public_github_release_link(text: str) -> re.Match[str]:
     if len(matches) != 1:
         raise ValueError(
             "must contain exactly one managed `latest public GitHub release "
-            "<https://github.com/ThalesGroup/agilab/releases/tag/v...>`__ link; "
+            "<https://github.com/ThalesGroup/agilab/releases/latest>`__ link "
+            "or its pinned /tag/v... form; "
             f"found {len(matches)}"
         )
     return matches[0]
@@ -2675,7 +2680,7 @@ def update_public_release_references(tag: str, chosen_version: str, package_name
 
 
 def assert_public_docs_index_release_link(tag: str) -> None:
-    """Require the managed public index to be canonically prepared for a release."""
+    """Accept stable release navigation or a link pinned to the intended tag."""
 
     public_index = REPO_ROOT / "docs/source/index.rst"
     release_url = github_release_url(tag)
@@ -2690,11 +2695,11 @@ def assert_public_docs_index_release_link(tag: str) -> None:
             "ERROR: public docs index is not prepared for the release tag: "
             f"{exc}"
         ) from exc
-    if managed_link.group("url") != release_url:
+    if managed_link.group("url") not in (release_url, LATEST_PUBLIC_GITHUB_RELEASE_URL):
         raise SystemExit(
             "ERROR: public docs index is not prepared for the release tag; update "
             "the canonical docs source and sync it before release metadata: "
-            f"expected {release_url} in {public_index}"
+            f"expected {release_url} or {LATEST_PUBLIC_GITHUB_RELEASE_URL} in {public_index}"
         )
 
 


### PR DESCRIPTION
The release-proof job failed after PR #981 changed the docs landing link to `/releases/latest`: the publication guard recognized only `/releases/tag/v...`. Accept the official stable navigation URL and preserve it during release refreshes. Pinned links must still match the intended tag, and missing, malformed, or duplicate supported links remain rejected. Release-proof evidence continues to pin the actual release tag independently.

## Repro

Release run [34148757505, attempt 2](https://github.com/ThalesGroup/agilab/actions/runs/34148757505/attempts/2) failed in `publish-release-proof` with `must contain exactly one managed ... link; found 0`. Its evidence branch starts from current main, which contains the new stable docs URL. The same read-only guard passes on the original release source. The new regressions produced three failures before the fix, covering stable-link validation, preservation, and mixed duplicate links.

## Root Cause

The marker-bound URL parser only accepted tagged release URLs. That conflated the documentation navigation target with pinned publication evidence and made the guard incompatible with the current docs contract. The canonical-link updater shared the parser and needed to preserve the stable navigation form too.

## Regression Test

201 tests passed across `test/test_pypi_publish.py`, `test/test_pypi_publish_workflow.py`, and `test/test_public_demo_links.py`, using the isolated release validation environment:

```bash
uv --preview-features extra-build-dependencies run python -m pytest --import-mode=importlib -q -o addopts='' test/test_pypi_publish.py test/test_pypi_publish_workflow.py test/test_public_demo_links.py
```

The current docs index also passes `assert_public_docs_index_release_link("v2026.09.07")` with the fix. Staged impact analysis reports low risk; scoped staging, whitespace validation, and agent commit provenance passed. All seven required GitHub checks passed on commit 256a267153fff373283437147cfb0e835b895ec2, including root-tests. The additional Windows core, lock verification, and GitGuardian checks passed. public-demo-smoke was GitHub skipped; this release-tool-only diff does not change the demo surface. Path-based pre-push docs, release-proof, agent-instruction, app-contract, and protected-core checks were not applicable because their classified inputs did not change. No local guard was bypassed.

## Merge Status

All required checks passed. Normal squash merge was blocked by the main branch policy because GitHub reported the head commit signature as unverified (`unknown_key`), and the active ruleset requires verified signatures. On 2026-09-08, the user explicitly authorized an administrative squash merge exception limited to PR #982, followed by retrying only the failed publish-release-proof job of release run 34148757505. All seven required checks passed on head 256a267153fff373283437147cfb0e835b895ec2 before this exception. The authorized administrative squash merge completed at 2026-09-08T08:06:37Z as 8132c498cdbb7eda95383ead55d32c3de19c087a. Repository rules remain enabled. Only the failed proof job was retried in release run attempt 3, which succeeded: https://github.com/ThalesGroup/agilab/actions/runs/34148757505/attempts/3 . Published TOML/RST checksums and the TOML GitHub attestation verified. The job opened docs PR #983. Post-run inspection found a separate pre-existing evidence-binding defect: the new release proof retains the PyPI CI row for run 30616241713 (2026-07-31), rather than run 34148757505. The navigation fix is complete; the evidence-binding repair needs separate shared-tool approval.

## Shared Tool Approval

On 2026-09-08, the user explicitly approved this release-tool repair in `tools/pypi_publish.py` with the regression in `test/test_pypi_publish.py`. The affected contract is release navigation validation and canonical link refresh; no package runtime code changes. After merge, rerun only the failed proof job of the original release workflow. The four PyPI packages, GitHub Release assets, and hosted Hugging Face deployment are already published.

## Review Evidence

- GPT-6 self-review: scoped diff checked; stable navigation remains unchanged, tagged URLs retain exact-version checks, and duplicate stable/tagged markers are rejected.
- No sub-agents were used.

## Agent Metadata

- Tokki: 1.0.63 (authenticated protected runtime).
- Agent/runtime: Codex API session; runtime version unavailable.
- Model: GPT-6.
- Reasoning effort: unknown.
- `/fast` mode: unknown.
