### PR TITLE
fix(proof): bind release evidence to publication attempts

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -28,6 +28,12 @@ on:
           - hotfix
           - candidate
           - repair
+      proof_publication_run:
+        description: "Proof repair only: exact successful publication run/attempt, for example 34148757505/3. Requires release_mode=repair."
+        required: false
+      proof_hf_space_commit:
+        description: "Proof repair only: immutable HF commit already validated by that publication."
+        required: false
       include_existing_pypi:
         description: "Include package versions that already exist on PyPI to repair release assets. Default skips them."
         required: false
@@ -1079,7 +1085,7 @@ jobs:
   # releases, attestations, and workflow dispatches. The immutable HF commit is
   # the only value crossing this credential boundary.
   publish-release-proof:
-    if: ${{ always() && needs.release-approval.result == 'success' && needs.sync-hf-space.result == 'success' }}
+    if: ${{ always() && needs.release-approval.result == 'success' && (needs.sync-hf-space.result == 'success' || github.event.inputs.proof_publication_run != '') }}
     needs:
       - release-approval
       - release-plan
@@ -1119,9 +1125,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HF_SPACE_COMMIT: ${{ needs.sync-hf-space.outputs.hf_space_commit }}
+          PROOF_PUBLICATION_RUN: ${{ github.event.inputs.proof_publication_run || '' }}
+          PROOF_HF_SPACE_COMMIT: ${{ github.event.inputs.proof_hf_space_commit || '' }}
+          RELEASE_MODE: ${{ github.event.inputs.release_mode || 'stable' }}
+          PYPI_PUBLISH_SELECTED: ${{ needs.release-plan.outputs.pypi_publish_selected }}
         run: |
           set -euo pipefail
           hf_commit="${HF_SPACE_COMMIT}"
+          publication_run_id="$GITHUB_RUN_ID"
+          publication_attempt="$GITHUB_RUN_ATTEMPT"
+          if [ -n "$PROOF_PUBLICATION_RUN" ]; then
+            if [ "$RELEASE_MODE" != repair ] || [ "$PYPI_PUBLISH_SELECTED" != false ]; then
+              echo "Proof repair requires release_mode=repair with no selected PyPI distributions." >&2
+              exit 2
+            fi
+            if [[ ! "$PROOF_PUBLICATION_RUN" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]]; then
+              echo "Proof publication run must be a positive run ID/attempt pair." >&2
+              exit 2
+            fi
+            publication_run_id="${PROOF_PUBLICATION_RUN%/*}"
+            publication_attempt="${PROOF_PUBLICATION_RUN#*/}"
+            hf_commit="$PROOF_HF_SPACE_COMMIT"
+          elif [ -n "$PROOF_HF_SPACE_COMMIT" ]; then
+            echo "An HF proof override requires an explicit publication run repair." >&2
+            exit 2
+          fi
           if [[ ! "$hf_commit" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid Hugging Face commit: expected a 40-character lowercase SHA." >&2
             exit 2
@@ -1159,6 +1187,8 @@ jobs:
 
           python tools/release_proof_report.py \
             --refresh-from-local \
+            --publication-run-id "$publication_run_id" \
+            --publication-run-attempt "$publication_attempt" \
             --github-release-tag "$release_tag" \
             --github-release-url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${release_tag}" \
             --hf-space-commit "$hf_commit" \
@@ -1180,17 +1210,18 @@ jobs:
           )
 
           release_version="${release_tag#v}"
+          proof_basename="agilab-${release_version}-release-proof-run-${publication_run_id}-attempt-${publication_attempt}"
           mkdir -p release-proof-assets
           cp docs/source/data/release_proof.toml \
-            "release-proof-assets/agilab-${release_version}-release-proof.toml"
+            "release-proof-assets/${proof_basename}.toml"
           cp docs/source/release-proof.rst \
-            "release-proof-assets/agilab-${release_version}-release-proof.rst"
+            "release-proof-assets/${proof_basename}.rst"
           (
             cd release-proof-assets
             shasum -a 256 \
-              "agilab-${release_version}-release-proof.toml" \
-              "agilab-${release_version}-release-proof.rst" \
-              > "agilab-${release_version}-release-proof-SHA256SUMS.txt"
+              "${proof_basename}.toml" \
+              "${proof_basename}.rst" \
+              > "${proof_basename}-SHA256SUMS.txt"
           )
 
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
@@ -1248,7 +1279,7 @@ jobs:
           cat > release-evidence-pr.md <<EOF
           ## Summary
 
-          - record the final Hugging Face Space commit for release ${RELEASE_VERSION}
+          - record the final Hugging Face Space commit and exact publication workflow attempt for release ${RELEASE_VERSION}
           - refresh the public release-proof manifest, rendered page, badge, and mirror integrity stamp
           - preserve review and required-check enforcement instead of writing directly to main
 

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -317,6 +317,25 @@ jobs:
       pypi_existing_packages: ${{ steps.release-plan.outputs.pypi_existing_packages }}
       provenance_packages: ${{ steps.release-plan.outputs.provenance_packages }}
     steps:
+      - name: Validate proof repair inputs
+        if: ${{ github.event.inputs.proof_publication_run || github.event.inputs.proof_hf_space_commit }}
+        env:
+          PROOF_PUBLICATION_RUN: ${{ github.event.inputs.proof_publication_run || '' }}
+          PROOF_HF_SPACE_COMMIT: ${{ github.event.inputs.proof_hf_space_commit || '' }}
+          RELEASE_MODE: ${{ github.event.inputs.release_mode || 'stable' }}
+          INCLUDE_EXISTING_PYPI: ${{ github.event.inputs.include_existing_pypi || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEASE_MODE" != repair ] || [ "$INCLUDE_EXISTING_PYPI" != false ]; then
+            echo "Proof repair requires release_mode=repair and include_existing_pypi=false before release planning." >&2
+            exit 2
+          fi
+          if [[ ! "$PROOF_PUBLICATION_RUN" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]] || \
+             [[ ! "$PROOF_HF_SPACE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Proof repair requires an exact publication run/attempt and a validated HF commit." >&2
+            exit 2
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1182,6 +1201,7 @@ jobs:
               release_tag,
               chosen_version,
               package_names,
+              refresh_proof=False,
           )
           PY
 

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -4166,3 +4166,30 @@ def test_main_resets_release_files_only_when_publish_fails(tmp_path, monkeypatch
         raise AssertionError("main() should propagate upload failures")
 
     assert reset_calls == ["reset"]
+
+
+def test_guard_can_prepare_metadata_before_exact_publication_proof(tmp_path, monkeypatch):
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    index = tmp_path / "docs" / "source" / "index.rst"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        "`latest public GitHub release\n"
+        "<https://github.com/ThalesGroup/agilab/releases/latest>`__.\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(module, "update_static_badge", lambda *args: calls.append("badge"))
+    monkeypatch.setattr(module, "update_changelog_release_entry", lambda *args: calls.append("changelog"))
+    monkeypatch.setattr(
+        module, "update_release_proof_references_in_source",
+        lambda *args: pytest.fail("proof must wait for the exact publication identity"),
+    )
+    monkeypatch.setattr(
+        module, "update_public_docs_mirror_stamp_from_current_tree",
+        lambda: pytest.fail("mirror stamp must wait for the completed proof"),
+    )
+    module.update_public_release_references_for_guard(
+        "v2026.09.07", "2026.09.07", ["agilab"], refresh_proof=False,
+    )
+    assert calls == ["badge", "changelog"]

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -420,7 +420,7 @@ def test_pypi_publish_syncs_hf_space_only_for_umbrella_release() -> None:
     assert 'hf_commit="${HF_SPACE_COMMIT}"' in text
     assert "Invalid Hugging Face commit" in text
     assert "PROVENANCE_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}" in text
-    assert "update_public_release_references_for_guard(" in text
+    assert "pypi_publish.update_public_release_references_for_guard(" in text
     assert "--hf-space-commit \"$hf_commit\"" in text
     assert "tools/sync_docs_source.py" in text
     assert "badges/pypi-version-agilab.svg" in text
@@ -684,3 +684,39 @@ def test_proof_repair_preflight_preserves_publication_boundary() -> None:
         "release-proof-run-${publication_run_id}-attempt-${publication_attempt}"
         in script
     )
+
+
+def test_proof_job_generates_once_after_preparing_release_metadata() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    step = next(
+        x for x in workflow["jobs"]["publish-release-proof"]["steps"]
+        if x.get("id") == "release-proof"
+    )
+    script = step["run"]
+    assert "refresh_proof=False" in script
+    assert script.count("python tools/release_proof_report.py") == 1
+    assert script.index("update_public_release_references_for_guard(") < script.index("python tools/release_proof_report.py")
+    assert script.index("--publication-run-attempt") < script.index("python tools/sync_docs_source.py")
+
+
+def test_invalid_proof_repair_is_rejected_before_release_planning() -> None:
+    import subprocess
+
+    jobs = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))["jobs"]
+    steps = jobs["release-plan"]["steps"]
+    assert steps[0]["name"] == "Validate proof repair inputs"
+    base = {
+        "PROOF_PUBLICATION_RUN": "123/3", "PROOF_HF_SPACE_COMMIT": "a" * 40,
+        "RELEASE_MODE": "repair", "INCLUDE_EXISTING_PYPI": "false",
+    }
+    for overrides in [
+        {"RELEASE_MODE": "stable"}, {"INCLUDE_EXISTING_PYPI": "true"},
+        {"PROOF_PUBLICATION_RUN": ""}, {"PROOF_PUBLICATION_RUN": "123/0"},
+        {"PROOF_HF_SPACE_COMMIT": ""}, {"PROOF_HF_SPACE_COMMIT": "../escape"}, {},
+    ]:
+        result = subprocess.run(
+            ["bash", "-c", steps[0]["run"]], env={**base, **overrides},
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == (2 if overrides else 0), result.stderr
+    assert "release-plan" in jobs["release-approval"]["needs"]

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -437,9 +437,9 @@ def test_pypi_publish_syncs_hf_space_only_for_umbrella_release() -> None:
     assert "gh workflow run ci.yml --ref \"$RELEASE_BRANCH\"" in text
     assert "gh workflow run root-test-suite.yml --ref \"$RELEASE_BRANCH\"" in text
     assert "gh workflow run docs-source-guard.yaml --ref \"$RELEASE_BRANCH\"" in text
-    assert "release-proof-assets/agilab-${release_version}-release-proof.toml" in text
-    assert "release-proof-assets/agilab-${release_version}-release-proof.rst" in text
-    assert "release-proof-SHA256SUMS.txt" in text
+    assert "release-proof-assets/${proof_basename}.toml" in text
+    assert "release-proof-assets/${proof_basename}.rst" in text
+    assert "${proof_basename}-SHA256SUMS.txt" in text
     assert "Existing immutable release asset differs" in text
     assert "subject-path: release-proof-assets/**" in text
 
@@ -600,3 +600,87 @@ def test_test_pypi_publish_uses_the_local_shortcut() -> None:
     assert "package_split_contract" in tool_text
     for package in PACKAGE_NAMES:
         assert package in contract_text
+
+
+def test_proof_repair_preflight_preserves_publication_boundary() -> None:
+    import os
+    import subprocess
+
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["publish-release-proof"]
+    assert "needs.release-approval.result == 'success'" in job["if"]
+    step = next(x for x in job["steps"] if x.get("id") == "release-proof")
+    script = step["run"]
+    preflight = script.split('release_tag="${RELEASE_TAG#refs/tags/}"', 1)[0]
+    preflight += (
+        'printf "%s/%s %s" "$publication_run_id" "$publication_attempt" "$hf_commit"\n'
+    )
+    base = {
+        "PATH": os.environ.get("PATH", ""),
+        "GITHUB_RUN_ID": "456",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "HF_SPACE_COMMIT": "a" * 40,
+        "PROOF_PUBLICATION_RUN": "",
+        "PROOF_HF_SPACE_COMMIT": "",
+        "RELEASE_MODE": "stable",
+        "PYPI_PUBLISH_SELECTED": "true",
+    }
+    cases = [
+        ({}, 0, "456/1 " + "a" * 40),
+        (
+            {
+                "PROOF_PUBLICATION_RUN": "123/3",
+                "PROOF_HF_SPACE_COMMIT": "b" * 40,
+                "RELEASE_MODE": "repair",
+                "PYPI_PUBLISH_SELECTED": "false",
+            },
+            0,
+            "123/3 " + "b" * 40,
+        ),
+        ({"PROOF_PUBLICATION_RUN": "123/3", "PROOF_HF_SPACE_COMMIT": "b" * 40}, 2, ""),
+        (
+            {
+                "PROOF_PUBLICATION_RUN": "123/3",
+                "PROOF_HF_SPACE_COMMIT": "b" * 40,
+                "RELEASE_MODE": "repair",
+            },
+            2,
+            "",
+        ),
+        (
+            {
+                "PROOF_PUBLICATION_RUN": "123/0",
+                "PROOF_HF_SPACE_COMMIT": "b" * 40,
+                "RELEASE_MODE": "repair",
+                "PYPI_PUBLISH_SELECTED": "false",
+            },
+            2,
+            "",
+        ),
+        (
+            {
+                "PROOF_PUBLICATION_RUN": "123/3",
+                "RELEASE_MODE": "repair",
+                "PYPI_PUBLISH_SELECTED": "false",
+            },
+            2,
+            "",
+        ),
+        ({"PROOF_HF_SPACE_COMMIT": "b" * 40}, 2, ""),
+    ]
+    for overrides, expected_code, expected_output in cases:
+        result = subprocess.run(
+            ["bash", "-c", preflight],
+            env={**base, **overrides},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == expected_code, (overrides, result.stderr)
+        assert result.stdout == expected_output
+    assert '--publication-run-id "$publication_run_id"' in script
+    assert '--publication-run-attempt "$publication_attempt"' in script
+    assert (
+        "release-proof-run-${publication_run_id}-attempt-${publication_attempt}"
+        in script
+    )

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -891,3 +891,291 @@ def test_release_proof_latest_successful_github_runs_filters_rows(monkeypatch) -
             head_sha="abc",
             limit=10,
         )
+
+
+def test_release_proof_rejects_successful_ci_from_another_release(
+    tmp_path, monkeypatch
+) -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    old_run = next(
+        row for row in manifest["ci_runs"] if row["workflow"] == "pypi-publish"
+    )
+    manifest["release"]["github_release_commit"] = "b" * 40
+    assert old_run["head_sha"] != manifest["release"]["github_release_commit"]
+    path = tmp_path / "release_proof.toml"
+    module.write_manifest(path, manifest)
+    report = module.build_report(manifest_path=path, output_path=tmp_path / "proof.rst")
+    check = next(row for row in report["checks"] if row["id"] == "publication_binding")
+    assert check["status"] == "fail"
+    assert "release commit" in check["summary"]
+    assert old_run["head_sha"] in check["details"]["failures"][0]
+
+
+def _publication_run_fixture():
+    return {
+        "databaseId": 123,
+        "attempt": 3,
+        "workflowName": "pypi-publish",
+        "headSha": "a" * 40,
+        "status": "completed",
+        "conclusion": "success",
+        "url": "https://github.com/ThalesGroup/agilab/actions/runs/123/attempts/3",
+        "createdAt": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "event": "workflow_dispatch",
+        "jobs": [
+            {"name": name, "status": "completed", "conclusion": "success"}
+            for name in [
+                "release-approval",
+                "publish-agilab",
+                "publish-release-assets",
+                "pypi-provenance-evidence",
+                "sync-hf-space",
+                "publish-release-proof",
+            ]
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "invalid", ["head", "workflow", "failed", "running", "attempt", "id"]
+)
+def test_publication_refresh_rejects_invalid_producer(monkeypatch, invalid) -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "a" * 40
+    run = _publication_run_fixture()
+    field, value = {
+        "head": ("headSha", "b" * 40),
+        "workflow": ("workflowName", "root-test-suite"),
+        "failed": ("conclusion", "failure"),
+        "running": ("status", "in_progress"),
+        "attempt": ("attempt", 2),
+        "id": ("databaseId", 456),
+    }[invalid]
+    run[field] = value
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: run)
+    monkeypatch.delenv("GITHUB_JOB", raising=False)
+    with pytest.raises(ValueError, match="publication"):
+        module.refresh_publication_run(
+            manifest, run_id="123", attempt="3", github_repo="ThalesGroup/agilab"
+        )
+
+
+def test_publication_refresh_pins_exact_successful_attempt(monkeypatch) -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "a" * 40
+    before = json.dumps(manifest, sort_keys=True)
+    seen = []
+
+    def fake_gh(args):
+        seen.append(args)
+        return _publication_run_fixture()
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh)
+    refreshed = module.refresh_publication_run(
+        manifest, run_id="123", attempt="3", github_repo="ThalesGroup/agilab"
+    )
+    row = next(x for x in refreshed["ci_runs"] if x["workflow"] == "pypi-publish")
+    assert (row["run_id"], row["attempt"], row["head_sha"]) == ("123", "3", "a" * 40)
+    assert row["url"].endswith("/runs/123/attempts/3")
+    assert module._ci_run_urls_are_consistent(refreshed["ci_runs"])
+    assert all(args[args.index("--attempt") + 1] == "3" for args in seen)
+    assert json.dumps(manifest, sort_keys=True) == before
+
+
+def _set_publication_producer(monkeypatch):
+    for key, value in {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_JOB": "publish-release-proof",
+        "GITHUB_REPOSITORY": "ThalesGroup/agilab",
+        "GITHUB_RUN_ID": "123",
+        "GITHUB_RUN_ATTEMPT": "3",
+        "GITHUB_SHA": "a" * 40,
+    }.items():
+        monkeypatch.setenv(key, value)
+
+
+@pytest.mark.parametrize(
+    "defect",
+    [None, "missing", "failed", "skipped", "pending", "foreign_attempt", "foreign_job"],
+)
+def test_active_publication_requires_own_job_and_finished_publishers(
+    monkeypatch, defect
+):
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "a" * 40
+    raw = _publication_run_fixture()
+    raw.update(status="in_progress", conclusion="")
+    raw["jobs"][-1].update(status="in_progress", conclusion="")
+    _set_publication_producer(monkeypatch)
+    if defect == "missing":
+        raw["jobs"] = [
+            x for x in raw["jobs"] if x["name"] != "pypi-provenance-evidence"
+        ]
+    elif defect in {"failed", "skipped", "pending"}:
+        raw["jobs"][1].update(
+            status="in_progress" if defect == "pending" else "completed",
+            conclusion={"failed": "failure", "skipped": "skipped", "pending": ""}[
+                defect
+            ],
+        )
+    elif defect == "foreign_attempt":
+        monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "4")
+    elif defect == "foreign_job":
+        monkeypatch.setenv("GITHUB_JOB", "unrelated-job")
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: raw)
+    if defect:
+        with pytest.raises(ValueError, match="publication"):
+            module.refresh_publication_run(
+                manifest, run_id="123", attempt="3", github_repo="ThalesGroup/agilab"
+            )
+        return
+    refreshed = module.refresh_publication_run(
+        manifest, run_id="123", attempt="3", github_repo="ThalesGroup/agilab"
+    )
+    row = next(x for x in refreshed["ci_runs"] if x["workflow"] == "pypi-publish")
+    check = module._github_ci_runs_check(
+        [row],
+        repo_root=Path.cwd(),
+        github_repo="ThalesGroup/agilab",
+        max_age_days=45,
+        release_commit="a" * 40,
+    )
+    assert check["status"] == "pass", check["details"]["failures"]
+    assert check["details"]["producer_workflow_in_progress"] is True
+    assert "still in progress" in check["summary"]
+
+
+def test_successful_workflow_without_publication_is_rejected(monkeypatch):
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "a" * 40
+    raw = _publication_run_fixture()
+    raw["jobs"] = [x for x in raw["jobs"] if x["name"] != "publish-agilab"]
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: raw)
+    with pytest.raises(ValueError, match="publication jobs"):
+        module.refresh_publication_run(
+            manifest, run_id="123", attempt="3", github_repo="ThalesGroup/agilab"
+        )
+
+
+def test_live_publication_check_rejects_consistent_old_success(monkeypatch):
+    module = _load_module()
+    raw = _publication_run_fixture()
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: raw)
+    row = {
+        "workflow": "pypi-publish",
+        "run_id": "123",
+        "attempt": "3",
+        "head_sha": "a" * 40,
+        "url": raw["url"],
+    }
+    check = module._github_ci_runs_check(
+        [row],
+        repo_root=Path.cwd(),
+        github_repo="ThalesGroup/agilab",
+        max_age_days=45,
+        release_commit="b" * 40,
+    )
+    assert check["status"] == "fail"
+    assert "release commit" in " ".join(check["details"]["failures"])
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_publication_refresh_cli_persists_exact_identity(
+    tmp_path, monkeypatch, explicit
+):
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "a" * 40
+    path = tmp_path / "proof.toml"
+    module.write_manifest(path, manifest)
+    monkeypatch.setattr(
+        module, "refresh_manifest_from_local", lambda data, **kwargs: data
+    )
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: _publication_run_fixture())
+    monkeypatch.setattr(module, "build_report", lambda **kwargs: {"status": "pass"})
+    argv = [
+        "--data",
+        str(path),
+        "--output",
+        str(tmp_path / "proof.rst"),
+        "--refresh-from-local",
+        "--check-github-runs",
+        "--github-repo",
+        "ThalesGroup/agilab",
+        "--render",
+        "--quiet",
+        "--check",
+    ]
+    if explicit:
+        monkeypatch.setenv("GITHUB_JOB", "unrelated-job")
+        argv += ["--publication-run-id", "123", "--publication-run-attempt", "3"]
+    else:
+        _set_publication_producer(monkeypatch)
+    assert module.main(argv) == 0
+    row = next(
+        x
+        for x in module.load_manifest(path)["ci_runs"]
+        if x["workflow"] == "pypi-publish"
+    )
+    assert (row["run_id"], row["attempt"], row["head_sha"]) == ("123", "3", "a" * 40)
+    assert "/runs/123/attempts/3" in (tmp_path / "proof.rst").read_text()
+
+
+def test_invalid_publication_refresh_does_not_write_manifest(tmp_path, monkeypatch):
+    module = _load_module()
+    path = tmp_path / "proof.toml"
+    shutil.copyfile(Path("docs/source/data/release_proof.toml"), path)
+    before = path.read_bytes()
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: _publication_run_fixture())
+    with pytest.raises(ValueError, match="release commit"):
+        module.main(
+            [
+                "--data",
+                str(path),
+                "--publication-run-id",
+                "123",
+                "--publication-run-attempt",
+                "3",
+                "--github-repo",
+                "ThalesGroup/agilab",
+            ]
+        )
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("matches_release", [False, True])
+def test_bulk_github_refresh_cannot_bypass_publication_binding(
+    monkeypatch, matches_release
+):
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = (
+        "a" if matches_release else "b"
+    ) * 40
+    monkeypatch.setattr(
+        module,
+        "_latest_successful_github_runs",
+        lambda **kwargs: {"pypi-publish": _publication_run_fixture()},
+    )
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: _publication_run_fixture())
+    if not matches_release:
+        with pytest.raises(ValueError, match="release commit"):
+            module.refresh_manifest_from_github(
+                manifest,
+                workflows=("pypi-publish",),
+                github_repo="ThalesGroup/agilab",
+            )
+    else:
+        refreshed = module.refresh_manifest_from_github(
+            manifest,
+            workflows=("pypi-publish",),
+            github_repo="ThalesGroup/agilab",
+        )
+        row = next(x for x in refreshed["ci_runs"] if x["workflow"] == "pypi-publish")
+        assert row["attempt"] == "3"
+        assert row["url"].endswith("/runs/123/attempts/3")

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -2707,14 +2707,16 @@ def update_public_release_references_for_guard(
     tag: str,
     chosen_version: str,
     package_names: list[str],
+    *,
+    refresh_proof: bool = True,
 ) -> None:
-    """Update only release metadata tracked in this repository for pre-upload tests."""
+    """Update release metadata; defer proof/stamp when the caller binds publication evidence."""
 
     assert_public_docs_index_release_link(tag)
     update_static_badge(static_badge_path(UMBRELLA[0]), chosen_version)
     update_changelog_release_entry(chosen_version, tag, package_names)
     public_source = REPO_ROOT / "docs/source"
-    if public_source.exists():
+    if public_source.exists() and refresh_proof:
         update_release_proof_references_in_source(tag, public_source)
         update_public_docs_mirror_stamp_from_current_tree()
 

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -8,6 +8,7 @@ import copy
 from datetime import UTC, datetime
 import importlib.util
 import json
+import os
 from pathlib import Path
 import re
 from string import Formatter
@@ -26,6 +27,7 @@ OUTPUT_RELATIVE_PATH = Path("release-proof.rst")
 SCHEMA = "agilab.release_proof.v1"
 GITHUB_RUN_FIELDS = (
     "databaseId",
+    "attempt",
     "workflowName",
     "headSha",
     "status",
@@ -813,6 +815,15 @@ def refresh_manifest_from_github(
         )
 
     refreshed["ci_runs"] = normalized_runs
+    if "pypi-publish" in runs:
+        publication = runs["pypi-publish"]
+        refreshed = refresh_publication_run(
+            refreshed,
+            run_id=_github_run_id(publication),
+            attempt=str(publication.get("attempt", "") or ""),
+            repo_root=repo_root,
+            github_repo=repo,
+        )
     return refreshed
 
 
@@ -896,6 +907,203 @@ def _changelog_section_has_release_url(section: str, release_url: str) -> bool:
     }
 
 
+def _publication_binding_check(
+    release: Mapping[str, Any], ci_runs: Sequence[Any]
+) -> dict[str, Any]:
+    rows = [
+        row
+        for row in ci_runs
+        if isinstance(row, Mapping) and row.get("workflow") == "pypi-publish"
+    ]
+    commit = str(release.get("github_release_commit", "") or "")
+    failures = []
+    if len(rows) != 1:
+        failures.append(f"expected one publication run, found {len(rows)}")
+    elif not commit or rows[0].get("head_sha") != commit:
+        failures.append(
+            f"publication run {rows[0].get('run_id')} records {rows[0].get('head_sha')}; "
+            f"expected release commit {commit or '<missing>'}"
+        )
+    return _check_result(
+        "publication_binding",
+        not failures,
+        "publication run must match the declared release commit",
+        evidence=[str(MANIFEST_RELATIVE_PATH)],
+        details={"release_commit": commit, "failures": failures},
+    )
+
+
+def _publication_run_args(repo: str, run_id: str, attempt: str) -> list[str]:
+    if (
+        not run_id.isdecimal()
+        or int(run_id) < 1
+        or not attempt.isdecimal()
+        or int(attempt) < 1
+    ):
+        raise ValueError("publication run ID and attempt must be positive integers")
+    return [
+        "run",
+        "view",
+        run_id,
+        "--repo",
+        repo,
+        "--attempt",
+        attempt,
+        "--json",
+        _github_json_fields() + ",jobs",
+    ]
+
+
+def _publication_jobs_succeeded(raw: Mapping[str, Any]) -> bool:
+    jobs = raw.get("jobs", [])
+    if not isinstance(jobs, list) or not jobs:
+        return False
+    if any(
+        not isinstance(job, Mapping) or not isinstance(job.get("name"), str)
+        for job in jobs
+    ):
+        return False
+    by_name = {job["name"]: job for job in jobs}
+    if len(by_name) != len(jobs):
+        return False
+    required = {
+        "release-approval",
+        "publish-release-assets",
+        "pypi-provenance-evidence",
+    }
+    if not required.issubset(by_name):
+        return False
+    succeeded = {
+        name
+        for name, job in by_name.items()
+        if job.get("status") == "completed" and job.get("conclusion") == "success"
+    }
+    return required.issubset(succeeded) and any(
+        name == "publish-agilab" or name.startswith("publish-library-packages (")
+        for name in succeeded
+    )
+
+
+def _active_publication_is_ready(
+    raw: Mapping[str, Any], *, repo: str, run_id: str, attempt: str, release_commit: str
+) -> bool:
+    # Only the exact proof-producing job may validate its already-finished
+    # publication prerequisites while its enclosing workflow is still active.
+    context = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_JOB": "publish-release-proof",
+        "GITHUB_REPOSITORY": repo,
+        "GITHUB_RUN_ID": run_id,
+        "GITHUB_RUN_ATTEMPT": attempt,
+        "GITHUB_SHA": release_commit,
+    }
+    if any(os.environ.get(key) != value for key, value in context.items()):
+        return False
+    if raw.get("status") != "in_progress" or raw.get("conclusion"):
+        return False
+    if not _publication_jobs_succeeded(raw):
+        return False
+    jobs = raw["jobs"]
+    by_name = {job["name"]: job for job in jobs}
+    required = {
+        "release-approval",
+        "publish-agilab",
+        "publish-release-assets",
+        "pypi-provenance-evidence",
+        "sync-hf-space",
+    }
+    if not required.issubset(by_name):
+        return False
+    if any(by_name[name].get("conclusion") != "success" for name in required):
+        return False
+    producer = by_name.get("publish-release-proof", {})
+    if producer.get("status") != "in_progress":
+        return False
+    return all(
+        job.get("status") == "completed"
+        and job.get("conclusion") in {"success", "skipped"}
+        for name, job in by_name.items()
+        if name != "publish-release-proof"
+    ) and len(by_name) == len(jobs)
+
+
+def _publication_run_failures(
+    raw: Mapping[str, Any], *, repo: str, run_id: str, attempt: str, release_commit: str
+) -> list[str]:
+    failures = []
+    if _github_run_id(raw) != run_id:
+        failures.append("publication run ID differs from GitHub")
+    if str(raw.get("attempt", "")) != attempt:
+        failures.append("publication attempt differs from GitHub")
+    if not _github_workflow_name_matches(
+        "pypi-publish", str(raw.get("workflowName", ""))
+    ):
+        failures.append("publication workflow is not pypi-publish")
+    if not release_commit or raw.get("headSha") != release_commit:
+        failures.append("publication run does not match the release commit")
+    expected_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+    if str(raw.get("url", "")) not in {
+        expected_url,
+        f"{expected_url}/attempts/{attempt}",
+    }:
+        failures.append("publication URL does not match the repository and run")
+    if not _publication_jobs_succeeded(raw):
+        failures.append("publication jobs are missing, skipped, or unsuccessful")
+    if not _github_run_is_success(raw) and not _active_publication_is_ready(
+        raw, repo=repo, run_id=run_id, attempt=attempt, release_commit=release_commit
+    ):
+        failures.append(
+            "publication workflow is not successful; active producer prerequisites are not complete"
+        )
+    return failures
+
+
+def refresh_publication_run(
+    manifest: Mapping[str, Any],
+    *,
+    run_id: str,
+    attempt: str,
+    repo_root: Path = REPO_ROOT,
+    github_repo: str | None = None,
+) -> dict[str, Any]:
+    repo = _resolve_github_repo(repo_root, github_repo)
+    raw = _run_gh_json(_publication_run_args(repo, run_id, attempt))
+    if not isinstance(raw, Mapping):
+        raise ValueError("publication run lookup did not return an object")
+    release_commit = str(
+        _required_table("release", manifest).get("github_release_commit", "") or ""
+    )
+    failures = _publication_run_failures(
+        raw, repo=repo, run_id=run_id, attempt=attempt, release_commit=release_commit
+    )
+    if failures:
+        raise ValueError("; ".join(failures))
+    refreshed = copy.deepcopy(dict(manifest))
+    ci_runs = _required_list("ci_runs", refreshed)
+    rows = [
+        row
+        for row in ci_runs
+        if isinstance(row, dict) and row.get("workflow") == "pypi-publish"
+    ]
+    if len(rows) > 1:
+        raise ValueError("publication evidence contains duplicate pypi-publish rows")
+    row = (
+        rows[0]
+        if rows
+        else {"id": "pypi-publish", "label": "PyPI publish", "workflow": "pypi-publish"}
+    )
+    if not rows:
+        ci_runs.append(row)
+    row.update(
+        run_id=run_id,
+        attempt=attempt,
+        head_sha=release_commit,
+        url=f"https://github.com/{repo}/actions/runs/{run_id}/attempts/{attempt}",
+        summary="publication workflow for the recorded release commit; see the linked attempt for its final result",
+    )
+    return refreshed
+
+
 def _ci_run_urls_are_consistent(ci_runs: Sequence[Any]) -> bool:
     for run in ci_runs:
         if not isinstance(run, Mapping):
@@ -903,9 +1111,12 @@ def _ci_run_urls_are_consistent(ci_runs: Sequence[Any]) -> bool:
         run_id = str(run.get("run_id", ""))
         url = str(run.get("url", ""))
         head_sha = str(run.get("head_sha", ""))
+        attempt = str(run.get("attempt", "") or "")
+        suffix = f"/actions/runs/{run_id}" + (f"/attempts/{attempt}" if attempt else "")
         if (
             not run_id
-            or not url.endswith(f"/actions/runs/{run_id}")
+            or not url.endswith(suffix)
+            or (attempt and (not attempt.isdecimal() or int(attempt) < 1))
             or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None
         ):
             return False
@@ -919,6 +1130,7 @@ def _github_ci_runs_check(
     github_repo: str | None,
     max_age_days: int,
     now: datetime | None = None,
+    release_commit: str | None = None,
 ) -> dict[str, Any]:
     checked_at = now or datetime.now(UTC)
     try:
@@ -934,6 +1146,7 @@ def _github_ci_runs_check(
 
     details: list[dict[str, Any]] = []
     failures: list[str] = []
+    active_producer = False
     for run in ci_runs:
         if not isinstance(run, Mapping):
             failures.append("malformed ci_runs entry")
@@ -943,9 +1156,12 @@ def _github_ci_runs_check(
         if not run_id:
             failures.append(f"{workflow or '<unknown>'}: missing run_id")
             continue
+        attempt = str(run.get("attempt", "") or "")
         try:
-            raw = _run_gh_json(
-                [
+            args = (
+                _publication_run_args(repo, run_id, attempt)
+                if workflow == "pypi-publish" and attempt
+                else [
                     "run",
                     "view",
                     run_id,
@@ -955,11 +1171,14 @@ def _github_ci_runs_check(
                     _github_json_fields(),
                 ]
             )
-        except RuntimeError as exc:
+            raw = _run_gh_json(args)
+        except (RuntimeError, ValueError) as exc:
             failures.append(f"{workflow or run_id}: {exc}")
             continue
         if not isinstance(raw, Mapping):
-            failures.append(f"{workflow or run_id}: gh run view did not return an object")
+            failures.append(
+                f"{workflow or run_id}: gh run view did not return an object"
+            )
             continue
 
         github_run = _normalize_github_run(raw)
@@ -970,12 +1189,33 @@ def _github_ci_runs_check(
             age_days = max((checked_at - created_at).total_seconds() / 86400, 0.0)
         run_failures: list[str] = []
         if not _github_workflow_name_matches(workflow, github_workflow):
-            run_failures.append(f"workflow mismatch: expected {workflow}, got {github_workflow}")
-        if not _github_run_is_success(raw):
+            run_failures.append(
+                f"workflow mismatch: expected {workflow}, got {github_workflow}"
+            )
+        if workflow == "pypi-publish" and attempt and release_commit is not None:
+            run_failures.extend(
+                _publication_run_failures(
+                    raw,
+                    repo=repo,
+                    run_id=run_id,
+                    attempt=attempt,
+                    release_commit=release_commit,
+                )
+            )
+            if not run_failures and raw.get("status") == "in_progress":
+                active_producer = True
+        elif not _github_run_is_success(raw):
             run_failures.append(
                 "run is not successful: "
                 f"status={github_run['status']} conclusion={github_run['conclusion']}"
             )
+        if workflow == "pypi-publish" and release_commit is not None:
+            if not release_commit or github_run["headSha"] != release_commit:
+                run_failures.append(
+                    "publication run differs from the declared release commit"
+                )
+        if _github_run_id(raw) != run_id:
+            run_failures.append("manifest run ID differs from GitHub")
         expected_url = str(run.get("url", "") or "")
         if expected_url and github_run["url"] and expected_url != github_run["url"]:
             run_failures.append("manifest URL differs from GitHub run URL")
@@ -987,7 +1227,9 @@ def _github_ci_runs_check(
         if age_days is None:
             run_failures.append("run createdAt timestamp is missing or invalid")
         elif age_days > max_age_days:
-            run_failures.append(f"run is stale: {age_days:.1f} days old > {max_age_days}")
+            run_failures.append(
+                f"run is stale: {age_days:.1f} days old > {max_age_days}"
+            )
 
         details.append(
             {
@@ -1010,7 +1252,11 @@ def _github_ci_runs_check(
         "github_ci_runs",
         not failures,
         (
-            "manifest CI runs exist on GitHub, succeeded, and are fresh"
+            (
+                "publication prerequisites succeeded; producer workflow is still in progress"
+                if active_producer
+                else "manifest CI runs exist on GitHub, succeeded, and are fresh"
+            )
             if not failures
             else "manifest CI runs are missing, failed, or stale on GitHub"
         ),
@@ -1018,6 +1264,7 @@ def _github_ci_runs_check(
         details={
             "repo": repo,
             "max_age_days": max_age_days,
+            "producer_workflow_in_progress": active_producer,
             "checked_at": checked_at.isoformat(),
             "runs": details,
             "failures": failures,
@@ -1233,6 +1480,8 @@ def build_report(
     dataset_count = release.get("dataset_count")
     checks: list[dict[str, Any]] = []
 
+    checks.append(_publication_binding_check(release, ci_runs))
+
     project_version = _load_project_version(repo_root)
     version_matches, version_summary, version_details = _source_version_check(
         release,
@@ -1435,6 +1684,7 @@ def build_report(
                 repo_root=repo_root,
                 github_repo=github_repo,
                 max_age_days=github_max_age_days,
+                release_commit=github_release_commit,
             )
         )
     output_matches = output_path.exists() and output_path.read_text(encoding="utf-8") == rendered
@@ -1549,6 +1799,16 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail if manifest CI run IDs are missing, failed, mismatched, or stale on GitHub.",
     )
+    parser.add_argument(
+        "--publication-run-id",
+        default=None,
+        help="Bind the PyPI evidence to this exact publication run (requires --publication-run-attempt).",
+    )
+    parser.add_argument(
+        "--publication-run-attempt",
+        default=None,
+        help="Exact publication workflow attempt.",
+    )
     parser.add_argument("--render", action="store_true", help="Write the rendered RST page.")
     parser.add_argument("--check", action="store_true", help="Fail if manifest checks or rendered page drift.")
     parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
@@ -1571,7 +1831,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             github_release_url=args.github_release_url,
             hf_space_commit=args.hf_space_commit,
         )
-        write_manifest(manifest_path, manifest)
     if args.refresh_from_github:
         manifest = refresh_manifest_from_github(
             manifest,
@@ -1582,6 +1841,35 @@ def main(argv: Sequence[str] | None = None) -> int:
             workflows=tuple(args.github_workflows or DEFAULT_GITHUB_WORKFLOWS),
             run_limit=args.github_run_limit,
         )
+    publication_run_id = args.publication_run_id
+    publication_attempt = args.publication_run_attempt
+    # An old release attempt reuses its original YAML but imports the current
+    # tool from main. Its explicit Actions job identity supports that recovery.
+    if (
+        not publication_run_id
+        and not publication_attempt
+        and args.refresh_from_local
+        and args.check_github_runs
+        and os.environ.get("GITHUB_ACTIONS") == "true"
+        and os.environ.get("GITHUB_JOB") == "publish-release-proof"
+    ):
+        publication_run_id = os.environ.get("GITHUB_RUN_ID")
+        publication_attempt = os.environ.get("GITHUB_RUN_ATTEMPT")
+        if not publication_run_id or not publication_attempt:
+            raise ValueError(
+                "publication producer context is missing its run ID or attempt"
+            )
+    if publication_run_id or publication_attempt:
+        if not publication_run_id or not publication_attempt:
+            raise ValueError("publication run ID and attempt must be provided together")
+        manifest = refresh_publication_run(
+            manifest,
+            run_id=publication_run_id,
+            attempt=publication_attempt,
+            repo_root=REPO_ROOT,
+            github_repo=args.github_repo,
+        )
+    if args.refresh_from_local or args.refresh_from_github or publication_run_id:
         write_manifest(manifest_path, manifest)
 
     rendered = render_release_proof(


### PR DESCRIPTION
Release proof for v2026.09.07 retained a successful PyPI run from July, even though the declared release commit was from September. Bind publication evidence to the release commit and an exact workflow attempt, and verify that the publishing, release-assets, approval, and provenance jobs actually succeeded.

The validator rejects old successful releases, wrong attempts, and successful workflows that did not publish packages. While the exact proof-producing job is still active, it can validate its completed publication prerequisites; the report explicitly says the enclosing workflow is still in progress. Other active workflows remain rejected.

The existing repair mode accepts an explicit publication run/attempt and an already-validated HF commit, with the existing release approval gate and no selected PyPI distributions. Proof assets include the publication run and attempt in their names so a corrected proof can coexist with immutable earlier artifacts.

## Repro

Run 34148757505 attempt 3 completed successfully and produced docs PR #983. Its published manifest declared release commit `5d60124b8699803198fd692969328dce262083b3`, but the PyPI row still referenced run `30616241713` at commit `3e88def4dda5be155d8d9a91537a671c00851c83`.

The new stale-release regression failed before this change because no publication-to-release binding check existed. The generator regressions also failed before implementation.

## Root Cause

`--refresh-from-local` changed release metadata while retaining `ci_runs`. Live verification compared the old run with its own stored SHA and freshness, so an internally consistent old success passed. Generic GitHub refresh now uses the same publication validator, and the CLI records the exact producer identity before writing refreshed evidence.

## Regression Test

201 targeted tests passed:

```bash
UV_PROJECT_ENVIRONMENT=.venv-dev uv --preview-features extra-build-dependencies run python -m pytest --import-mode=importlib -q -o addopts='' test/test_release_proof_report.py test/test_pypi_publish_workflow.py test/test_pypi_publish.py
```

Coverage includes stale release binding, exact retries, missing/failed/skipped publishers, active producer isolation, polluted job context, CLI persistence, atomic rejection, generic refresh, metadata preparation without premature proof generation, and executable Bash preflight cases that reject invalid repair inputs before release planning.

Ruff, whitespace, raw workflow YAML parsing, workflow contract validation, scoped staging, and agent commit provenance passed. Staged impact: low risk. Executing the actual workflow metadata-preparation, proof-generation, and mirror-stamp commands in an isolated checkout passed all 14 checks against publication run 34148757505, attempt 3. This validates the workflow entrypoint as well as the standalone generator. Public proof files have not yet been regenerated.

Full package builds, installers, and new badge generation: not applicable to this tooling-only change. Existing documentation metadata was preserved in the code branch.

## Shared Tool Approval

On 2026-09-08 the user explicitly approved correcting this evidence generator/validator and its regressions. The final scope covers `tools/release_proof_report.py`, the existing metadata helper in `tools/pypi_publish.py`, `.github/workflows/pypi-publish.yaml`, and their three focused test modules. The helper now has an explicit `refresh_proof=False` option so the workflow prepares its badge/changelog without generating a premature, unbound proof; existing callers retain the default behavior. The blast radius is shared release evidence generation and verification; no package runtime or agi-core files changed.

## Merge Status

After all required checks passed, normal squash merge was rejected by the main branch policy. GitHub reports the head signature as unverified (`unknown_key`), and main requires verified signatures. The user explicitly authorized the administrative squash merge of this PR and regeneration of the v2026.09.07 evidence on 2026-09-08 after reviewing this exact signature blocker. All required checks passed. The authorized administrative squash merge completed at 2026-09-08T09:12:52Z as 219387d036b7916fb1bcb5d91a599644715b0407. Proof repair run: https://github.com/ThalesGroup/agilab/actions/runs/34208818992 (publication identity 34148757505/3).

## Review Evidence

- GPT-6 self-review: release identity, attempt pinning, publisher completion, active-job isolation, immutable asset naming, quoted workflow inputs, and the existing approval/credential boundaries reviewed; findings addressed.
- No sub-agents were used.
- All seven required GitHub checks passed on e837cee5dbe000079437a63e9b46ae3ee873b62e, including root-tests (run 34207094987) and guardrails (run 34207094976). Additional verify, lock-integrity, Windows core, and GitGuardian checks passed. public-demo-smoke was GitHub skipped because this change does not touch the demo surface. The user explicitly approved the administrative merge exception for this PR after all checks passed.

## Agent Metadata

- Tokki: 1.0.63 (authenticated protected runtime).
- Agent/runtime: Codex API session; runtime version unavailable.
- Model: GPT-6.
- Reasoning effort: unknown.
- `/fast` mode: unknown.
