### PR TITLE
fix(pool): enforce batch deadlines and executor capabilities

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_pool_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_pool_support.py
@@ -51,9 +51,9 @@ POOL_MAX_WORKERS_ENV = "AGILAB_POOL_MAX_WORKERS"
 #: Optional per-app override read from ``worker.args`` when present.
 POOL_MAX_WORKERS_ARG = "pool_max_workers"
 
-#: Per-work-item time budget in seconds (float). Opt-in: unset means no
-#: timeout, preserving historical behavior. Read from ``worker.args`` first,
-#: then the environment.
+#: Per-item budget in seconds used to derive a deadline for the whole chunk's
+#: batch waves. It does not preempt individual items. Opt-in: unset means no
+#: timeout. Read from ``worker.args`` first, then the environment.
 POOL_ITEM_TIMEOUT_ENV = "AGILAB_POOL_ITEM_TIMEOUT"
 POOL_ITEM_TIMEOUT_ARG = "pool_item_timeout"
 
@@ -68,6 +68,8 @@ POOL_EXECUTOR_ENV = "AGILAB_POOL_EXECUTOR"
 _POOL_TIMEOUT_GRACE_SECONDS = 5.0
 
 _MAP_CHUNKSIZE_CAP = 32
+# CPython ProcessPoolExecutor reserves two of Windows' 63 wait handles.
+_WINDOWS_PROCESS_POOL_LIMIT = 61
 
 # Worker code boundary: pool children execute app work_pool implementations;
 # each failure is captured with its work item and re-raised in the parent
@@ -88,7 +90,7 @@ class PoolFrameHooks:
     """Per worker-family hooks used by the shared pool engine."""
 
     family: str
-    executor_kind: str  # "process" or "thread" (logging/diagnostics only)
+    executor_kind: str  # Native family backend: "process" or "thread".
     executor_factory: Callable[..., Any]
     is_frame: Callable[[Any], bool]
     is_empty: Callable[[Any], bool]
@@ -106,13 +108,16 @@ def pool_mode_requested(mode: Any) -> bool:
         return False
 
 
-def resolve_pool_width(chunk_lengths: Sequence[int], args: Any = None) -> int:
+def resolve_pool_width(
+    chunk_lengths: Sequence[int], args: Any = None, *, executor_kind: str | None = None
+) -> int:
     """Resolve the pool width once per ``works()`` call.
 
     The width is bounded by the largest chunk (extra workers would idle), the
     machine's CPU count (guarding ``os.cpu_count()`` returning ``None``), and
     an optional cap from ``args[pool_max_workers]`` or
-    ``AGILAB_POOL_MAX_WORKERS``.
+    ``AGILAB_POOL_MAX_WORKERS``. A resolved process backend also respects the
+    Windows ProcessPoolExecutor limit; thread backends do not share that limit.
     """
     largest_chunk = max((int(length) for length in chunk_lengths), default=0)
     cpu_count = os.cpu_count() or 1
@@ -120,6 +125,8 @@ def resolve_pool_width(chunk_lengths: Sequence[int], args: Any = None) -> int:
     cap = _resolve_pool_cap(args)
     if cap is not None:
         width = max(min(width, cap), 1)
+    if executor_kind == "process" and sys.platform == "win32":
+        width = min(width, _WINDOWS_PROCESS_POOL_LIMIT)
     return width
 
 
@@ -172,9 +179,15 @@ def resolve_pool_item_timeout(args: Any = None) -> float | None:
 
 
 def _chunk_deadline_seconds(item_timeout: float, item_count: int, width: int) -> float:
-    """Whole-chunk deadline: serial item budget per pool slot plus grace."""
-    waves = math.ceil(item_count / max(width, 1))
-    return item_timeout * max(waves, 1) + _POOL_TIMEOUT_GRACE_SECONDS
+    """Budget whole batch waves: each future runs its items serially.
+
+    An incomplete final wave can put two batches on one slot even when an
+    average item count suggests less work. Budget a full batch for each wave
+    so healthy items do not time out because of that scheduling imbalance.
+    """
+    batch_size = map_chunksize(item_count, width)
+    waves = math.ceil(item_count / (batch_size * max(width, 1)))
+    return item_timeout * batch_size * max(waves, 1) + _POOL_TIMEOUT_GRACE_SECONDS
 
 
 def _free_threading_active() -> bool:
@@ -195,7 +208,8 @@ def resolve_executor(hooks: PoolFrameHooks) -> tuple[Callable[..., Any], str]:
     ``AGILAB_POOL_EXECUTOR=process|thread`` forces a backend; ``auto`` (or
     unset) keeps the family default, except that process-pool families run a
     thread pool on free-threaded interpreters where threads deliver the same
-    parallelism without spawn and pickling costs.
+    parallelism without spawn and pickling costs. Thread-only families reject
+    a process override because their worker state need not be picklable.
     """
     choice = os.environ.get(POOL_EXECUTOR_ENV, "auto").strip().lower() or "auto"
     if choice not in ("auto", "process", "thread"):
@@ -207,10 +221,13 @@ def resolve_executor(hooks: PoolFrameHooks) -> tuple[Callable[..., Any], str]:
         choice = "auto"
     if choice == "thread" and hooks.executor_kind != "thread":
         return ThreadPoolExecutor, "thread (forced by env)"
+    if choice == "process" and hooks.executor_kind == "thread":
+        raise ValueError(
+            f"{hooks.family} does not support process pool execution. "
+            f"Set {POOL_EXECUTOR_ENV}=auto or thread; this worker family requires threads."
+        )
     if choice in ("process", "thread"):
-        # "process" pins process families to their default (disables the
-        # free-threading auto-switch); it cannot convert a thread family,
-        # whose workers are not required to be picklable.
+        # Explicit process selection disables the free-threading auto-switch.
         return hooks.executor_factory, hooks.executor_kind
     if hooks.executor_kind == "process" and _free_threading_active():
         return ThreadPoolExecutor, "thread (free-threaded interpreter)"
@@ -318,9 +335,9 @@ def exec_multi_process(
     chunks = select_worker_chunks(worker, workers_plan)
     chunk_lengths = [len(chunk) for chunk in chunks]
     args = getattr(worker, "args", None)
-    width = resolve_pool_width(chunk_lengths, args)
-    item_timeout = resolve_pool_item_timeout(args)
     executor_factory, executor_kind = resolve_executor(hooks)
+    width = resolve_pool_width(chunk_lengths, args, executor_kind=executor_kind)
+    item_timeout = resolve_pool_item_timeout(args)
     logging.info(
         f"{hooks.family}.works - {executor_kind} pool width {width}"
         f" - worker #{worker._worker_id}"
@@ -429,9 +446,9 @@ def _run_chunk(
         if len(pending) > 3:
             preview += ", ..."
         raise _PoolItemTimeoutError(
-            f"{hooks.family}.work_pool exceeded the {item_timeout}s per-item time "
-            f"budget on chunk #{work_id} ({deadline:.1f}s chunk deadline); "
-            f"{len(pending)} item(s) still pending: {preview}. Process-pool "
+            f"{hooks.family}.work_pool exceeded the {deadline:.1f}s chunk deadline "
+            f"on chunk #{work_id} (derived from a {item_timeout}s per-item budget); "
+            f"{len(pending)} item(s) in unfinished batches: {preview}. Process-pool "
             "children are terminated; thread-pool stragglers cannot be stopped "
             "and may keep running in the background."
         ) from exc

--- a/src/agilab/core/test/test_worker_pool_support.py
+++ b/src/agilab/core/test/test_worker_pool_support.py
@@ -1,9 +1,11 @@
 """Tests for the shared in-worker pool engine (agi_node.agi_dispatcher.worker_pool_support)."""
 
+import heapq
 import logging
+import multiprocessing
 import threading
 import time
-from concurrent.futures import Future
+from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 
 import pandas as pd
@@ -284,6 +286,89 @@ def test_chunk_deadline_scales_with_waves():
     assert deadline == 2.0 * 2 + worker_pool_support._POOL_TIMEOUT_GRACE_SECONDS
 
 
+@pytest.mark.parametrize("item_count,width", [(62, 8), (100, 8), (300, 8)])
+def test_healthy_batched_chunk_waits_for_its_actual_schedule(monkeypatch, item_count, width):
+    """A virtual clock exercises real submission batches without sleep races."""
+    class ScheduledPool(RecordingPool):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.slots = [0.0] * self.max_workers
+
+        def submit(self, fn, *args):
+            future = super().submit(fn, *args)
+            # Every item is healthy: 1.8 seconds for a 2-second item budget.
+            finish = heapq.heappop(self.slots) + len(args[0]) * 1.8
+            heapq.heappush(self.slots, finish)
+            future.virtual_finish = finish
+            return future
+
+    def collect_at_virtual_completion(futures, timeout=None):
+        for future in sorted(futures, key=lambda future: future.virtual_finish):
+            if timeout is not None and future.virtual_finish > timeout:
+                raise worker_pool_support.FuturesTimeoutError()
+            yield future
+
+    monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, "process")
+    monkeypatch.setattr(worker_pool_support.os, "cpu_count", lambda: width)
+    monkeypatch.setattr(worker_pool_support, "as_completed", collect_at_virtual_completion)
+    worker = EngineWorker()
+    worker.args.update(pool_max_workers=width, pool_item_timeout=2.0)
+    worker_pool_support.exec_multi_process(
+        worker, {0: [list(range(item_count))]}, None, _pandas_hooks(ScheduledPool)
+    )
+    assert len(worker.last_dfs) == 1
+    assert worker.last_dfs[0]["col"].tolist() == list(range(item_count))
+
+
+@pytest.mark.parametrize(
+    "platform,kind,cpu_count,cap,expected",
+    [
+        ("win32", "process", 60, None, 60),
+        ("win32", "process", 61, None, 61),
+        ("win32", "process", 64, None, 61),
+        ("win32", "process", 128, None, 61),
+        ("win32", "process", 128, 4, 4),
+        ("win32", "thread", 64, None, 64),
+        ("win32", "thread", 128, None, 128),
+        ("linux", "process", 128, None, 128),
+        ("darwin", "process", 128, None, 128),
+    ],
+)
+def test_pool_width_respects_backend_platform_limits(monkeypatch, platform, kind, cpu_count, cap, expected):
+    monkeypatch.setattr(worker_pool_support.sys, "platform", platform)
+    monkeypatch.setattr(worker_pool_support.os, "cpu_count", lambda: cpu_count)
+    monkeypatch.delenv(worker_pool_support.POOL_MAX_WORKERS_ENV, raising=False)
+    args = {} if cap is None else {"pool_max_workers": cap}
+    assert worker_pool_support.resolve_pool_width([256], args, executor_kind=kind) == expected
+
+
+def test_resolved_process_width_is_accepted_by_native_executor(monkeypatch):
+    monkeypatch.setattr(worker_pool_support.os, "cpu_count", lambda: 128)
+    width = worker_pool_support.resolve_pool_width([128], {"pool_max_workers": 128}, executor_kind="process")
+    # Exercise CPython's real platform guard; no tasks or child processes start.
+    with ProcessPoolExecutor(max_workers=width, mp_context=multiprocessing.get_context("spawn")):
+        pass
+
+
+@pytest.mark.parametrize(
+    "choice,free_threaded,expected_width",
+    [("process", False, 61), ("thread", False, 64), ("auto", True, 64), ("auto", False, 61)],
+)
+def test_windows_pool_width_uses_resolved_executor(monkeypatch, choice, free_threaded, expected_width):
+    monkeypatch.setattr(worker_pool_support.sys, "platform", "win32")
+    monkeypatch.setattr(worker_pool_support.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(worker_pool_support, "_free_threading_active", lambda: free_threaded)
+    monkeypatch.setattr(worker_pool_support, "ThreadPoolExecutor", RecordingPool)
+    monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, choice)
+    worker = EngineWorker()
+    worker.args.update(pool_max_workers=128)
+    worker_pool_support.exec_multi_process(
+        worker, {0: [list(range(128))]}, None, _pandas_hooks(RecordingPool)
+    )
+    assert RecordingPool.instances[-1].max_workers == expected_width
+    assert len(worker.last_dfs[0]) == 128
+
+
 def test_timed_out_chunk_raises_and_abandons_pool(monkeypatch):
     class StuckFuture:
         def done(self):
@@ -305,7 +390,7 @@ def test_timed_out_chunk_raises_and_abandons_pool(monkeypatch):
     monkeypatch.setattr(worker_pool_support, "as_completed", _raise_timeout)
     worker = EngineWorker(mode=1)
     worker.args = {"output_format": "csv", "pool_item_timeout": 0.01}
-    with pytest.raises(RuntimeError, match="per-item time"):
+    with pytest.raises(RuntimeError, match="chunk deadline"):
         worker_pool_support.exec_multi_process(
             worker, {0: [["slow1", "slow2"]]}, None, _pandas_hooks(StuckPool)
         )
@@ -405,7 +490,7 @@ def test_resolve_executor_process_pins_default_despite_free_threading(monkeypatc
     assert factory is RecordingPool and kind == "process"
 
 
-def test_resolve_executor_never_converts_thread_family_to_process(monkeypatch):
+def test_thread_family_rejects_forced_process_before_initializing_work(monkeypatch):
     monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, "process")
     hooks = worker_pool_support.PoolFrameHooks(
         family="PolarsWorker",
@@ -416,5 +501,15 @@ def test_resolve_executor_never_converts_thread_family_to_process(monkeypatch):
         concat_labeled=lambda frames, labels: frames[0],
         empty_frame=lambda: None,
     )
-    factory, kind = worker_pool_support.resolve_executor(hooks)
-    assert factory is RecordingPool and kind == "thread"
+    worker = EngineWorker()
+    initialized = []
+    monkeypatch.setattr(worker, "work_init", lambda: initialized.append(True))
+    with pytest.raises(ValueError, match="PolarsWorker does not support process pool execution"):
+        worker_pool_support.exec_multi_process(worker, {0: [[1]]}, None, hooks)
+    assert initialized == []
+    assert RecordingPool.instances == []
+
+    for choice in ("auto", "thread"):
+        monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, choice)
+        factory, kind = worker_pool_support.resolve_executor(hooks)
+        assert factory is RecordingPool and kind == "thread"


### PR DESCRIPTION
Healthy work could fail the pool timeout because the deadline budgeted individual items while futures executed serial batches. With 62 items, eight workers and a two-second item budget, the old deadline was 21 seconds even though the batch schedule needed about 23.4 seconds.

The pool now budgets complete batch waves, applies Windows' process-worker limit after resolving the actual backend, and rejects unsupported forced process execution for thread-only families before work initialization.

## Repro

- 62 healthy 1.8-second items, width eight, two-second item budget: the original runtime timed out after 21 seconds and did not hand off a result chunk.
- A 64-CPU Windows process pool resolved width 64, exceeding CPython's limit of 61.
- Selecting `AGILAB_POOL_EXECUTOR=process` with native Polars hooks silently retained a thread executor.

## Root Cause

The deadline assumed evenly assigned individual items rather than whole submitted batches. Width selection did not know the resolved backend's platform capacity. The explicit process override intentionally retained thread-family defaults although the UI described a forced backend choice.

## Changes

- Derive a conservative chunk deadline from the actual batch size and batch waves, and describe a chunk deadline in timeout diagnostics.
- Resolve the backend before width; preserve smaller operator caps and leave thread/non-Windows capacities unchanged.
- Raise an actionable error for unsupported forced process execution before `work_init`.
- Keep changes within `agi-node`'s shared pool engine and its focused tests.

## Regression Test

- Full shared-core suite: **1,583 passed, 4 skipped**.
- Skips: two live LAN cases require explicit `AGILAB_RUN_LAN_CLUSTER_TESTS=1`; one native Windows ownership test is not applicable on macOS; one case-sensitive filesystem test is not applicable on this case-insensitive volume.
- Deterministic scheduling regressions cover uneven final waves and the batch-size cap. Backend tests cover Windows capacities of 60, 61, 64 and 128, explicit caps, forced threads, free-threading selection, and unsupported process requests before initialization.
- A native CPython executor-constructor regression runs on the actual CI platform without starting child processes.
- Real finite-thread reproduction: all **62 outputs retained**, one completed chunk, **23.449 seconds**, longest item **1.805 seconds**, corrected chunk deadline **33 seconds**.
- Ruff, scoped impact and commit-provenance checks passed. Local evidence: `reports/worker-pool-fix/`.
- Native Windows validation passed in the [Windows core CI job](https://github.com/ThalesGroup/agilab/actions/runs/34238192061), including the actual CPython executor-constructor regression. Live application/cluster workloads were not executed because the affected contracts are covered by synthetic workers and the shared-core suite.
- All seven required GitHub checks passed on 181e2aaa99291f6b2d5c618868ff1bd1e3af9790. The Windows core job and GitGuardian also passed. The optional public-demo-smoke check was GitHub skipped. [Root test suite evidence](https://github.com/ThalesGroup/agilab/actions/runs/34238192037).

## Approval and Scope

The user's “fix and merge” explicitly approves the three audited shared-core fixes and merging this PR. Shared scope: `src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_pool_support.py`; regressions: `src/agilab/core/test/test_worker_pool_support.py`. App-local patches cannot repair shared scheduling or backend selection. No `agi-core`, installer, dependency or DAG changes are included.

## Review Evidence

GPT-6 self-review: all three audit findings addressed. Reviewed batching bounds, resolved-backend capacity, early rejection, timeout cleanup and preservation of successful outputs. No sub-agents used. Existing straggler cancellation and worker-family regressions remain green. All required checks passed on head 181e2aaa99291f6b2d5c618868ff1bd1e3af9790. The normal squash merge was attempted and rejected by the main branch policy: verified commit signatures are required, while this head is unsigned. Explicit local signing also failed because the runtime uses /dev/null as the signing executable. No signing control or branch rule was bypassed. The operator subsequently authorized merging all branches, including the requested administrative squash-merge exception for this PR.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex via API; runtime version unavailable
- Model: GPT-6
- Reasoning effort: unknown
- /fast: unknown


## Merge Authorization

The operator requested `merge all branches` after the signature exception was explained. Required checks on head 181e2aaa99291f6b2d5c618868ff1bd1e3af9790 are green. Existing branch rules remain unchanged. The authorized administrative squash merge was completed for the signed-commit blocker only; all required checks had passed.


## Verified Merge Result

Merged into main at 2026-09-08T14:51:40Z as f1273aed199da91ddad7cd02283b892e6da357d5. GitHub reports the resulting commit signature as verified. The source branch was automatically deleted by repository policy.
