### PR TITLE
Fix Ubuntu CI dependency setup when third-party APT sources fail

### DIFF
--- a/.github/actions/configure-ubuntu-apt/action.yml
+++ b/.github/actions/configure-ubuntu-apt/action.yml
@@ -1,0 +1,9 @@
+name: Configure Ubuntu APT sources
+description: Use the runner's Ubuntu archive for CI dependencies, preserving APT verification.
+
+runs:
+  using: composite
+  steps:
+    - name: Select Ubuntu package sources
+      shell: bash
+      run: sudo bash "$GITHUB_ACTION_PATH/configure.sh"

--- a/.github/actions/configure-ubuntu-apt/configure.sh
+++ b/.github/actions/configure-ubuntu-apt/configure.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# CI-only setup for Ubuntu runners. An alternate APT directory supports isolated tests.
+set -euo pipefail
+
+apt_dir="${1:-/etc/apt}"
+if [[ "$apt_dir" != /* || "$apt_dir" == *\"* || "$apt_dir" == *\\* || "$apt_dir" == *$'\n'* || "$apt_dir" == *$'\r'* ]]; then
+  echo "APT directory must be absolute and contain no quotes, backslashes or newlines." >&2
+  exit 1
+fi
+ubuntu_source="$apt_dir/sources.list.d/ubuntu.sources"
+if [[ ! -s "$ubuntu_source" ]]; then
+  echo "Expected Ubuntu runner source file $ubuntu_source; refusing to use unrelated repositories." >&2
+  exit 1
+fi
+
+# All APT callers, including Playwright's sudo subprocess, read this configuration.
+# Keep the runner's archive mirrors, suites and Signed-By keyring unchanged.
+# See https://manpages.ubuntu.com/manpages/noble/man5/apt.conf.5.html
+mkdir -p "$apt_dir/apt.conf.d"
+cat > "$apt_dir/apt.conf.d/99-agilab-ubuntu-sources" <<EOF
+Dir::Etc::sourcelist "$ubuntu_source";
+Dir::Etc::sourceparts "-";
+APT::Update::Error-Mode "any";
+EOF
+echo "APT configured to use $ubuntu_source; package index errors remain fatal."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
         run: |
           set -euo pipefail
           uv --preview-features extra-build-dependencies run --extra dev pytest -q -o addopts='' \
+            test/test_ci_workflow.py \
             test/test_package_split_contract.py \
             test/test_pypi_publish_workflow.py \
             test/test_compat_shim_inventory.py \
@@ -185,6 +186,9 @@ jobs:
         run: |
           set -euo pipefail
           uv --preview-features extra-build-dependencies run --extra ui python tools/first_launch_robot.py --json --output first-launch-robot.json
+
+      - name: Configure Ubuntu APT sources
+        uses: ./.github/actions/configure-ubuntu-apt
 
       - name: Install Playwright browser for frontend smoke
         run: |

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -11,6 +11,7 @@ on:
       - 'src/agilab/resources/help/**'
       - 'tools/release_proof_report.py'
       - '.github/workflows/docs-publish.yaml'
+      - '.github/actions/configure-ubuntu-apt/**'
   workflow_dispatch:
 
 env:
@@ -59,6 +60,9 @@ jobs:
           set -euo pipefail
           uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --skip-missing-source --quiet
           uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact
+      - name: Configure Ubuntu APT sources
+        uses: ./.github/actions/configure-ubuntu-apt
+
       - name: Install Graphviz
         run: |
           set -euo pipefail

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -152,6 +152,9 @@ jobs:
           # browser revisions and unioning them into ever-growing saves.
           key: playwright-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.playwright-version.outputs.version }}-chromium
 
+      - name: Configure Ubuntu APT sources
+        uses: ./.github/actions/configure-ubuntu-apt
+
       - name: Install Playwright browser for frontend smoke
         run: |
           set -euxo pipefail

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -101,6 +101,9 @@ jobs:
           # browser revisions and unioning them into ever-growing saves.
           key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium
 
+      - name: Configure Ubuntu APT sources
+        uses: ./.github/actions/configure-ubuntu-apt
+
       - name: Install Playwright browser
         run: |
           set -euo pipefail

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -1,6 +1,11 @@
 import ast
 import importlib.util
 import sys
+import shutil
+import subprocess
+
+import pytest
+import yaml
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -613,3 +618,115 @@ def test_dev_extra_installs_ruff_for_local_linting() -> None:
     # Exact version bounds belong to dependency-policy tests. This contract only
     # requires the local lint tool to remain present exactly once.
     assert len(ruff_dependencies) == 1
+
+
+UBUNTU_APT_ACTION = Path('.github/actions/configure-ubuntu-apt')
+
+
+def _ubuntu_apt_fixture(tmp_path: Path) -> Path:
+    apt_dir = tmp_path / 'apt'
+    sources = apt_dir / 'sources.list.d'
+    sources.mkdir(parents=True)
+    (sources / 'ubuntu.sources').write_text(
+        'Types: deb\nURIs: http://archive.ubuntu.com/ubuntu\n'
+        'Suites: noble noble-updates\nComponents: main universe\n'
+        'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n',
+        encoding='utf-8',
+    )
+    (sources / 'google-chrome.list').write_text('malformed third-party source\n', encoding='utf-8')
+    return apt_dir
+
+
+def _configure_ubuntu_apt(apt_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['bash', str(UBUNTU_APT_ACTION / 'configure.sh'), str(apt_dir)],
+        text=True, capture_output=True, check=False,
+    )
+
+
+def test_ubuntu_apt_configuration_preserves_sources_and_verification(tmp_path: Path) -> None:
+    apt_dir = _ubuntu_apt_fixture(tmp_path)
+    sources = {path: path.read_bytes() for path in sorted((apt_dir / 'sources.list.d').iterdir())}
+    result = _configure_ubuntu_apt(apt_dir)
+    assert result.returncode == 0, result.stderr
+    assert all(path.read_bytes() == content for path, content in sources.items())
+    config = (apt_dir / 'apt.conf.d/99-agilab-ubuntu-sources').read_text(encoding='utf-8')
+    assert f'Dir::Etc::sourcelist "{apt_dir}/sources.list.d/ubuntu.sources";' in config
+    assert 'Dir::Etc::sourceparts "-";' in config
+    assert 'APT::Update::Error-Mode "any";' in config
+    assert 'AllowInsecure' not in config
+    assert 'AllowUnauthenticated' not in config
+
+
+@pytest.mark.parametrize("source_content", [None, ""])
+def test_ubuntu_apt_missing_source_fails_without_changing_configuration(tmp_path: Path, source_content) -> None:
+    apt_dir = tmp_path / 'apt'
+    config = apt_dir / 'apt.conf.d/99-agilab-ubuntu-sources'
+    config.parent.mkdir(parents=True)
+    config.write_text('existing config\n', encoding='utf-8')
+    if source_content is not None:
+        source = apt_dir / 'sources.list.d/ubuntu.sources'
+        source.parent.mkdir()
+        source.write_text(source_content, encoding='utf-8')
+    result = _configure_ubuntu_apt(apt_dir)
+    assert result.returncode != 0
+    assert 'Expected Ubuntu runner source file' in result.stderr
+    assert config.read_text(encoding='utf-8') == 'existing config\n'
+
+
+def test_ubuntu_apt_ignores_malformed_third_party_source_with_real_apt(tmp_path: Path) -> None:
+    apt_get = shutil.which('apt-get')
+    if apt_get is None:
+        pytest.skip('Real APT source selection is validated on Ubuntu CI runners')
+    apt_dir = _ubuntu_apt_fixture(tmp_path)
+    before_config = tmp_path / 'before.conf'
+    before_config.write_text(
+        f'Dir::Etc::sourcelist "/dev/null";\nDir::Etc::sourceparts "{apt_dir}/sources.list.d";\n',
+        encoding='utf-8',
+    )
+    lists = tmp_path / 'lists'
+    (lists / 'partial').mkdir(parents=True)
+
+    def planned_downloads(config: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [apt_get, '-c', str(config), '-o', f'Dir::State::lists={lists}',
+             '--print-uris', 'update'],
+            text=True, capture_output=True, check=False,
+        )
+
+    before = planned_downloads(before_config)
+    assert before.returncode != 0
+    assert 'google-chrome.list' in before.stderr
+    assert _configure_ubuntu_apt(apt_dir).returncode == 0
+    after = planned_downloads(apt_dir / 'apt.conf.d/99-agilab-ubuntu-sources')
+    assert after.returncode == 0, after.stderr
+    assert 'archive.ubuntu.com' in after.stdout
+    assert 'google-chrome' not in after.stdout + after.stderr
+
+    # Isolating vendor sources must still reject a broken Ubuntu source.
+    (apt_dir / 'sources.list.d/ubuntu.sources').write_text('invalid deb822 source\n', encoding='utf-8')
+    broken = planned_downloads(apt_dir / 'apt.conf.d/99-agilab-ubuntu-sources')
+    assert broken.returncode != 0
+    assert 'ubuntu.sources' in broken.stderr
+
+
+def test_all_ubuntu_dependency_steps_select_the_archive_first() -> None:
+    action_ref = './.github/actions/configure-ubuntu-apt'
+    consumers = set()
+    for path in sorted(Path('.github/workflows').glob('*')):
+        if path.suffix not in {'.yml', '.yaml'}:
+            continue
+        workflow = yaml.safe_load(path.read_text(encoding='utf-8'))
+        for job in workflow.get('jobs', {}).values():
+            steps = job.get('steps', [])
+            for index, step in enumerate(steps):
+                command = step.get('run', '')
+                if 'apt-get update' not in command and 'playwright install --with-deps' not in command:
+                    continue
+                setups = [item for item in steps[:index] if item.get('uses') == action_ref]
+                assert len(setups) == 1, f'{path}: missing Ubuntu source setup before {step.get("name")}'
+                assert 'if' not in setups[0], 'APT configuration must also run on browser cache hits'
+                consumers.add(path)
+    assert consumers == {WORKFLOW_PATH, DOCS_PUBLISH_WORKFLOW_PATH,
+                         PYPI_PUBLISH_WORKFLOW_PATH, UI_ROBOT_MATRIX_WORKFLOW_PATH}
+    assert "'.github/actions/configure-ubuntu-apt/**'" in DOCS_PUBLISH_WORKFLOW_PATH.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary

GitHub's preinstalled Chrome APT index returned a Hash Sum mismatch, so both repo-guardrails and docs-publish failed before running their frontend/docs work. Retrying the same merged commit failed again.

Add a shared CI action that selects the runner's existing Ubuntu `ubuntu.sources` file through APT configuration. Use it before Graphviz and all three Playwright dependency-install paths (repo guardrails, release preflight and UI robots). This also covers Playwright's sudo subprocesses. The original repository files, Ubuntu mirrors, suites and Signed-By keyring remain intact; index errors remain fatal. Missing or empty Ubuntu source metadata fails with an actionable error. The action is limited to the current Ubuntu hosted-runner jobs.

Docs publication now also triggers when the shared action changes.

## Repro

Post-merge runs [repo-guardrails 34384084194](https://github.com/ThalesGroup/agilab/actions/runs/34384084194) and [docs-publish 34384084241](https://github.com/ThalesGroup/agilab/actions/runs/34384084241), including their retries, stopped in apt-get update on dl.google.com/linux/chrome-stable/deb metadata. The checkout was 15ea3f227cbbee281f68bc6cc1eced77e0638ce9.

## Root Cause

APT updated every preconfigured runner repository even though these jobs need Ubuntu packages. A broken third-party index therefore blocked Graphviz and Playwright system dependencies. A shared configuration action fixes this at the CI setup layer and covers the sibling consumers. No authentication/checksum bypass or error suppression is introduced.

APT source configuration is documented in the [Ubuntu APT manual](https://manpages.ubuntu.com/manpages/noble/man5/apt.conf.5.html); GitHub's [Ubuntu image setup](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-apt.sh) supplies the source file.

## Regression Test

- Real APT regression creates a malformed third-party source in a temporary source directory. The original configuration fails; after running the production helper, APT plans Ubuntu downloads successfully. A malformed Ubuntu source still fails. This uses --print-uris, without downloads or system changes.
- Local tests verify source/keyring metadata remains byte-identical, missing/empty Ubuntu sources preserve existing configuration and fail, and every Ubuntu dependency-install step has an unconditional setup action before it.
- The workflow contract suite is now included in repo-guardrails' fast tests so the Linux APT regression runs before the real browser install.

## Validation

- Local: 69 passed, 1 skipped across CI, release-workflow, credential-boundary, action-runtime and action-execution tests. The real APT case is skipped on macOS because APT is unavailable; it is required by the Ubuntu CI path. Docker/Colima is stopped, so no local Linux container was used.
- Passed: Bash syntax, Ruff, git diff checks, staged scope, provenance, impact review and release workflow contract. All workflow/composite-action YAML parses successfully.
- One existing compatibility-shim DeprecationWarning in test_action_execution remains unrelated.
- GitHub PR checks passed on exact head `1f3bb69be22bf6c6fed8f01440f5dac366acb4ed`: 10 successes, zero failures; public-demo-smoke is GitHub-skipped because its schedule/dispatch condition does not apply. [Repo guardrails](https://github.com/ThalesGroup/agilab/actions/runs/34386357438) passed the real APT regression, all 72 fast contract tests, the shared setup action, Playwright installation and frontend smoke. [Root tests](https://github.com/ThalesGroup/agilab/actions/runs/34386357587), [Windows core](https://github.com/ThalesGroup/agilab/actions/runs/34386357417), Python/clean-install checks and tool-lock verification passed. Post-merge Pages deployment passed; see the final main-branch evidence below.
- Final main-branch verification on merge commit `77ab575be412a44400b80cdb32d7378b388d8ba5` (2026-09-10): [repository guards](https://github.com/ThalesGroup/agilab/actions/runs/34443997686), [Pages](https://github.com/ThalesGroup/agilab/actions/runs/34443997685), [root tests](https://github.com/ThalesGroup/agilab/actions/runs/34443997697), [coverage](https://github.com/ThalesGroup/agilab/actions/runs/34443997682), and [tool-lock integrity](https://github.com/ThalesGroup/agilab/actions/runs/34443997652) passed.
- Live documentation index and release-proof page returned HTTP 200. Release proof still identifies public release 2026.09.07 and explicitly says the source checkout is ahead.
- [Post-merge Windows core](https://github.com/ThalesGroup/agilab/actions/runs/34443997662) failed: 1 failed, 2624 passed, 25 skipped. `test_service_loop_records_worker_failures` did not observe the task in the failed queue within its two-second wait (`Failed task was not moved to failed`). The cause is not yet established; this remains a release blocker. The successful PR Windows result above remains the historical PR result.
- PyPI publication is not applicable to this CI fix and has not been dispatched.

## Scope and authority

The user's fix instruction authorizes the named runner-setup repair, including the shared CI action and affected workflows. App/core runtime files, package versions and release payloads are unchanged. Work was isolated from the original dirty checkouts. Standard PR merge rules apply; no administrator waiver is requested.

## Review Evidence

Primary-agent review: GPT-6 Astra, xhigh. Reviewed source selection, fail-closed errors, sudo inheritance, workflow ordering and sibling consumers. No unresolved code finding. No sub-agents were used.

## Agent Metadata

- Tokki: 1.0.63
- Agent/runtime: Codex CLI 0.153.4, codex-tui
- Model: gpt-6-astra
- Reasoning effort: xhigh
- /fast mode: unknown
