### PR TITLE
test: remove timing races from service queue terminal checks

### DIFF
--- a/src/agilab/core/test/test_base_worker_service_support.py
+++ b/src/agilab/core/test/test_base_worker_service_support.py
@@ -152,7 +152,7 @@ def test_heartbeat_json_reader_retries_only_transient_permission_errors(tmp_path
 
 
 def test_service_loop_without_worker_override_stops_cleanly():
-    worker = DummyWorker()
+    DummyWorker()
     result: dict[str, object] = {}
 
     def _run_loop():
@@ -529,6 +529,9 @@ def test_service_loop_records_worker_failures(tmp_path):
     worker.args = SimpleNamespace(_agi_service_queue_dir=str(tmp_path / "service_queue"))
 
     def _raise(*_args, **_kwargs):
+        # Stop after this task; the loop must still publish its failure before
+        # returning. Run synchronously so slow CI I/O is not a test deadline.
+        assert BaseWorker.break_loop() is True
         raise RuntimeError("boom")
 
     worker.works = _raise
@@ -557,19 +560,8 @@ def test_service_loop_records_worker_failures(tmp_path):
     task_file = pending / "000003-batch-fail-000-worker.task.json"
     _write_task(task_file, payload)
 
-    result: dict[str, object] = {}
-
-    def _run_loop():
-        result["payload"] = BaseWorker.loop(poll_interval=0.05)
-
-    thread = threading.Thread(target=_run_loop, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 2.0
+    payload_out = BaseWorker.loop(poll_interval=0.05)
     failed_file = queue_root / "failed" / task_file.name
-    while time.time() < deadline and not failed_file.exists():
-        time.sleep(0.05)
-
     assert failed_file.exists(), "Failed task was not moved to failed"
 
     failed_payload = json.loads(failed_file.read_text(encoding="utf-8"))
@@ -577,13 +569,14 @@ def test_service_loop_records_worker_failures(tmp_path):
     assert failed_payload["error"] == "boom"
     assert "RuntimeError: boom" in failed_payload["traceback"]
 
-    assert BaseWorker.break_loop() is True
-    thread.join(timeout=2)
-    assert not thread.is_alive(), "Service loop did not stop after break_loop"
-
-    payload_out = result.get("payload")
     assert isinstance(payload_out, dict)
+    assert payload_out.get("status") == "stopped"
     assert payload_out.get("failed") == 1
+    assert payload_out.get("processed") == 0
+    assert not task_file.exists()
+    assert list((queue_root / "running").glob("*.task.json")) == []
+    assert BaseWorker._service_stop_events == {}
+    assert BaseWorker._service_active == {}
 
 
 def test_service_loop_skips_tasks_for_other_workers(tmp_path):

--- a/src/agilab/core/test/test_base_worker_service_support.py
+++ b/src/agilab/core/test/test_base_worker_service_support.py
@@ -24,6 +24,20 @@ def _write_task(path: Path, payload: dict[str, object]) -> None:
     )
 
 
+def _run_until_task_moved(monkeypatch, source: Path, destination: Path):
+    """Stop after the real quarantine move, without racing filesystem timing."""
+    original_replace = Path.replace
+
+    def _replace(path, target):
+        result = original_replace(path, target)
+        if path == source and target == destination:
+            assert BaseWorker.break_loop() is True
+        return result
+
+    monkeypatch.setattr(Path, "replace", _replace)
+    return BaseWorker.loop(poll_interval=0.05)
+
+
 def _read_json_with_permission_retry(
     path: Path,
     *,
@@ -180,6 +194,7 @@ def test_service_loop_consumes_queued_tasks(tmp_path):
 
     def _works(plan, metadata):
         calls.append((plan, metadata))
+        assert BaseWorker.break_loop() is True
 
     worker.works = _works
 
@@ -207,29 +222,16 @@ def test_service_loop_consumes_queued_tasks(tmp_path):
     task_file = pending / "000001-batch-1-000-worker.task.json"
     _write_task(task_file, payload)
 
-    result: dict[str, object] = {}
-
-    def _run_loop():
-        result["payload"] = BaseWorker.loop(poll_interval=0.05)
-
-    thread = threading.Thread(target=_run_loop, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 2.0
+    payload_out = BaseWorker.loop(poll_interval=0.05)
     done_file = queue_root / "done" / task_file.name
-    while time.time() < deadline and not done_file.exists():
-        time.sleep(0.05)
 
     assert done_file.exists(), "Service queue task was not moved to done"
     assert len(calls) == 1
 
-    assert BaseWorker.break_loop() is True
-    thread.join(timeout=2)
-    assert not thread.is_alive(), "Service loop did not stop after break_loop"
-
-    payload_out = result.get("payload")
     assert isinstance(payload_out, dict)
+    assert payload_out.get("status") == "stopped"
     assert payload_out.get("processed") == 1
+    assert payload_out.get("failed") == 0
 
 
 def test_service_loop_refreshes_heartbeat_during_long_task(tmp_path):
@@ -449,7 +451,7 @@ def test_service_loop_unique_running_claim_does_not_overwrite_duplicate_name(tmp
     assert list(running.glob("*.claim-*.task.json")) == []
 
 
-def test_service_loop_moves_unreadable_task_to_failed(tmp_path):
+def test_service_loop_moves_unreadable_task_to_failed(tmp_path, monkeypatch):
     worker = DummyWorker()
     BaseWorker._worker_id = 0
     BaseWorker._worker = "127.0.0.1:8787"
@@ -462,31 +464,18 @@ def test_service_loop_moves_unreadable_task_to_failed(tmp_path):
     task_file = pending / "000002-bad.task.json"
     task_file.write_text("not-json", encoding="utf-8")
 
-    result: dict[str, object] = {}
-
-    def _run_loop():
-        result["payload"] = BaseWorker.loop(poll_interval=0.05)
-
-    thread = threading.Thread(target=_run_loop, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 2.0
     failed_file = queue_root / "failed" / task_file.name
-    while time.time() < deadline and not failed_file.exists():
-        time.sleep(0.05)
+    payload_out = _run_until_task_moved(monkeypatch, task_file, failed_file)
 
     assert failed_file.exists(), "Unreadable task was not moved to failed"
-
-    assert BaseWorker.break_loop() is True
-    thread.join(timeout=2)
-    assert not thread.is_alive(), "Service loop did not stop after break_loop"
-
-    payload_out = result.get("payload")
+    assert failed_file.read_text(encoding="utf-8") == "not-json"
+    assert not task_file.exists()
     assert isinstance(payload_out, dict)
+    assert payload_out.get("status") == "stopped"
     assert payload_out.get("failed") == 0
 
 
-def test_service_loop_rejects_legacy_pickle_task_without_loading(tmp_path):
+def test_service_loop_rejects_legacy_pickle_task_without_loading(tmp_path, monkeypatch):
     worker = DummyWorker()
     BaseWorker._worker_id = 0
     BaseWorker._worker = "127.0.0.1:8787"
@@ -501,25 +490,15 @@ def test_service_loop_rejects_legacy_pickle_task_without_loading(tmp_path):
     legacy_task = pending / "000002-legacy.task.pkl"
     legacy_task.write_bytes(b"\x80\x04legacy-pickle-payload")
 
-    result: dict[str, object] = {}
-
-    def _run_loop():
-        result["payload"] = BaseWorker.loop(poll_interval=0.05)
-
-    thread = threading.Thread(target=_run_loop, daemon=True)
-    thread.start()
-
-    deadline = time.time() + 2.0
     failed_file = queue_root / "failed" / legacy_task.name
-    while time.time() < deadline and not failed_file.exists():
-        time.sleep(0.05)
+    payload_out = _run_until_task_moved(monkeypatch, legacy_task, failed_file)
 
     assert failed_file.exists(), "Legacy pickle task was not quarantined"
+    assert failed_file.read_bytes() == b"\x80\x04legacy-pickle-payload"
+    assert not legacy_task.exists()
     assert calls == []
-
-    assert BaseWorker.break_loop() is True
-    thread.join(timeout=2)
-    assert not thread.is_alive(), "Service loop did not stop after break_loop"
+    assert payload_out["status"] == "stopped"
+    assert payload_out["processed"] == 0
 
 
 def test_service_loop_records_worker_failures(tmp_path):


### PR DESCRIPTION
The Windows core run on `77ab575be412a44400b80cdb32d7378b388d8ba5` failed because the worker-failure test did not observe its terminal file within two seconds. Run the public service loop synchronously, requesting shutdown inside the worker or immediately after a real quarantine move, then assert completed terminal evidence and cleanup. This removes machine-speed assumptions and assertion-before-thread-cleanup paths from the four neighboring success/failure/quarantine tests. Heartbeat and concurrency tests remain threaded.

Only the service test module changes. Worker runtime and package metadata are unchanged. A pre-existing unused assignment in the adjacent shutdown test is removed while preserving the worker constructor call.

## Repro

- Original Windows failure: https://github.com/ThalesGroup/agilab/actions/runs/34443997662 (1 failed, 2624 passed, 25 skipped).
- Locally inject a 2.2-second delay into `service_support._dump_service_payload` only when publishing to `failed/`, and invoke `test_service_loop_records_worker_failures`. The original test fails at its two-second assertion although publication subsequently completes with `status=failed`, `error=boom`, and the traceback. The revised test passes with the identical injected delay.
- The isolated reproduction and downloaded CI artifacts are preserved in `reports/windows-service-failure/` (ignored local evidence). Reproduction command: `UV_PROJECT_ENVIRONMENT=.venv-dev uv --preview-features extra-build-dependencies run --no-sync python reports/windows-service-failure/reproduce_slow_publication.py`.

## Root Cause

The assertion imposed a two-second wall-clock performance limit on asynchronous task execution, logging, and durable publication. Failure-record correctness has no such timing contract. Its early assertion also bypassed `break_loop` and thread join, allowing test-owned work to leak into later tests. Windows logs confirm the expected exception reached the failure handler; they do not identify which I/O or scheduling operation consumed the deadline. The controlled delay reproduces the false-negative mechanism without claiming a runtime defect.

## Regression Test

The existing public `BaseWorker.loop` regression now stops after its failing task and checks failure status, error, traceback, counters, removal of pending/running claims, and cleared service state after the loop returns. The injected-delay reproduction fails before this change and passes afterward. The sibling sweep applies the same synchronous approach to successful execution and both quarantine paths, preserving the real filesystem moves and asserting their resulting bytes. Adjacent service and worker tests remain covered by the focused slice.

Validation:

- `UV_PROJECT_ENVIRONMENT=.venv-dev uv --preview-features extra-build-dependencies run --no-sync python -m pytest -q -o addopts='' src/agilab/core/test/test_base_worker_service_support.py src/agilab/core/test/test_base_worker.py`: 91 passed.
- Ruff on the touched test module, `git diff --check`, impact classification, staged scope, and agent provenance: passed.
- Native Windows run 34448871727 on final head `2eac10bb57d84bcbf98ea9094745c7599c600369`: passed, 2625 tests passed and 25 skipped. All four updated queue regressions passed (0.059–0.095 seconds each).
- Repository guards, Python 3.12/3.14 compatibility, Ubuntu/macOS/Windows public installs, GitGuardian, and root suite 34448871728: passed on final head `2eac10bb57d84bcbf98ea9094745c7599c600369`. Final PR checks: 9 successes, zero failures/pending checks, and the intentional public-demo skip.
- GitHub skipped `public-demo-smoke`: its schedule/workflow-dispatch condition does not apply to this PR event.
- Release builds/docs/UI robots: not applicable to this test-only fix; the separate release gate remains pending on merged main.

## Review Evidence

An independent reviewer was requested with the available `gpt-6-astra` model (high reasoning) under the repository's higher-model review rule. The reviewer self-reported GPT-6 with exact runtime variant unavailable. It reviewed both the initial change and final sibling sweep against the public service-loop implementation, baseline CI logs, and reproduction script. No blocking findings. Review only; no files edited and no independent test reruns. The reviewer noted that a future regression preventing the stop callback would rely on the outer test-job timeout, and that quarantine tests intentionally observe the existing `Path.replace` boundary. The primary Codex agent also reviewed the final diff.

## Agent Metadata

- Tokki: 1.0.63.
- Agent/runtime: Codex; runtime version unavailable.
- Model: GPT-6; exact model variant unavailable.
- Reasoning effort: unknown.
- `/fast` mode: unknown.

## Post-merge verification

Merged normally as `5e393cca69a91bb649a66d5cced1d41e107f87a3`, with a verified GitHub signature and an identical file tree to the tested PR head. Remote branch deleted; the local reviewed branch was bundled before deletion.

The full local `./dev release --impact-base-ref v2026.09.07` gate passed on clean merged main using the clean canonical docs checkout. It included 56 built-in app tests, 29 dependency-policy tests, and strict typing on 21 files. The existing Sphinx warning for `agi-page-inference-report-licenses.md` missing from a toctree also appears in the previous successful Pages run.

Main repository guards 34449931001, Pages 34449930988, and coverage 34449931033 passed. Live docs returned HTTP 200 and retain the published 2026.09.07 release/source-ahead contract.

**Main Windows run 34449930967 failed: 2 failed, 2623 passed, 25 skipped.** The four tests changed here passed. Two neighboring unchanged tests, `test_service_loop_skips_tasks_for_other_workers` and `test_service_loop_handles_disappearing_task_files`, exceeded their existing two-second thread shutdown waits (lines 591 and 697). The exact blocking operation is not established by the logs; release readiness remains blocked. Main root run 34449931130 passed. Windows is the remaining failed main check.

A follow-up candidate is preserved locally at `reports/windows-service-failure/test_base_worker_service_support.proposed.py` for the two failed tests plus their adjacent claim-race sibling. It observes a complete real queue scan at the idle-wait boundary and removes thread scheduling from those three assertions. Read-only review of this candidate found no blocking logic findings; it intentionally preserves separate threaded tests for asynchronous wakeup coverage. **The candidate is not applied, validated, committed, or pushed.**

Further shell validation/Git publishing is blocked by Tokki `protected_source_binary_integrity` (`integrity_detail=dirty`, build `595428dd9834d130b6a3395eca847408fd1f4cb9`). The supported remedy is to finish or restore the separately edited protected build inputs and rebuild the licensed runtime. No locks, quota state, source integrity checks or publication gates were bypassed. The GitHub connector was used to read the final job log and keep this evidence current. No PyPI publication or release workflow was dispatched.
