### PR TITLE
Include receipt tests in GUI coverage plans

### DIFF
--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="agi-gui coverage: 94%">
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="agi-gui coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="54.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="54.0" y="14">agi-gui coverage</text>
-  <text x="124.0" y="15" fill="#010101" fill-opacity=".3">94%</text>
-  <text x="124.0" y="14">94%</text>
+  <text x="124.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="124.0" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="agi-gui coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="agi-gui coverage: 94%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="54.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="54.0" y="14">agi-gui coverage</text>
-  <text x="124.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="124.0" y="14">95%</text>
+  <text x="124.0" y="15" fill="#010101" fill-opacity=".3">94%</text>
+  <text x="124.0" y="14">94%</text>
 </g>
 </svg>

--- a/test/test_coverage_shard_plan.py
+++ b/test/test_coverage_shard_plan.py
@@ -6,6 +6,8 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import pytest
+
 
 MODULE_PATH = Path("tools/coverage_shard_plan.py").resolve()
 
@@ -105,6 +107,29 @@ def test_timing_balanced_plan_greedily_spreads_slow_files(tmp_path) -> None:
             _item_chunk(plan, "test/test_first_launch_robot.py"),
         }
     ) == 3
+
+
+@pytest.mark.parametrize("with_timings", [False, True])
+def test_evidence_runtime_tests_are_in_coverage_plan(tmp_path, with_timings) -> None:
+    """A passing root suite must not conceal omitted evidence coverage tests."""
+    module = _load_module()
+    junit_path = tmp_path / "junit-agi-gui-support.xml"
+    if with_timings:
+        _write_junit(junit_path, [("test.test_evidence_graph", "graph", 1.0)])
+    plan = module.build_plan([str(junit_path)])
+    assert plan.mode == ("timing-balanced" if with_timings else "static")
+    scheduled = {arg for shard in plan.shards for arg in shard.pytest_args}
+    # Scope this contract to runtime evidence modules with a same-named root
+    # test file; inspect source inventory rather than duplicating the plan list.
+    expected = {
+        f"test/test_{source.stem}.py"
+        for source in sorted((module.REPO_ROOT / "src/agilab/evidence").glob("*.py"))
+        if (module.REPO_ROOT / f"test/test_{source.stem}.py").is_file()
+    }
+    assert expected, "No evidence runtime test pairs were discovered"
+    assert not expected - scheduled, (
+        f"Evidence tests omitted from coverage: {sorted(expected - scheduled)}"
+    )
 
 
 def test_timing_balanced_plan_does_not_schedule_legacy_src_test_package(tmp_path) -> None:

--- a/tools/coverage_shard_plan.py
+++ b/tools/coverage_shard_plan.py
@@ -68,6 +68,7 @@ STATIC_AGI_GUI_CHUNKS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "test/test_ga_regression_selector.py",
             "test/test_evidence_contract.py",
             "test/test_evidence_graph.py",
+            "test/test_skill_evaluation.py",
             "test/test_env_file_utils.py",
             "test/test_env_footprint.py",
             "test/test_import_guard.py",


### PR DESCRIPTION
The GUI coverage workflow omitted `test/test_skill_evaluation.py` from its curated test inventory, so the new receipt module appeared entirely uncovered even though the full root suite exercised it. Add the missing suite to the common shard inventory and guard paired evidence-module tests in both static and timing-balanced plans. Corrected local GUI coverage is 54,802/57,483 lines (95.3360%); the existing generator produces the committed 95% badge, leaving no net badge change.

## Repro

[Main coverage run 34470788143](https://github.com/ThalesGroup/agilab/actions/runs/34470788143) measured `evidence/skill_evaluation.py` at 0/282 covered lines and failed its badge freshness step. Both new parametrized cases fail against the original plan with `test/test_skill_evaluation.py` identified as omitted.

## Root Cause

Both coverage planning modes derive their test candidates from `STATIC_AGI_GUI_CHUNKS`. The new receipt tests were present in the full root suite but absent from that coverage inventory. The correction belongs in the inventory; the source coverage denominator and badge rendering policy remain unchanged.

## Regression Test

- `PYTHONPATH=src uv run --no-project python -m pytest -q -o addopts='' test/test_coverage_shard_plan.py test/test_skill_evaluation.py`: 42 passed.
- The new regression derives 11 evidence-module/same-named-test pairs from the source tree and checks that both static and timing-balanced plans schedule them.
- All seven GUI coverage groups from `tools/workflow_parity.py --profile agi-gui`: 3,991 passed, 7 skipped. The receipt module now measures 259/282 lines (91.84%); GUI coverage XML SHA-256 is `8f1cc8d71acae0ffc92affe1c98dd16fa7230fd3a26cb0b7b3755b4620a6bf83`.
- The local reports group initially failed because the unrelated sibling docs checkout differs from the public mirror. Reran only that group plus combine/XML steps using an isolated, hash-checked copy of this revision's public docs as a fixture. This validates the coverage change and does not establish live private-to-public docs alignment. Other six groups reused their successful current run artifacts. Skips are the existing platform/optional test markers; live browser validation is not applicable to this test-plan-only change.
- Ruff, whitespace, impact triage, provenance, staged scope, existing badge generation and badge guard passed. All component and aggregate badges are byte-identical to main. The four unaffected component XMLs come from the referenced main CI run; the corrected GUI measurement is local.
- All seven required GitHub checks passed on `f2d746738095d89347dd1586c4ec98ef324873e4`; Windows core and GitGuardian also passed. Public demo smoke was GitHub-skipped. The corrected post-merge main coverage workflow passed; see the current run evidence below.

## Review Evidence

GPT-6 Astra, high reasoning, reviewed the root cause, coverage inventory and regression read-only; no files edited and no actionable findings. Independently verified the original 0/282 result and the static/timing-balanced regression coverage. Final measurement review also passed: independently verified the corrected XML hash/counts, 3,991 passed/7 skipped, all 279 docs-fixture hashes, unchanged badge, and two-file net diff. A stronger-than-parent model could not be established from exposed runtime metadata.

## Agent Metadata

- Tokki: 1.0.63; existing user-authorized direct-command exception used for the broken protected runtime.
- Agent/runtime: Codex; installed CLI 0.153.4.
- Model: GPT-6; exact parent variant unavailable.
- Reasoning effort: unknown.
- `/fast` mode: unknown.

## Merge status

Normal merge of the reviewed head was rejected by base-branch policy; signature verification reports `unknown_key`. The operator approved the signature-only administrator exception with "merge all". The PR merged as `476ebf9771124e1b42f1d7bf1f85e58b06a9d050`; the merge tree equals the validated head tree. No required check was bypassed.


## Authorized Merge

The operator explicitly authorized "merge all" after the signature blocker was explained. This authorizes the signature-only administrative exception for PRs #997 and #999–#1002, including required base refreshes. For this PR, all seven required checks pass on `f2d746738095d89347dd1586c4ec98ef324873e4` against current main `dfeb1acb00c5e65fe372678dda695476e7325e71`. No failed/pending-check bypass or repository-policy change is authorized. The existing review and local coverage evidence above remain applicable.

Post-merge verification: [main coverage run 34480547765](https://github.com/ThalesGroup/agilab/actions/runs/34480547765) passed on `476ebf9771124e1b42f1d7bf1f85e58b06a9d050`, including all component jobs, GUI aggregation and the final badge guard.
