### PR TITLE
Fix operator signing identity for agent commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,11 +207,20 @@ Use this runbook whenever you:
 - **PR agent metadata**: Every AGILAB PR description must include an `Agent Metadata`
   section with the Tokki version (`tokki --version`, or `not used`/`unavailable`),
   agent/runtime name and version when exposed, model name, reasoning effort, and
-  whether `/fast` mode was used. Do not infer missing values; write `unknown`,
-  `unavailable`, or `not used` explicitly.
+  whether `/fast` mode was used. Record the confirmed human operator/approver
+  separately from the agent. For this operator's sessions, the user-confirmed
+  identity is Jean-Pierre MORARD (`jpmorard`); check the authenticated GitHub
+  actor before publishing. Never assign that identity to another contributor
+  by default. Technical fields describe the agent: use `not exposed by the
+  runtime` when unavailable and `not used` only when known, without guessing.
 - **Agent commit provenance**: Agent-prefixed branches such as `codex/*`,
   `codex-*`, `claude/*`, `aider/*`, `opencode/*`, and `agent/*` must not use a
-  human Git author or committer identity. Before committing on those branches,
+  human Git author or committer display names. An explicit agent display name
+  may use the confirmed operator's verified email and matching signing key.
+  Do not invent an agent noreply address: it may belong to a different account.
+  The offline guard checks effective author/committer names, including Git
+  config and environment overrides; it does not prove email ownership or
+  signature validity. Verify new signed commits on GitHub. Before committing on those branches,
   run `python3 tools/agent_commit_provenance_guard.py --check-config`; the
   repo hooks also run this guard at pre-commit and pre-push. If a released
   commit already has misleading identity metadata, do not rewrite public

--- a/AGENT_CONVENTIONS.md
+++ b/AGENT_CONVENTIONS.md
@@ -25,6 +25,10 @@ publication, or other risky surfaces, read [AGENTS.md](AGENTS.md) too.
   `BUILTIN_APPS`; do not substitute a root reinstall, manual `.env` edits, or
   ad-hoc pytest loops.
 - Keep edits narrow and validate with the smallest relevant proof first.
+- Agent commits need explicit agent author and committer display names. Use the
+  confirmed operator's verified email and matching signing key, and record the
+  operator separately in PR metadata. Do not invent a bot noreply address or
+  infer unavailable model/runtime settings from the operator's identity.
 - For successful final close-outs, write `Validation passed.` without listing
   every command unless failures, skipped checks, release/audit evidence, PR
   proof, or an explicit user request make the details useful.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -90,10 +90,10 @@ and repo-managed skills. It records recurring agent mistakes, not task logs.
 - Before acting on a stale sibling worktree reported by `./dev audit`, verify
   it still exists in `git worktree list --porcelain`. If it is missing, stop
   and ask whether to recreate that branch or continue from the current checkout.
-- On agent-prefixed branches such as `codex/*`, `codex-*`, `claude/*`,
-  `aider/*`, `opencode/*`, or `agent/*`, never commit with a human Git
-  identity. Run `python3 tools/agent_commit_provenance_guard.py --check-config`
-  before committing; configure an explicit agent identity when needed.
+- Agent branches require explicit agent author/committer names and the confirmed
+  operator's verified email/key; invented noreply addresses can cause `unknown_key`.
+  Run `python3 tools/agent_commit_provenance_guard.py --check-config` before commits
+  and verify new signatures on GitHub. Record the operator separately in PR metadata.
 - When `gh pr merge --delete-branch` fails because another local worktree owns
   `main`, check the remote PR state before retrying. Prefer a remote-only
   retry from outside the checkout, for example `gh pr merge <n> --repo

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -14,9 +14,9 @@
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
     "release-proof.rst": "ed22c62eaf881bb7e3e07beb452b8bfe17908b2dbff8d43b8a54f03084a95234"
   },
-  "source_digest_sha256": "298651da43faf528de79408e4288b85af9d15179c8f30366ccb47bbcd4d80449",
+  "source_digest_sha256": "499f53d4422046ff781920e1c8b08366d26f339197be2d8615da746176a28741",
   "source_hint": "../thales_agilab/docs/source",
   "source_status": "verified",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "298651da43faf528de79408e4288b85af9d15179c8f30366ccb47bbcd4d80449"
+  "target_digest_sha256": "499f53d4422046ff781920e1c8b08366d26f339197be2d8615da746176a28741"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -63,7 +63,13 @@ Agent commit provenance is checked separately::
 The output uses schema ``agilab.agent_commit_provenance.v1``. On
 agent-prefixed branches such as ``codex/*``, ``codex-*``, ``claude/*``,
 ``aider/*``, ``opencode/*``, and ``agent/*``, the guard rejects human Git
-author or committer identities and requires an explicit agent or bot identity.
+author or committer display names and requires explicit agent or bot names.
+Those names may use the confirmed operator's verified email and matching
+signing key. Do not invent a bot noreply address: it may belong to another
+GitHub account. The offline guard checks attribution conventions; verify email
+ownership and new commit signatures separately on GitHub. The config check
+reads effective identities, including author/committer config and environment
+overrides.
 The repo hooks run the config check before commits and the pushed-commit check
 before pushes, so agent-authored PRs cannot silently appear as human-authored
 work.
@@ -71,8 +77,14 @@ work.
 .. figure:: diagrams/agent_commit_provenance_guard.svg
    :alt: Diagram of the AGILAB agent commit provenance guard
 
-   Agent-prefixed branches are checked before commit and before push so the
-   Git author and committer fields stay aligned with PR Agent Metadata.
+   Agent-prefixed branches preserve explicit agent display names while the
+   confirmed operator owns the signing account.
+
+PR Agent Metadata records the confirmed operator/approver separately from the
+agent and its technical settings. In Jean-Pierre MORARD's confirmed sessions,
+the operator is ``jpmorard``; verify the publishing GitHub actor. Other operators
+must supply their own identity. For unavailable model/runtime details, write
+``not exposed by the runtime``. A person's name does not fill those fields.
 
 Shared repo contract
 --------------------

--- a/docs/source/diagrams/agent_commit_provenance_guard.svg
+++ b/docs/source/diagrams/agent_commit_provenance_guard.svg
@@ -50,7 +50,7 @@
   <text class="label" x="88" y="392">Old failure mode</text>
   <text class="body" x="88" y="422">
     <tspan x="88" dy="0">Local Git config kept a</tspan>
-    <tspan x="88" dy="24">human name and email, so</tspan>
+    <tspan x="88" dy="24">a human display name, so</tspan>
     <tspan x="88" dy="24">agent commits looked human.</tspan>
   </text>
 
@@ -59,17 +59,17 @@
   <text class="badgeText" x="524" y="171" text-anchor="middle">PRE-COMMIT</text>
   <text class="label" x="472" y="206">Config guard</text>
   <text class="body" x="472" y="236">
-    <tspan x="472" dy="0">Rejects human Git identity</tspan>
-    <tspan x="472" dy="24">before a commit is created</tspan>
-    <tspan x="472" dy="24">on an agent branch.</tspan>
+    <tspan x="472" dy="0">Checks effective Git names</tspan>
+    <tspan x="472" dy="24">and identity overrides</tspan>
+    <tspan x="472" dy="24">before an agent commit.</tspan>
   </text>
 
   <rect class="guard" x="448" y="352" width="290" height="132" rx="18"/>
   <text class="label" x="472" y="392">Required identity</text>
   <text class="body" x="472" y="422">
     <tspan x="472" dy="0">AGILAB Codex Agent</tspan>
-    <tspan x="472" dy="24">&lt;codex-agent@users.</tspan>
-    <tspan x="472" dy="24">noreply.github.com&gt;</tspan>
+    <tspan x="472" dy="24">Operator's verified email</tspan>
+    <tspan x="472" dy="24">and matching signing key</tspan>
   </text>
 
   <rect class="guard" x="862" y="132" width="290" height="190" rx="18"/>

--- a/test/test_agent_commit_provenance_guard.py
+++ b/test/test_agent_commit_provenance_guard.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "tools" / "agent_commit_provenance_guard.py"
+TEST_AGENT_EMAIL = "agent.operator@example.test"
+
+
+@pytest.fixture(autouse=True)
+def isolate_git_environment(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("GIT_") or key == "EMAIL":
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "empty-git-config"))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location("agent_commit_provenance_guard_test_module", MODULE_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "agent_commit_provenance_guard_test_module", MODULE_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -49,7 +64,143 @@ def test_agent_branch_detection_covers_codex_dash_and_slash() -> None:
     assert not module.is_agent_branch("main")
 
 
-def test_current_config_fails_for_human_identity_on_agent_branch(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("Claude Martin", False),
+        ("Talbot", False),
+        ("Codex Smith", False),
+        ("Claude Code", True),
+        ("OpenAI Codex", True),
+        ("AGILAB Codex Agent", True),
+        ("github-actions[bot]", True),
+    ],
+)
+def test_display_name_requires_explicit_agent_marker_or_runtime(name, expected):
+    module = _load_module()
+    assert module.is_agent_identity(module.Identity(name, TEST_AGENT_EMAIL)) is expected
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "203319130+jpmorard@users.noreply.github.com",
+        "123456+another-operator@users.noreply.github.com",
+    ],
+)
+def test_operator_email_preserves_agent_attribution_in_config_and_push(tmp_path, email):
+    module = _load_module()
+    _init_repo(tmp_path)
+    _git(tmp_path, "switch", "-c", "codex/provenance")
+    _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
+    _git(tmp_path, "config", "user.email", email)
+    report = module.check_current_config(tmp_path)
+    assert report["status"] == "pass"
+    assert report["evidence"]["effective_identities"]["committer"]["email"] == email
+    assert report["evidence"]["default_agent_identity"]["email"] is None
+    assert "Offline" in report["evidence"]["verification_basis"]
+    _git(
+        tmp_path,
+        "commit",
+        "--allow-empty",
+        "-m",
+        "agent work, operator signing account",
+    )
+    head = _git(tmp_path, "rev-parse", "HEAD")
+    spec = module.PushSpec(
+        "refs/heads/codex/provenance",
+        head,
+        "refs/heads/codex/provenance",
+        module.ZERO_SHA,
+    )
+    assert (
+        module.check_pre_push_specs(tmp_path, [spec], base_ref="main")["status"]
+        == "pass"
+    )
+
+
+def test_agent_looking_email_does_not_mask_human_display_name(tmp_path):
+    module = _load_module()
+    _init_repo(tmp_path)
+    _git(tmp_path, "switch", "-c", "codex/provenance")
+    _git(tmp_path, "config", "user.name", "Alex Maintainer")
+    _git(tmp_path, "config", "user.email", "codex.agent@example.test")
+    assert module.check_current_config(tmp_path)["status"] == "fail"
+
+
+@pytest.mark.parametrize("field", ["author", "committer"])
+@pytest.mark.parametrize("source", ["environment", "role-config"])
+def test_effective_identity_overrides_cannot_bypass_guard(
+    tmp_path, monkeypatch, field, source
+):
+    module = _load_module()
+    _init_repo(tmp_path)
+    _git(tmp_path, "switch", "-c", "codex/provenance")
+    _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
+    _git(tmp_path, "config", "user.email", TEST_AGENT_EMAIL)
+    if source == "environment":
+        monkeypatch.setenv(f"GIT_{field.upper()}_NAME", "Jean-Pierre MORARD")
+    else:
+        _git(tmp_path, "config", f"{field}.name", "Jean-Pierre MORARD")
+    report = module.check_current_config(tmp_path)
+    assert report["status"] == "fail"
+    assert {issue["field"] for issue in report["issues"]} == {field}
+
+
+def test_unresolved_effective_identity_fails_with_actionable_error(tmp_path):
+    module = _load_module()
+    _init_repo(tmp_path)
+    _git(tmp_path, "switch", "-c", "codex/provenance")
+    _git(tmp_path, "config", "--unset", "user.email")
+    _git(tmp_path, "config", "user.useConfigOnly", "true")
+    report = module.check_current_config(tmp_path)
+    assert report["status"] == "fail"
+    assert {issue["rule"] for issue in report["issues"]} == {
+        "agent-identity-unresolved"
+    }
+    assert "GIT_AUTHOR_IDENT" in report["issues"][0]["message"]
+    rendered = module.render_text(report)
+    assert "codex-agent@users.noreply.github.com" not in rendered
+    assert "confirmed verified email" in rendered
+
+
+@pytest.mark.parametrize(
+    "name,expected", [("AGILAB Codex Agent", "pass"), ("Jean-Pierre MORARD", "fail")]
+)
+def test_github_inventory_distinguishes_agent_name_from_operator_email(
+    monkeypatch, name, expected
+):
+    module = _load_module()
+
+    def github(args):
+        if args[1] == "list":
+            return [{"number": 1, "headRefName": "codex/example"}]
+        return {
+            "commits": [
+                {
+                    "oid": "a" * 40,
+                    "authors": [
+                        {
+                            "name": name,
+                            "email": "203319130+jpmorard@users.noreply.github.com",
+                        }
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(module, "_run_gh_json", github)
+    assert (
+        module.inventory_github_prs(repo="example/repo", limit=1, prefixes=["codex"])[
+            "status"
+        ]
+        == expected
+    )
+
+
+def test_current_config_fails_for_human_identity_on_agent_branch(
+    tmp_path: Path,
+) -> None:
     module = _load_module()
     _init_repo(tmp_path)
     _git(tmp_path, "switch", "-c", "codex/provenance")
@@ -60,7 +211,7 @@ def test_current_config_fails_for_human_identity_on_agent_branch(tmp_path: Path)
 
     assert report["status"] == "fail"
     assert report["issues"][0]["rule"] == "agent-branch-human-identity"
-    assert report["issues"][0]["field"] == "git-config"
+    assert {issue["field"] for issue in report["issues"]} == {"author", "committer"}
 
 
 def test_pre_push_fails_for_human_identity_commit_on_agent_branch(tmp_path: Path) -> None:
@@ -86,7 +237,7 @@ def test_pre_push_allows_explicit_agent_identity_on_agent_branch(tmp_path: Path)
     _init_repo(tmp_path)
     _git(tmp_path, "switch", "-c", "codex/provenance")
     _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
-    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    _git(tmp_path, "config", "user.email", TEST_AGENT_EMAIL)
     (tmp_path / "agent.txt").write_text("agent identity\n", encoding="utf-8")
     _git(tmp_path, "add", "agent.txt")
     _git(tmp_path, "commit", "-m", "good agent identity")
@@ -104,7 +255,7 @@ def test_pre_push_excludes_public_base_commits_after_branch_update(tmp_path: Pat
     _init_repo(tmp_path)
     _git(tmp_path, "switch", "-c", "agent/provenance")
     _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
-    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    _git(tmp_path, "config", "user.email", TEST_AGENT_EMAIL)
     (tmp_path / "agent.txt").write_text("first agent change\n", encoding="utf-8")
     _git(tmp_path, "add", "agent.txt")
     _git(tmp_path, "commit", "-m", "first agent change")
@@ -120,7 +271,7 @@ def test_pre_push_excludes_public_base_commits_after_branch_update(tmp_path: Pat
 
     _git(tmp_path, "switch", "agent/provenance")
     _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
-    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    _git(tmp_path, "config", "user.email", TEST_AGENT_EMAIL)
     _git(tmp_path, "merge", "--no-edit", "main")
     (tmp_path / "agent.txt").write_text("second agent change\n", encoding="utf-8")
     _git(tmp_path, "add", "agent.txt")
@@ -188,7 +339,7 @@ def test_git_history_inventory_skips_merges_by_default(tmp_path: Path) -> None:
     _init_repo(tmp_path)
     _git(tmp_path, "switch", "-c", "feature")
     _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
-    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    _git(tmp_path, "config", "user.email", TEST_AGENT_EMAIL)
     (tmp_path / "feature.txt").write_text("feature\n", encoding="utf-8")
     _git(tmp_path, "add", "feature.txt")
     _git(tmp_path, "commit", "-m", "feature")

--- a/tools/agent_commit_provenance_guard.py
+++ b/tools/agent_commit_provenance_guard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard agent branch commits from using human Git identities."""
+"""Require explicit agent display names while preserving operator-owned signing."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ import argparse
 import json
 import re
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
@@ -19,13 +18,11 @@ ZERO_SHA = "0" * 40
 FIELD_SEP = "\x1f"
 
 AGENT_BRANCH_RE = re.compile(r"^(codex|claude|aider|opencode|agent)(?:[-/].*)?$", re.I)
-AGENT_IDENTITY_TERMS = (
-    "agent",
+AGENT_RUNTIME_NAMES = (
     "aider",
-    "bot",
-    "claude",
+    "claude code",
     "codex",
-    "github-actions[bot]",
+    "openai codex",
     "opencode",
 )
 HUMAN_IDENTITY_TERMS = (
@@ -45,7 +42,6 @@ SUSPECT_DIRECT_HISTORY_TERMS = (
     "guilaumedemets",
 )
 DEFAULT_AGENT_NAME = "AGILAB Codex Agent"
-DEFAULT_AGENT_EMAIL = "codex-agent@users.noreply.github.com"
 
 
 @dataclass(frozen=True)
@@ -114,13 +110,14 @@ def is_agent_branch(branch: str) -> bool:
 
 
 def is_human_identity(identity: Identity) -> bool:
-    blob = _identity_blob(identity)
-    return any(term in blob for term in HUMAN_IDENTITY_TERMS)
+    # Email identifies the signing account, not who performed the agent work.
+    return any(term in identity.name.lower() for term in HUMAN_IDENTITY_TERMS)
 
 
 def is_agent_identity(identity: Identity) -> bool:
-    blob = _identity_blob(identity)
-    return any(term in blob for term in AGENT_IDENTITY_TERMS)
+    return bool(re.search(r"\b(?:agent|bot)\b", identity.name, re.I)) or (
+        identity.name.strip().lower() in AGENT_RUNTIME_NAMES
+    )
 
 
 def is_suspect_direct_history_identity(identity: Identity) -> bool:
@@ -140,8 +137,8 @@ def _identity_issues(*, branch: str, commit: str, field: str, identity: Identity
                 name=identity.name,
                 email=identity.email,
                 message=(
-                    "agent-prefixed branches must not use a human Git identity; "
-                    f"configure {DEFAULT_AGENT_NAME!r} <{DEFAULT_AGENT_EMAIL}> instead"
+                    "agent-prefixed branches require an explicit agent display name; "
+                    f"use {DEFAULT_AGENT_NAME!r} with the operator's confirmed email"
                 ),
             )
         ]
@@ -156,8 +153,8 @@ def _identity_issues(*, branch: str, commit: str, field: str, identity: Identity
                 name=identity.name,
                 email=identity.email,
                 message=(
-                    "agent-prefixed branches require an explicit agent/bot Git identity; "
-                    f"configure {DEFAULT_AGENT_NAME!r} <{DEFAULT_AGENT_EMAIL}> instead"
+                    "agent-prefixed branches require an explicit agent/bot display name; "
+                    f"use {DEFAULT_AGENT_NAME!r} with the operator's confirmed email"
                 ),
             )
         ]
@@ -207,17 +204,42 @@ def check_current_config(root: Path = REPO_ROOT) -> dict[str, Any]:
         email=_run_git(root, ["config", "--get", "user.email"], check=False),
     )
     issues: list[Issue] = []
+    effective: dict[str, dict[str, str]] = {}
     if is_agent_branch(branch):
-        issues.extend(_identity_issues(branch=branch, commit="", field="git-config", identity=identity))
+        for field in ("author", "committer"):
+            variable = f"GIT_{field.upper()}_IDENT"
+            raw = _run_git(root, ["var", variable], check=False)
+            match = re.fullmatch(r"(.+) <([^<>]+)> \d+ [+-]\d{4}", raw)
+            if match is None:
+                issues.append(
+                    Issue(
+                        severity="error",
+                        rule="agent-identity-unresolved",
+                        branch=branch,
+                        field=field,
+                        message=f"Cannot resolve {variable}; configure its name and confirmed email.",
+                    )
+                )
+                continue
+            resolved = Identity(name=match[1], email=match[2])
+            effective[field] = asdict(resolved)
+            issues.extend(
+                _identity_issues(
+                    branch=branch, commit="", field=field, identity=resolved
+                )
+            )
     return _build_report(
         action="check-config",
         issues=issues,
         evidence={
             "branch": branch,
             "git_config": asdict(identity),
+            "effective_identities": effective,
+            "verification_basis": "Offline display-name convention only; email ownership and GitHub signatures require separate verification.",
             "default_agent_identity": {
                 "name": DEFAULT_AGENT_NAME,
-                "email": DEFAULT_AGENT_EMAIL,
+                "email": None,
+                "email_requirement": "Use the current operator's confirmed verified address and matching signing key.",
             },
         },
     )
@@ -494,15 +516,14 @@ def inventory_github_prs(
                         name=str(author.get("name") or ""),
                         email=str(author.get("email") or ""),
                     )
-                    if is_human_identity(identity) or not is_agent_identity(identity):
-                        issues.extend(
-                            _identity_issues(
-                                branch=branch,
-                                commit=commit_sha,
-                                field="github-pr-author",
-                                identity=identity,
-                            )
+                    issues.extend(
+                        _identity_issues(
+                            branch=branch,
+                            commit=commit_sha,
+                            field="github-pr-author",
+                            identity=identity,
                         )
+                    )
     return _build_report(
         action="github-inventory",
         issues=issues,
@@ -549,7 +570,9 @@ def render_text(report: Mapping[str, Any]) -> str:
                 "",
                 "Use an explicit agent identity on agent-prefixed branches:",
                 f"  git config user.name {DEFAULT_AGENT_NAME!r}",
-                f"  git config user.email {DEFAULT_AGENT_EMAIL!r}",
+                "  Set user.email to the current operator's confirmed verified email.",
+                "  Keep the matching signing key; verify the new commit on GitHub.",
+                "  Check author/committer Git settings and GIT_AUTHOR_*/GIT_COMMITTER_* overrides.",
             ]
         )
     return "\n".join(lines)

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -47,10 +47,21 @@ python3 tools/agent_commit_provenance_guard.py --inventory-github --repo ThalesG
 
 The output uses schema `agilab.agent_commit_provenance.v1`. On agent-prefixed
 branches such as `codex/*`, `codex-*`, `claude/*`, `aider/*`, `opencode/*`,
-and `agent/*`, the guard rejects human Git author or committer identities and
-requires an explicit agent or bot identity. The repo hooks run the config check
+and `agent/*`, the guard requires explicit agent or bot author and committer
+display names. The confirmed operator's verified email and matching signing key
+may be used with those names. Never invent a bot noreply address: it may belong
+to a different GitHub account. The offline guard checks attribution conventions;
+email ownership and remote signature verification are separate checks.
+The config check reads effective Git identities, including author/committer
+configuration and environment overrides. The repo hooks run the config check
 before commits and the pushed-commit check before pushes, so agent-authored PRs
 cannot silently appear as human-authored work.
+
+PR Agent Metadata records the confirmed operator/approver separately from the
+agent and its technical settings. In Jean-Pierre MORARD's confirmed sessions,
+the operator is `jpmorard`; verify the publishing GitHub actor. Other operators
+must supply their own identity. When model/runtime details are unavailable,
+write `not exposed by the runtime`; a person's name does not fill those fields.
 
 The README badge contract is:
 


### PR DESCRIPTION
Agent commits can retain explicit agent display names while using the confirmed operator's verified email and matching signing key. The provenance guard now checks effective author and committer identities, including Git configuration and environment overrides, and PR guidance records the human operator separately from agent/runtime settings.

## Repro

Commit `71680f724bb482446a64552195bfa37556ccc953` used the former generic agent noreply address with `jpmorard`'s SSH key. GitHub associated that address with another account and returned `unknown_key`; PR #1003 needed an explicitly approved signature exception despite passing CI.

## Root Cause

The guard treated an operator-owned email as human authorship and recommended an invented agent account address. It also checked only `user.name`/`user.email`, so effective author/committer overrides could escape validation.

The repair requires explicit agent/bot display names or exact known runtime names, removes the invented email default and advice, and reads `git var GIT_AUTHOR_IDENT` and `GIT_COMMITTER_IDENT`. Names such as `Claude Martin` do not count as explicit agent attribution. The guard remains an offline convention check; email ownership and GitHub signature verification are separate evidence.

Operator-authorized guidance identifies Jean-Pierre MORARD (`jpmorard`) in his confirmed sessions, preserves separate agent attribution, and uses `not exposed by the runtime` for unavailable technical settings. Other contributors are not assigned his identity. Canonical docs, the public mirror/stamp, and the existing SVG were updated together.

## Regression Test

- 39 targeted tests passed: `VIRTUAL_ENV=/Users/agi/PycharmProjects/agilab/.venv-dev uv run --no-project python -m pytest -q -o addopts= test/test_agent_commit_provenance_guard.py test/test_agent_workflows.py test/test_agent_instruction_contract.py`.
- Covers operator and other-operator email acceptance, human-name rejection despite agent-looking email, author/committer environment and role-config overrides, unresolved identities, pre-push checks, GitHub inventory, ambiguous runtime words, and unchanged historical inventory. Git test fixtures isolate inherited config/signing/environment state.
- Ruff, instruction/capability/agenticweb checks, impact/scope checks, SVG marker checks, and pre-push guards passed. Docs workflow parity passed with one existing, unrelated `toc.not_included` warning for `agi-page-inference-report-licenses.md`.
- Chrome inspected the generated HTML and SVG: no text overflow or browser runtime/network issues. The temporary preview host supplies an empty favicon response.
- GitHub confirms [commit 89149a6](https://github.com/ThalesGroup/agilab/commit/89149a63290b7b5bdfcbe931e1d1ce28b1f61416) is `verified: true`, reason `valid`, with author and committer login `jpmorard`. This is the live verification of the signing repair; the guard itself does not assert cryptographic validity.
- All ten reported GitHub checks passed at `89149a63290b7b5bdfcbe931e1d1ce28b1f61416`, including [root tests](https://github.com/ThalesGroup/agilab/actions/runs/34499988437), [Windows core](https://github.com/ThalesGroup/agilab/actions/runs/34499988303), [docs mirror verification](https://github.com/ThalesGroup/agilab/actions/runs/34499988389), and [policy/compatibility/clean-install checks](https://github.com/ThalesGroup/agilab/actions/runs/34499988378). `public-demo-smoke` was GitHub skipped. Normal merge required no admin exception. No signing rules or historical commits were changed.

## Review Evidence

GPT-6 Astra, high reasoning, reviewed the design and final diff read-only. Its ambiguous-name finding was fixed, regression-tested, and re-reviewed with no further issues. The reviewer did not edit files or run tests. A demonstrably stronger-than-primary model could not be verified because the primary variant is not exposed.

## Agent Metadata

- Operator and approver: Jean-Pierre MORARD (`jpmorard`), user-confirmed and matched to the authenticated GitHub account
- Tokki: 1.0.63
- Agent/runtime: Codex; runtime version not exposed
- Model: GPT-6; exact variant not exposed
- Reasoning effort: not exposed by the runtime
- `/fast` mode: not exposed by the runtime
