### PR TITLE
Complete app versions for the 2026.09.09 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ await package publication.
 
 ### Changed
 
+- Added an offline first-proof execution tour and a replayable guided drift
+  lesson in Learning & Assessment.
+- Added frozen skill receipts, source-linked evidence graph explanations, and
+  replayable telemetry feature analysis.
+- Added declarative data-quality rules with hashed evaluation evidence.
+- Added read-only MCP and CLI artifact previews linked to saved manifests and
+  verified against the recorded artifact hash.
+- Corrected agent commit signing attribution and recorded the confirmed
+  operator separately from agent/runtime metadata.
 - Improved DAG execution selection, stage navigation, and inspection of run
   evidence and neighboring stages.
 - Kept analysis artifacts consistent and fresh across forecast, live-artifact,

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-09-10"
+updated: "2026-09-11"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-09-10T15:14:13Z",
+  "generated_at_utc": "2026-09-11T06:35:11Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -584,7 +584,7 @@
       "name": "agi-app-data-quality-gate",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.07.31",
+      "version": "2026.09.09",
       "description": "AGILAB deterministic data contract, drift, leakage, and promotion gate",
       "project": "src/agilab/lib/agi-app-data-quality-gate",
       "pyproject": "src/agilab/lib/agi-app-data-quality-gate/pyproject.toml",
@@ -606,7 +606,7 @@
       "name": "agi-app-learning-assessment",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.09.07",
+      "version": "2026.09.09",
       "description": "AGILAB learning and assessment workflow with evidence scoring and regression-plan artifacts",
       "project": "src/agilab/lib/agi-app-learning-assessment",
       "pyproject": "src/agilab/lib/agi-app-learning-assessment/pyproject.toml",
@@ -675,7 +675,7 @@
       "package": "agi-app-data-quality-gate",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-data-quality-gate",
-      "version": "2026.07.31",
+      "version": "2026.09.09",
       "description": "AGILAB deterministic data contract, drift, leakage, and promotion gate"
     },
     {
@@ -707,7 +707,7 @@
       "package": "agi-app-learning-assessment",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-learning-assessment",
-      "version": "2026.09.07",
+      "version": "2026.09.09",
       "description": "AGILAB learning and assessment workflow with evidence scoring and regression-plan artifacts"
     },
     {

--- a/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
+++ b/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.31"
+version = "2026.09.09"
 name = "agi-app-data-quality-gate"
 description = "AGILAB deterministic data contract, drift, leakage, and promotion gate"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-learning-assessment/pyproject.toml
+++ b/src/agilab/lib/agi-app-learning-assessment/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.09.07"
+version = "2026.09.09"
 name = "agi-app-learning-assessment"
 description = "AGILAB learning and assessment workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.09.09", "agi-app-mission-decision==2026.07.31", "agi-app-pandas-execution==2026.07.31", "agi-app-polars-execution==2026.07.31", "agi-app-flight-telemetry==2026.07.31", "agi-app-multi-dag==2026.07.17", "agi-app-weather-forecast==2026.07.31", "agi-app-sklearn-pipeline==2026.07.31", "agi-app-data-quality-gate==2026.07.31", "agi-app-pytorch-playground==2026.07.31; python_version >= '3.12'", "agi-app-learning-assessment==2026.09.07; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.07.31; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.09.09", "agi-app-mission-decision==2026.07.31", "agi-app-pandas-execution==2026.07.31", "agi-app-polars-execution==2026.07.31", "agi-app-flight-telemetry==2026.07.31", "agi-app-multi-dag==2026.07.17", "agi-app-weather-forecast==2026.07.31", "agi-app-sklearn-pipeline==2026.07.31", "agi-app-data-quality-gate==2026.09.09", "agi-app-pytorch-playground==2026.07.31; python_version >= '3.12'", "agi-app-learning-assessment==2026.09.09; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.07.31; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
The Data Quality Gate rules and Learning & Assessment drift lesson were merged after the initial 2026.09.09 release preparation. Their package versions still existed on PyPI, so optimized publication would skip those changes. Bump those two apps to 2026.09.09, update their exact `agi-apps` pins and generated discovery metadata, and include the intervening merged features in the unpublished changelog.

## Repro

`tools/release_plan.py --impact-base-ref v2026.09.07 --skip-existing-pypi` selected 16 impacted packages but excluded the two changed apps because their old wheel/sdist versions already existed.

## Root Cause

The app changes landed after the earlier release preparation without new distribution versions. Publication correctly skips existing artifacts. The first PR CI run also caught stale generated capability metadata after the version bump; the failure was reproduced locally, then the existing skills/discovery generation profile refreshed both discovery artifacts.

## Regression Test

- 38 dependency hygiene and release version-policy tests passed.
- The affected apps passed nine Data Quality Gate tests in its app environment and 27 Learning & Assessment package/lesson tests.
- Built the two app wheels, `agi-apps`, and `agilab`; inspected wheel metadata to verify version 2026.9.9 and the exact bundle pins.
- The optimized impact plan now selects all 16 impacted packages with no existing-artifact skips.
- Dependency-policy, shared-core-typing, docs, and agi-gui workflow profiles passed. Docs retained one pre-existing warning for the inference-report license page not being in a toctree.
- GUI validation recorded 3,997 passed tests and seven skips: debugpy unavailable (one), Windows-only handle test on macOS (one), Playwright unavailable (two), and torch unavailable (three). The publication workflow includes a separate browser smoke environment.
- The 18 capability-manifest, agenticweb, and instruction-contract tests passed after regeneration; the instruction contract reports zero issues. The existing AGENT_LEARNINGS rule already requires the skills profile after package-version changes and was followed for this repair.
- After committing the generated artifacts, the skills profile passed again without drift.
- PR CI passed on `2c4e32a4fb6e961b30024906bd893c551d92defa`: root-test-suite run 34570715962 and repo-guardrails run 34570715937, plus GitGuardian. This supersedes the initial stale-manifest failure. Public-demo-smoke is GitHub skipped for this scope; hosted smoke remains part of the release workflow.
- After merge, maintenance and the complete `./dev release` gate passed on exact merge commit `3349fc0a85ee264d8f30da999c50df679212fed0` in an isolated clone. This included the strict audit, PyPI checks, built-in app tests, dependency/typing/docs checks, and coverage guard (no coverage-sensitive diff at merged main). The initial all-worktrees audit warning was resolved by isolation; no worktrees were discarded and no audit guard was disabled. Maintenance retained its non-blocking coverage-goal, TODO, and activity-badge warnings.

## Release Scope

The user authorized completing publication of the merged changes. This PR contains only the two app versions, their bundle pins, generated discovery artifacts, and changelog entries. The release version remains the already prepared 2026.09.09. The app pair and dependent bundle form one coherent release change; the local push scope exception is limited to these six files. No core implementation is changed. Publication will use the existing workflow after the release gates pass, including its protected environment approval.

## Review Evidence

A separate Codex reviewer using the GPT-6 family found no blocking issue in the version/changelog patch or in the subsequent generated discovery refresh. Exact model variant and reasoning effort were not exposed, so stronger-than-parent status is unavailable. Review only; no files edited or tests run by the reviewer.

## Agent Metadata

- Confirmed operator/approver: jpmorard (Jean-Pierre MORARD)
- Tokki version: 1.0.63
- Agent/runtime: Codex; runtime version not exposed
- Model: GPT-6 family; exact variant not exposed by the runtime
- Reasoning effort: not exposed by the runtime
- Fast mode: not exposed by the runtime
