### PR TITLE
docs: verify effective deployment approval routes

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -35,10 +35,11 @@ and repo-managed skills. It records recurring agent mistakes, not task logs.
 - Before installing third-party agent skills, inspect the install mode and
   filesystem result. Run `streamlit skills --global` because project mode adds
   repo-local symlinks; verify the home copy and project discovery separately.
-- When a pre-push guard fails, do not bypass it silently. Re-run the underlying
-  guard with useful output, classify whether the failure belongs to the current
-  diff, a real repository contract, or polluted local filesystem state, then
-  fix the right layer or document the exact unrelated failure before pushing.
+- When a pre-push guard fails, rerun it with useful output; classify diff,
+  contract, or local-pollution causes, then fix or document it before pushing.
+  For release approvals, verify live reviewer eligibility and each environment's
+  rules; admin access and documented button names do not prove an available route.
+  Apply only authorized exceptions and verify temporary protections are restored.
 - When adding or changing visible UI actions, audit sibling pages for semantic collisions;
   the same button text must not mean different operations. Update page tests and robot labels.
   Before pushing, run `python3 tools/ui_robot_action_contract.py`; register stateful actions
@@ -53,10 +54,9 @@ and repo-managed skills. It records recurring agent mistakes, not task logs.
   step after its safety gate, report the result, and provide the next
   recommendation without requiring a second user round trip unless a real
   blocker needs input.
-- When asked for token-saving or workflow-saving tactics and a repo-local
-  default is clear, do not end with a broad clarification menu. State the
-  assumed target, choose the highest-leverage applicable mechanism, and either
-  implement it or name the exact blocker that prevents implementation.
+- When asked for token-saving or workflow-saving tactics and a repo-local default
+  is clear, state the assumed target, choose the highest-leverage applicable
+  mechanism, and implement it or name the exact blocker; avoid broad clarification menus.
 - When a product or code fix was designed or implemented with model assistance,
   request a review from a stronger model before closing, pushing, or merging
   when that is available. If no stronger model is available, say so explicitly


### PR DESCRIPTION
GitHub administrator access did not make the operator eligible for ordinary deployment review, and the documented bypass control was absent from the run page. Require live reviewer and environment checks before giving an approval route, and verify restoration after an explicitly authorized temporary exception.

The existing pre-push failure guidance is retained in condensed form. The token-saving paragraph is reflowed with its meaning preserved to keep the 120-line maintenance limit.

## Repro

Release run [34578309790](https://github.com/ThalesGroup/agilab/actions/runs/34578309790) reported `current_user_can_approve=false` for `jpmorard` despite repository administrator access and `can_admins_bypass=true`; the operator reported that the documented button was absent.

## Root Cause

The operating guidance treated administrator bypass capability as proof of an available approval route without verifying reviewer eligibility or the actual browser control.

## Regression Test

`tools/agent_instruction_contract.py --check` passed, including the 120-line ledger limit; scope, staged impact, whitespace and enabled pre-push guards passed. Browser automation is not practical for this conditional third-party control, so the manual validation is the run's approval history plus live environment rules and reviewer eligibility. The authorized approval was recorded and original protections were restored and verified.

GitHub CI passed on `4035ae09f4af2f18f9d5c388e7c74c4c82bc5bb9` (8 successful checks). `public-demo-smoke` was GitHub skipped because this is a documentation-only change. The new commit signature is GitHub verified.

## Agent Metadata

- Human operator/approver: Jean-Pierre MORARD (`jpmorard`), authenticated GitHub actor verified.
- Tokki: 1.0.63 active runtime unavailable because of unrelated protected-source drift; the operator previously authorized direct `uv`/`gh` execution with AGILAB guards enabled.
- Agent/runtime: Codex; exact runtime version not exposed by the runtime.
- Model: GPT-6 family; exact variant not exposed by the runtime.
- Reasoning effort: not exposed by the runtime.
- `/fast`: not exposed by the runtime.
