### PR TITLE
docs(release): publish signed 2026.09.09 evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,17 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 
 ## Unreleased
 
-Release target: **2026.09.09**. The changes below are merged in source and
-await package publication.
+## [2026.09.09] - 2026-09-11
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.09-1
+
+Publication evidence: [successful recovery workflow](https://github.com/ThalesGroup/agilab/actions/runs/34578309790).
 
 ### Changed
 
+- Published AGILAB `2026.09.09` to PyPI for `agi-env`, `agi-gui`, `agi-page-timeseries-forecast`, `agi-page-live-artifacts`, `agi-page-geospatial-map`, `agi-page-network-map`, `agi-page-feature-attribution`, `agi-page-training-report`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-data-quality-gate`, `agi-app-learning-assessment`, `agi-apps`, and `agilab`.
+- Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
+- Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
 - Added an offline first-proof execution tour and a replayable guided drift
   lesson in Learning & Assessment.
 - Added frozen skill receipts, source-linked evidence graph explanations, and
@@ -976,3 +982,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04
 [2026.07.17.1]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17_1
 [2026.07.31]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.31
 [2026.09.07]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07
+[2026.09.09]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.09-1

--- a/badges/pypi-version-agilab.svg
+++ b/badges/pypi-version-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.09.07">
+<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.09.09">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="19" y="15" fill="#010101" fill-opacity=".3">pypi</text>
   <text x="19" y="14">pypi</text>
-  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.09.07</text>
-  <text x="81.5" y="14">v2026.09.07</text>
+  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.09.09</text>
+  <text x="81.5" y="14">v2026.09.09</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,7 +2,7 @@
   "file_count": 276,
   "format_version": 3,
   "managed_target": "docs/source",
-  "public_owned_digest_sha256": "6869cf40bac023de1bb62a9399cbd93d1db318bc173990ac3068a505d2bfc7d0",
+  "public_owned_digest_sha256": "690a965fce960d05dc9f012f4a6d4b6a51b0ccbfd31d064aafff50d51edd0225",
   "public_owned_exclusions": [
     "data/release_proof.toml",
     "data/ui_robot_evidence.json",
@@ -10,9 +10,9 @@
   ],
   "public_owned_file_count": 3,
   "public_owned_files_sha256": {
-    "data/release_proof.toml": "88f6996d2e2c4e1d5edf4fae5570e5ca2cf51c8ad52bda48055df58e1c8163d6",
+    "data/release_proof.toml": "ab74dfbd07739070d145573dc3b57e36aa0983a858af0b96eeadff71f2ee181d",
     "data/ui_robot_evidence.json": "18c47a02a0122f6de1dbcffbdee31b6ed4eb53223d0dcb44b9a64bdc07e0dbac",
-    "release-proof.rst": "ed22c62eaf881bb7e3e07beb452b8bfe17908b2dbff8d43b8a54f03084a95234"
+    "release-proof.rst": "cd6f1407368392c3556a10c51e911a35514fdc5d149a56373d355a88a73096fc"
   },
   "source_digest_sha256": "499f53d4422046ff781920e1c8b08366d26f339197be2d8615da746176a28741",
   "source_hint": "../thales_agilab/docs/source",

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -20,18 +20,18 @@ related_pages = [
 
 [release]
 package_name = "agilab"
-package_version = "2026.09.07"
-source_version_relation = "ahead"
+package_version = "2026.09.09"
+source_version_relation = "exact"
 package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.09.07"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07"
-github_release_commit = "5d60124b8699803198fd692969328dce262083b3"
+github_release_tag = "v2026.09.09-1"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.09-1"
+github_release_commit = "1dc1002246fa4e6ff94411cf5a2ca1263217bffd"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
-hf_space_commit = "c102870edcb18d51d8c5225c13b2ae90357f4c7a"
+hf_space_commit = "52abf142970f712a8605f3b0ff48e9b47b323e54"
 dataset_release_tag = "datasets-535fcc176054e2fb"
 dataset_manifest_sha256 = "535fcc176054e2fb8e39c83d428273ea52c1521eaa2c694c39c3ee5a89df8d93"
 dataset_count = 10
@@ -45,47 +45,47 @@ expected_app_count = 14
 id = "release-guardrails"
 label = "Public guardrails"
 workflow = "repo-guardrails"
-run_id = "30618909264"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/30618909264"
-head_sha = "bae393fe6aef1b5dce7130f278867ddd9812900b"
+run_id = "34586112200"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/34586112200"
+head_sha = "a98b63c77d37633cb41744f22edc6e7c4c356596"
 summary = "passed repository guardrails; skipped jobs remain out of scope unless separately evidenced"
 
 [[ci_runs]]
 id = "docs-source-guard"
 label = "Docs source guard"
 workflow = "docs-source-guard"
-run_id = "30618909234"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/30618909234"
-head_sha = "bae393fe6aef1b5dce7130f278867ddd9812900b"
+run_id = "34501192329"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/34501192329"
+head_sha = "5dd3651b8ed88e111917bcb37b9fdf395eb76c77"
 summary = "passed docs mirror and release-proof consistency checks; canonical private-source drift is not checked by public CI"
 
 [[ci_runs]]
 id = "docs-publish"
 label = "Docs publish"
 workflow = "docs-publish"
-run_id = "30619166574"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/30619166574"
-head_sha = "81797b8193f6ffe7e6a163a8f19c1d630674a2df"
+run_id = "34501192332"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/34501192332"
+head_sha = "5dd3651b8ed88e111917bcb37b9fdf395eb76c77"
 summary = "built the public documentation from the managed docs mirror"
 
 [[ci_runs]]
 id = "coverage"
 label = "Coverage"
 workflow = "coverage"
-run_id = "30618909177"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/30618909177"
-head_sha = "bae393fe6aef1b5dce7130f278867ddd9812900b"
+run_id = "34577976386"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/34577976386"
+head_sha = "1dc1002246fa4e6ff94411cf5a2ca1263217bffd"
 summary = "passed component coverage and badge freshness checks"
 
 [[ci_runs]]
 id = "pypi-publish"
 label = "PyPI publish"
 workflow = "pypi-publish"
-run_id = "34148757505"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/34148757505/attempts/3"
-head_sha = "5d60124b8699803198fd692969328dce262083b3"
+run_id = "34578309790"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/34578309790/attempts/1"
+head_sha = "1dc1002246fa4e6ff94411cf5a2ca1263217bffd"
 summary = "publication workflow for the recorded release commit; see the linked attempt for its final result"
-attempt = "3"
+attempt = "1"
 
 [proof_command]
 summary = "A clean package install can run the public first proof:"

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -8,12 +8,6 @@ This page is the public verification index for the current AGILAB release. It
 records install, CI, demo, and scope evidence in one place so reviewers can
 check the release without inferring status from scattered badges.
 
-.. note::
-
-   The source checkout is intentionally ahead of the public release
-   ``2026.09.07``. The package and links below still describe that exact
-   published release.
-
 Current public release
 ----------------------
 
@@ -24,23 +18,23 @@ Current public release
    * - Item
      - Public evidence
    * - Package version
-     - ``agilab[examples]==2026.09.07`` on `PyPI <https://pypi.org/project/agilab/>`__
+     - ``agilab[examples]==2026.09.09`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.09.07 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.07>`__
+     - `v2026.09.09-1 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.09-1>`__
    * - Dataset release
      - `datasets-535fcc176054e2fb <https://github.com/ThalesGroup/agilab/releases/tag/datasets-535fcc176054e2fb>`__ for ``10`` tracked dataset files; manifest ``535fcc176054e2fb8e39c83d428273ea52c1521eaa2c694c39c3ee5a89df8d93``
    * - Hosted demo
-     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``c102870edcb18d51d8c5225c13b2ae90357f4c7a``
+     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``52abf142970f712a8605f3b0ff48e9b47b323e54``
    * - Public guardrails
-     - `repo-guardrails run 30618909264 <https://github.com/ThalesGroup/agilab/actions/runs/30618909264>`__ at commit ``bae393fe6aef`` passed repository guardrails; skipped jobs remain out of scope unless separately evidenced
+     - `repo-guardrails run 34586112200 <https://github.com/ThalesGroup/agilab/actions/runs/34586112200>`__ at commit ``a98b63c77d37`` passed repository guardrails; skipped jobs remain out of scope unless separately evidenced
    * - Docs source guard
-     - `docs-source-guard run 30618909234 <https://github.com/ThalesGroup/agilab/actions/runs/30618909234>`__ at commit ``bae393fe6aef`` passed docs mirror and release-proof consistency checks; canonical private-source drift is not checked by public CI
+     - `docs-source-guard run 34501192329 <https://github.com/ThalesGroup/agilab/actions/runs/34501192329>`__ at commit ``5dd3651b8ed8`` passed docs mirror and release-proof consistency checks; canonical private-source drift is not checked by public CI
    * - Docs publish
-     - `docs-publish run 30619166574 <https://github.com/ThalesGroup/agilab/actions/runs/30619166574>`__ at commit ``81797b8193f6`` built the public documentation from the managed docs mirror
+     - `docs-publish run 34501192332 <https://github.com/ThalesGroup/agilab/actions/runs/34501192332>`__ at commit ``5dd3651b8ed8`` built the public documentation from the managed docs mirror
    * - Coverage
-     - `coverage run 30618909177 <https://github.com/ThalesGroup/agilab/actions/runs/30618909177>`__ at commit ``bae393fe6aef`` passed component coverage and badge freshness checks
+     - `coverage run 34577976386 <https://github.com/ThalesGroup/agilab/actions/runs/34577976386>`__ at commit ``1dc1002246fa`` passed component coverage and badge freshness checks
    * - PyPI publish
-     - `pypi-publish run 34148757505 <https://github.com/ThalesGroup/agilab/actions/runs/34148757505/attempts/3>`__ at commit ``5d60124b8699`` publication workflow for the recorded release commit; see the linked attempt for its final result
+     - `pypi-publish run 34578309790 <https://github.com/ThalesGroup/agilab/actions/runs/34578309790/attempts/1>`__ at commit ``1dc1002246fa`` publication workflow for the recorded release commit; see the linked attempt for its final result
 
 What was proved
 ---------------
@@ -49,7 +43,7 @@ What was proved
 
   .. code-block:: bash
 
-     python -m pip install "agilab[examples]==2026.09.07"
+     python -m pip install "agilab[examples]==2026.09.09"
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
 - The pinned GitHub Actions rows record successful repository, documentation,
@@ -86,7 +80,7 @@ the current source checkout:
    python -m venv .venv
    . .venv/bin/activate
    python -m pip install --upgrade pip
-   python -m pip install "agilab[examples]==2026.09.07"
+   python -m pip install "agilab[examples]==2026.09.09"
    python -m agilab.lab_run first-proof --json --max-seconds 60
 
 Use :doc:`quick-start` when you want the fuller source-checkout path with the


### PR DESCRIPTION
## Summary

Replace #1009 with a signed commit containing the identical validated source tree. The original workflow commit in that PR was unsigned, so the required-signatures rule blocked a normal merge despite all nine CI checks passing. This branch preserves the existing PR history and introduces one signed agent commit from current main.

Record the completed 2026.09.09 publication under recovery tag `v2026.09.09-1`, including publication workflow attempt 1, release commit `1dc1002246fa4e6ff94411cf5a2ca1263217bffd`, and deployed Hugging Face commit `52abf142970f712a8605f3b0ff48e9b47b323e54`. Correct the changelog publication date to September 11 and refresh the public proof's CI references.

The workflow-generated manifest, rendered proof, version badge, and mirror stamp are retained and finalized here. The public-owned proof files are validated independently; the remaining documentation mirror was verified against the available canonical source. Immutable proof assets attached to the release retain the original publication snapshot; both downloaded proof files match their published SHA-256 checksums.

## Repro

After the successful publication, the generated changelog still said the release awaited package publication, and the public proof retained July CI links.

## Root Cause

Release generation retained freeform pending-publication prose and previous CI references. The release-date curation and existing GitHub evidence refresh had not yet been applied to the generated PR. The workflow also created its evidence commit with unsigned local `git commit`; a verified later commit does not satisfy the signature requirement for earlier commits introduced by a PR.

## Regression Test

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_release_proof_report.py`: 45 passed.
- `tools/release_proof_report.py --render --check --check-github-runs --compact`: passed, preserving the exact publication attempt and the public CI canonical-source limitation.
- `tools/workflow_parity.py --profile docs`: passed. Sphinx reports one existing `toc.not_included` warning for the unchanged `agi-page-inference-report-licenses.md` page.
- Canonical mirror verification, generated integrity stamp, scope/impact checks, whitespace, commit provenance, and enabled pre-push guards: passed.
- Manual changelog validation confirms the actual publication date, successful recovery workflow link, retained shipped notes, and removal of the stale pending-publication sentence. No new test was added for freeform release prose; the existing changelog accuracy rule requires this release-time review.

## Publication Evidence

- [Publication workflow 34578309790](https://github.com/ThalesGroup/agilab/actions/runs/34578309790): all 44 jobs succeeded.
- [GitHub release](https://github.com/ThalesGroup/agilab/releases/tag/v2026.09.09-1): 71 uploaded assets. All 32 distribution SHA-256 digests match the wheel/sdist artifacts on PyPI for the 16 selected packages. Twenty unchanged packages were excluded by the release plan.
- Published `agilab[examples]==2026.9.9` on Python 3.13 passed the clean, outside-checkout one-step package preinitialization smoke. This does not claim a full ML run or a fresh UI robot matrix; the historical UI baseline remains labeled accordingly.
- Retention completed successfully: the umbrella package reached the configured threshold and its ten older versions were removed. Selected packages below the threshold retain their history intentionally.
- Hugging Face reached `RUNNING` at the recorded commit and passed the workflow's hosted smoke.
- Dataset publication reused the unchanged content-addressed payload; creation and attestation steps were GitHub skipped for that reason.

## CI and Publication Status

All nine checks passed on signed head `862647c892f9b887d939ad2a933962ea89179c34`: [root tests](https://github.com/ThalesGroup/agilab/actions/runs/34588320049), [repository policy, Python 3.12/3.14 and Ubuntu/macOS/Windows installation checks](https://github.com/ThalesGroup/agilab/actions/runs/34588320064), [docs-source verification](https://github.com/ThalesGroup/agilab/actions/runs/34588320018), and GitGuardian. The PR introduces exactly one commit; GitHub reports its signature as verified and valid. The complete source tree matches the locally validated PR #1009 tree (`git diff --exit-code` passed).

`public-demo-smoke` is GitHub skipped on pull requests because it runs only on scheduled or manually dispatched events; the release workflow hosted smoke passed separately. [Pages deployment 34589276159](https://github.com/ThalesGroup/agilab/actions/runs/34589276159) succeeded on merge commit `a009f8a2c0c659f7a67bc5c05d176279b754b779`. The [published proof page](https://thalesgroup.github.io/agilab/release-proof.html) returned HTTP 200 and contains the expected version, recovery tag, publication attempt, HF commit, and refreshed CI references; the homepage also returned HTTP 200. HF remains `RUNNING` at the recorded commit. Post-merge [root tests](https://github.com/ThalesGroup/agilab/actions/runs/34589276141), [guardrails](https://github.com/ThalesGroup/agilab/actions/runs/34589276154), and [docs-source checks](https://github.com/ThalesGroup/agilab/actions/runs/34589276176) also passed on this merge commit. No required checks or signature protections are bypassed.

## Agent Metadata

- Human operator and approver: Jean-Pierre MORARD (`jpmorard`), confirmed by the user; authenticated GitHub actor checked as `jpmorard`.
- Initial evidence producer: `github-actions[bot]`; model, reasoning effort, and fast mode not used for that generation.
- Final curation agent/runtime: Codex; exact runtime version not exposed by the runtime.
- Model: GPT-6; exact variant not exposed by the runtime.
- Reasoning effort: not exposed by the runtime.
- `/fast` mode: not exposed by the runtime.
- Tokki version: 1.0.63; execution unavailable because of unrelated protected-source integrity drift. The previously authorized direct `uv`/Git/`gh` exception was used with AGILAB hooks and validation guards enabled.
- No sub-agents were used for this documentation correction.
